### PR TITLE
fixing commits_by_week endpoint to be what it says it is

### DIFF
--- a/augur/datasources/facade/facade.py
+++ b/augur/datasources/facade/facade.py
@@ -132,17 +132,16 @@ class Facade(object):
     @annotate(tag='commits-by-week')
     def commits_by_week(self, repo_url):
         """
-        Returns number of patches per commiter per week
-
+        Returns number of patches per repo per week
         :param repo_url: the repository's URL
         """
-        commitsByMonthSQL = s.sql.text("""
-            SELECT email AS author_email, affiliation, WEEK AS `week`, YEAR AS `year`, patches FROM repo_weekly_cache 
+        commitsByWeekSQL = s.sql.text("""
+            SELECT STR_TO_DATE(CONCAT(cast(`year` as char),cast(`week` as char), ' Sunday'), '%X%V %W') as author_date, patches FROM repo_weekly_cache 
             WHERE repos_id = (SELECT id FROM repos WHERE git LIKE :repourl LIMIT 1)
-            GROUP BY email, WEEK, YEAR
-            ORDER BY YEAR, WEEK, email ASC
+            GROUP BY author_date 
+            ORDER BY author_date asc
         """)
-        results = pd.read_sql(commitsByMonthSQL, self.db, params={"repourl": '%{}%'.format(repo_url)})
+        results = pd.read_sql(commitsByWeekSQL, self.db, params={"repourl": '%{}%'.format(repo_url)})
         return results
 
     @annotate(tag='facade-project')


### PR DESCRIPTION
Describe your pull request here: 
Looking over this endpoint I think it should reflect commits_by_week. It included author and affiliation information, which makes it "noncompliant" with our API practices associated with dates. This converts the `week of the year` and `year` data in the facade schema to the Sunday of that week and year and removes the author information. It can now be visualized as "commits by week". 

Next Gen Augur will have different queries, but this one makes this endpoint useful, IMHO. 

