### PR TITLE
Refactor and add routes for evolution metrics

### DIFF
--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -449,11 +449,12 @@ class Augur(object):
 
 
     @annotate(tag='issues-closed')
-    def issues_closed(self, repo_url, period='day', begin_date=None, end_date=None):
+    def issues_closed(self, repo_group_id, repo_id=None, period='day', begin_date=None, end_date=None):
         """Returns a timeseries of issues closed.
 
-        :param repo_url: The repository's URL
-        :param period: To set the periodicity to 'day', 'week', 'month', or 'year', defaults to 'day'
+        :param repo_group_id: The repository's repo_group_id
+        :param repo_id: The repository's repo_id, defaults to None
+        :param period: To set the periodicity to 'day', 'week', 'month' or 'year', defaults to 'day'
         :param begin_date: Specifies the begin date, defaults to '1970-1-1 00:00:00'
         :param end_date: Specifies the end date, defaults to datetime.now()
         :return: DataFrame of issues closed/period
@@ -463,18 +464,39 @@ class Augur(object):
         if not end_date:
             end_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
 
-        issues_closed_SQL = s.sql.text("""
-            SELECT date_trunc(:period, closed_at::DATE) as issue_close_date, COUNT(issue_id) as issues
-            FROM issues
-            WHERE repo_id = (SELECT repo_id FROM repo WHERE repo_git LIKE :repourl LIMIT 1)
-            AND closed_at IS NOT NULL AND closed_at BETWEEN :begin_date AND :end_date
-            GROUP BY issue_close_date
-            ORDER BY issue_close_date;
-        """)
+        if not repo_id:
+            issues_closed_SQL = s.sql.text("""
+                SELECT
+                    date_trunc(:period, closed_at::DATE) as issue_close_date,
+                    repo_id,
+                    COUNT(issue_id) as issues
+                FROM issues
+                WHERE repo_id IN (SELECT repo_id FROM repo WHERE repo_group_id = :repo_group_id)
+                AND closed_at IS NOT NULL
+                AND closed_at BETWEEN to_timestamp(:begin_date, 'YYYY-MM-DD HH24:MI:SS') AND to_timestamp(:end_date, 'YYYY-MM-DD HH24:MI:SS')
+                GROUP BY issue_close_date, repo_id
+                ORDER BY repo_id, issue_close_date
+            """)
 
-        results = pd.read_sql(issues_closed_SQL, self.db, params={'repourl': '%{}%'.format(repo_url), 'period': period,
-                                                                'begin_date': begin_date, 'end_date': end_date})
-        return results
+            results = pd.read_sql(issues_closed_SQL, self.db, params={'repo_group_id': repo_group_id, 'period': period,
+                                                                       'begin_date': begin_date, 'end_date': end_date})
+
+            return results
+
+        else:
+            issues_closed_SQL = s.sql.text("""
+                SELECT date_trunc(:period, closed_at::DATE) as issue_close_date, COUNT(issue_id) as issues
+                FROM issues
+                WHERE repo_id = :repo_id
+                AND closed_at IS NOT NULL
+                AND closed_at BETWEEN to_timestamp(:begin_date, 'YYYY-MM-DD HH24:MI:SS') AND to_timestamp(:end_date, 'YYYY-MM-DD HH24:MI:SS')
+                GROUP BY issue_close_date
+                ORDER BY issue_close_date;
+            """)
+
+            results = pd.read_sql(issues_closed_SQL, self.db, params={'repo_id': repo_id, 'period': period,
+                                                                    'begin_date': begin_date, 'end_date': end_date})
+            return results
 
     @annotate(tag='issue-duration')
     def issue_duration(self, repo_url):

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -174,6 +174,59 @@ def create_routes(server):
     """
     server.addRepoMetric(augur_db.code_changes_lines, 'code-changes-lines')
 
