### PR TITLE
Implement 'code_changes' metric

### DIFF
--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -7,6 +7,7 @@ import pandas as pd
 import sqlalchemy as s
 import numpy as np
 import re
+import datetime
 from augur import logger
 from augur.util import annotate
 
@@ -33,6 +34,43 @@ class Augur(object):
         #     self.userid('howderek')
         # except Exception as e:
         #     logger.error("Could not connect to GHTorrent database. Error: " + str(e))
+
+    #####################################
+    ###           EVOLUTION           ###
+    #####################################
+
+    @annotate(tag='code-changes')
+    def code_changes(self, repo_url, period='day', begin_date=None, end_date=None):
+        """
+        Returns a timeseries of the count of code commits.
+
+        :param repo_url: The repository's URL
+        :param period: To set the periodicity to 'day', 'week', 'month' or 'year', defaults to 'day'
+        :param begin_date: Specifies the begin date, defaults to '1970-1-1 00:00:00'
+        :param end_date: Specifies the end date, defaults to datetime.now()
+        :return: DataFrame of commits/period
+        """
+        if not begin_date:
+            begin_date = '1970-1-1 00:00:00:00'
+        if not end_date:
+            end_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+        code_changes_SQL = s.sql.text("""
+            SELECT date_trunc(:period, cmt_committer_date::DATE) as commit_date, COUNT(cmt_id) 
+            FROM commits
+            WHERE repo_id = (SELECT repo_id FROM repo WHERE repo_git LIKE :repourl LIMIT 1) 
+            AND cmt_committer_date BETWEEN :begin_date AND :end_date
+            GROUP BY commit_date
+            ORDER BY commit_date;
+        """)
+
+        results = pd.read_sql(code_changes_SQL, self.db, params={'repourl': '%{}%'.format(repo_url), 'period': period, 
+                                                                'begin_date': begin_date, 'end_date': end_date})
+        return results
+
+    #####################################
+    ###         EXPERIMENTAL          ###
+    #####################################
 
     @annotate(tag='lines-changed-by-author')
     def lines_changed_by_author(self, repo_url):


### PR DESCRIPTION
Implemented '[code_changes](https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes.md)' metric with the following optional parameters:

- period: 
    - Specifies the periodicity. 
    - Can be set to 'day', 'week', 'month' or 'year'. 
    - Defaults to 'day'
- begin_date: 
    - Specifies the beginning date. 
    - Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'
    - Defaults to '1970-1-1 0:0:0'
- end_date:
    - Specifies the ending date.
    - Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'
    - Defaults to the current date and time

**Example Output:**
`ag.code_changes('augur', period='year')`

|         | commit_date           | count  |
| ------------- |:-------------:| -----:|
| 0      | 2017-01-01 00:00:00+00:00 |   1525 |
| 1      | 2018-01-01 00:00:00+00:00  | 5140 |
| 2 | 2019-01-01 00:00:00+00:00 |    711|

`ag.code_changes('augur', period='month', begin_date='2018', end_date='2018-06')`

|         | commit_date           | count  |
| ------------- |:-------------:| -----:|
|0 | 2018-01-01 00:00:00+00:00 |    99 |
|1 | 2018-02-01 00:00:00+00:00 |    55 |
|2 | 2018-03-01 00:00:00+00:00 |   105 |
|3 | 2018-04-01 00:00:00+00:00 |   235 |
|4 | 2018-05-01 00:00:00+00:00 |   506 |


Signed-off-by: Parth Sharma <parth261297@gmail.com>