### PR TITLE
Add preinstall script to Makefile for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ default:
 # 
 #  Installation
 #
+preinstall:
+	bash -c 'sudo apt-get install curl && curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - && sudo apt-get install -y nodejs && sudo apt-get install -y mariadb-server && curl https://repo.anaconda.com/archive/Anaconda3-5.1.0-Linux-x86_64.sh > Anaconda.sh && chmod +x Anaconda.sh && ./Anaconda.sh -b && rm Anaconda.sh'
+
 install:
 	bash -c '$(CONDAUPDATE) $(CONDAACTIVATE) pip install --upgrade .'
 


### PR DESCRIPTION
Describe your pull request here: 

This is a script that attempts to run all preinstall operations for the user, and stops if a command fails to execute as expected.

In the case that this is accepted, the installation docs will also need to be updated to include this option.