+    """
+    @api {get} /repo-groups/:repo_group_id/issues-new Issues New
+    @apiName issues-new
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "issue_date": "2019-05-01T00:00:00.000Z",
+                            "repo_id": 1,
+                            "issues": 3
+                        },
+                        {
+                            "issue_date": "2019-05-01T00:00:00.000Z",
+                            "repo_id": 25001,
+                            "issues": 1
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.issues_new, 'issues-new')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/issues-new Issues New
+    @apiName issues-new
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID.
+    @apiParma {String} repo_id Repository ID.
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "issue_date": "2019-05-01T00:00:00.000Z",
+                            "issues": 1
+                        },
+                        {
+                            "issue_date": "2019-06-01T00:00:00.000Z",
+                            "issues": 31
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.issues_new, 'issues-new')
+
     # @server.app.route('/{}/repo-groups/<repo_group_id>/code-changes'.format(server.api_version))
     # def code_changes_repo_group_route(repo_group_id):
     #     period = request.args.get('period', 'day')

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -5,7 +5,7 @@ Creates routes for the Augur database data source plugin
 
 from flask import request, Response
 
-def create_routes(server):  
+def create_routes(server):
 
     augur_db = server._augur['augur_db']()
 
@@ -24,3 +24,104 @@ def create_routes(server):
                         status=200,
                         mimetype="application/json")
     server.updateMetricMetadata(function=augur_db.downloaded_repos, endpoint='/{}/repos'.format(server.api_version), metric_type='git')
+
+    #####################################
+    ###           EVOLUTION           ###
+    #####################################
+
+    """
+    @api {get} /repo-groups/:repo_group_id/code-changes
+    @apiName Code Changes
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "commit_date": "2018-01-01T00:00:00.000Z",
+                            "repo_id": 1,
+                            "commit_count": 5140
+                        },
+                        {
+                            "commit_date": "2019-01-01T00:00:00.000Z",
+                            "repo_id": 1,
+                            "commit_count": 711
+                        },
+                        {
+                            "commit_date": "2015-01-01T00:00:00.000Z",
+                            "repo_id": 25001,
+                            "commit_count": 1071
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.code_changes, 'code-changes')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/code-changes
+    @apiName Code Changes
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID.
+    @apiParma {String} repo_id Repository ID.
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "commit_date": "2018-01-01T00:00:00.000Z",
+                            "commit_count": 2287
+                        },
+                        {
+                            "commit_date": "2018-02-01T00:00:00.000Z",
+                            "commit_count": 1939
+                        },
+                        {
+                            "commit_date": "2018-03-01T00:00:00.000Z",
+                            "commit_count": 1979
+                        },
+                        {
+                            "commit_date": "2018-04-01T00:00:00.000Z",
+                            "commit_count": 2159
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.code_changes, 'code-changes')
+
+    # @server.app.route('/{}/repo-groups/<repo_group_id>/code-changes'.format(server.api_version))
+    # def code_changes_repo_group_route(repo_group_id):
+    #     period = request.args.get('period', 'day')
+    #     begin_date = request.args.get('begin_date')
+    #     end_date = request.args.get('end_date')
+
+    #     kwargs = {'repo_group_id': repo_group_id, 'period': period,
+    #               'begin_date': begin_date, 'end_date': end_date}
+
+    #     data = server.transform(augur_db.code_changes,
+    #                             args=[],
+    #                             kwargs=kwargs)
+
+    #     return Response(response=data, status=200, mimetype='application/json')
+
+    # @server.app.route('/{}/repo-groups/<repo_group_id>/repo/<repo_id>/code-changes'.format(server.api_version))
+    # def code_changes_repo_route(repo_group_id, repo_id):
+    #     period = request.args.get('period', 'day')
+    #     begin_date = request.args.get('begin_date')
+    #     end_date = request.args.get('end_date')
+
+    #     kwargs = {'repo_group_id': repo_group_id, 'repo_id': repo_id,
+    #               'period': period, 'begin_date': begin_date,
+    #               'end_date': end_date}
+
+    #     data = server.transform(augur_db.code_changes,
+    #                             args=[],
+    #                             kwargs=kwargs)
+
+    #     return Response(response=data, status=200, mimetype='application/json')

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -95,6 +95,85 @@ def create_routes(server):
     """
     server.addRepoMetric(augur_db.code_changes, 'code-changes')
 
+    """
+    @api {get} /repo-groups/:repo_group_id/code-changes-lines Code Changes Lines
+    @apiName code-changes-lines
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes_Lines.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "commit_date": "2018-01-01T00:00:00.000Z",
+                            "repo_id": 1,
+                            "added": 640098,
+                            "removed": 694608
+                        },
+                        {
+                            "commit_date": "2019-01-01T00:00:00.000Z",
+                            "repo_id": 1,
+                            "added": 56549,
+                            "removed": 48962
+                        },
+                        {
+                            "commit_date": "2014-01-01T00:00:00.000Z",
+                            "repo_id": 25001,
+                            "added": 19,
+                            "removed": 1
+                        },
+                        {
+                            "commit_date": "2015-01-01T00:00:00.000Z",
+                            "repo_id": 25001,
+                            "added": 429535,
+                            "removed": 204015
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.code_changes_lines, 'code-changes-lines')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/code-changes-lines Code Changes Lines
+    @apiName code-changes-lines
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes_Lines.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID.
+    @apiParma {String} repo_id Repository ID.
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "commit_date": "2014-01-01T00:00:00.000Z",
+                            "added": 19,
+                            "removed": 1
+                        },
+                        {
+                            "commit_date": "2015-01-01T00:00:00.000Z",
+                            "added": 429535,
+                            "removed": 204015
+                        },
+                        {
+                            "commit_date": "2016-01-01T00:00:00.000Z",
+                            "added": 2739765,
+                            "removed": 944568
+                        },
+                        {
+                            "commit_date": "2017-01-01T00:00:00.000Z",
+                            "added": 3945001,
+                            "removed": 1011396
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.code_changes_lines, 'code-changes-lines')
+
     # @server.app.route('/{}/repo-groups/<repo_group_id>/code-changes'.format(server.api_version))
     # def code_changes_repo_group_route(repo_group_id):
     #     period = request.args.get('period', 'day')

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -260,6 +260,46 @@ def create_routes(server):
     """
     server.addRepoMetric(augur_db.issues_closed, 'issues-closed')
 
+    """
+    @api {get} /repo-groups/:repo_group_id/issue-backlog Issue Backlog
+    @apiName issue-backlog
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_id": 1,
+                            "issue_backlog": 3
+                        },
+                        {
+                            "repo_id": 25001,
+                            "issue_backlog": 32
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.issue_backlog, 'issue-backlog')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/issue-backlog Issue Backlog
+    @apiName issue-backlog
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID.
+    @apiParma {String} repo_id Repository ID.
+
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "issue_backlog": 3
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.issue_backlog, 'issue-backlog')
+
     # @server.app.route('/{}/repo-groups/<repo_group_id>/code-changes'.format(server.api_version))
     # def code_changes_repo_group_route(repo_group_id):
     #     period = request.args.get('period', 'day')

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -227,6 +227,39 @@ def create_routes(server):
     """
     server.addRepoMetric(augur_db.issues_new, 'issues-new')
 
+    """
+    @api {get} /repo-groups/:repo_group_id/issues-closed Issues Closed
+    @apiName issues-closed
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_Closed.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    TODO
+    """
+    server.addRepoGroupMetric(augur_db.issues_closed, 'issues-closed')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/issues-closed Issues Closed
+    @apiName issues-closed
+    @apiGroup Evolution
+    @apiDescription <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md">CHAOSS Metric Definition</a>
+
+    @apiParam {String} repo_group_id Repository Group ID.
+    @apiParma {String} repo_id Repository ID.
+    @apiParam {string} period Periodicity specification. Possible values: 'day', 'week', 'month', 'year'. Defaults to 'day'
+    @apiParam {string} begin_date Beginning date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to '1970-1-1 0:0:0'
+    @apiParam {string} end_date Ending date specification. Possible values: '2018', '2018-05', '2019-05-01', ..., ' 2017-03-02 05:34:19'. Defaults to current date & time.
+
+    @apiSuccessExample {json} Success-Response:
+                    TODO
+    """
+    server.addRepoMetric(augur_db.issues_closed, 'issues-closed')
+
     # @server.app.route('/{}/repo-groups/<repo_group_id>/code-changes'.format(server.api_version))
     # def code_changes_repo_group_route(repo_group_id):
     #     period = request.args.get('period', 'day')


### PR DESCRIPTION
- Refactored the 'code_changes' metric to accept `repo_group_id` and `repo_id` instead of `repo_url`
- Added the following routes:
  - `repo-groups/:repo_group_id/code-changes` : This route returns the output for the metric 'code_changes' for a repo group with the given `repo_group_id`.
  - `repo-groups/<repo_group_id>/repo/<repo_id>/code-changes` : This route returns the output for the metric 'code_changes' about a repo with a given `repo_id` within a repo group with the given `repo_group_id`.

**Suggestion:** Adding routes requires writing a lot of repeating code. I suggest we create a utility function for adding routes. Something similar to `addMetric` and `addTimeseries` functions.

**Update:** Added helper functions for simplifying the creation of API endpoints. They are
- `addRepoGroupMetric` for creating `/repo-groups/:repo_group_id/[metric]` endpoints.
- `addRepoMetric` for creating `/repo-groups/:repo_group_id/repos/:repo_id/[metric]` endpoints.
- `routify` helps `addRepoGroupMetric` & `addRepoMetric`. Similar to `flaskify`

All of these functions are implemented in the `Server` class.