### PR TITLE
fix typo in dev-guide

### DIFF
--- a/docs/python/source/dev-guide/2-install.rst
+++ b/docs/python/source/dev-guide/2-install.rst
@@ -134,7 +134,7 @@ Clone the repo and install the libraries and tools needed by Augur
 
 **Make sure you have a database user that has select access to the
 database where you installed `GHTorrent <http://ghtorrent.org/>`__ and
-all priviledges on another database for Augur.**
+all privileges on another database for Augur.**
 
 .. code:: sql
 
@@ -142,7 +142,7 @@ all priviledges on another database for Augur.**
     GRANT SELECT ON ghtorrent.* TO 'augur'@'localhost';
 
     CREATE DATABASE augur;
-    GRANT ALL PRIVILEDGES ON augur.* TO 'augur'@'localhost';
+    GRANT ALL PRIVILEGES ON augur.* TO 'augur'@'localhost';
 
 Augur runs in an Anaconda environment. To get started, activate the environment and then 
 run ``augur``.

--- a/frontend/public/docs/dev-guide/2-install.html
+++ b/frontend/public/docs/dev-guide/2-install.html
@@ -163,12 +163,12 @@ that case:</p>
 </div>
 <p><strong>Make sure you have a database user that has select access to the
 database where you installed `GHTorrent &lt;http://ghtorrent.org/&gt;`__ and
-all priviledges on another database for Augur.</strong></p>
+all privileges on another database for Augur.</strong></p>
 <div class="code sql highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">CREATE</span> <span class="n">USER</span> <span class="s1">&#39;augur&#39;</span><span class="o">@</span><span class="s1">&#39;localhost&#39;</span> <span class="n">IDENTIFIED</span> <span class="n">BY</span> <span class="s1">&#39;password&#39;</span><span class="p">;</span>
 <span class="n">GRANT</span> <span class="n">SELECT</span> <span class="n">ON</span> <span class="n">ghtorrent</span><span class="o">.*</span> <span class="n">TO</span> <span class="s1">&#39;augur&#39;</span><span class="o">@</span><span class="s1">&#39;localhost&#39;</span><span class="p">;</span>
 
 <span class="n">CREATE</span> <span class="n">DATABASE</span> <span class="n">augur</span><span class="p">;</span>
-<span class="n">GRANT</span> <span class="n">ALL</span> <span class="n">PRIVILEDGES</span> <span class="n">ON</span> <span class="n">augur</span><span class="o">.*</span> <span class="n">TO</span> <span class="s1">&#39;augur&#39;</span><span class="o">@</span><span class="s1">&#39;localhost&#39;</span><span class="p">;</span>
+<span class="n">GRANT</span> <span class="n">ALL</span> <span class="n">PRIVILEGES</span> <span class="n">ON</span> <span class="n">augur</span><span class="o">.*</span> <span class="n">TO</span> <span class="s1">&#39;augur&#39;</span><span class="o">@</span><span class="s1">&#39;localhost&#39;</span><span class="p">;</span>
 </pre></div>
 </div>
 <p>Augur runs in an Anaconda environment. To get started, activate the environment and then


### PR DESCRIPTION
In [dev-guide 2.3](http://augur.augurlabs.io/static/docs/dev-guide/2-install.html#augur-installation-instructions), there is a typo about granting privileges. 

The original one in [dev-guide](https://github.com/chaoss/augur/blob/master/docs/python/source/dev-guide/2-install.rst) is:
`GRANT ALL PRIVILEDGES ON augur.* TO 'augur'@'localhost';`

However, It should be:
`GRANT ALL PRIVILEGES ON augur.* TO 'augur'@'localhost';`