### PR TITLE
Initial repo_group_id and repo_id when Repo construct

### DIFF
--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -826,3 +826,21 @@ class Augur(object):
         """)
         results = pd.read_sql(closedIssueCountSQL, self.db)#, params={"rg_id": '{}'.format(rg_id)})
         return results
+
+    @annotate(tag='get-repo')
+    def get_repo(self, owner, repo):
+        """
+        Returns repo id and repo group id by owner and repo
+
+        :param owner: the owner of the repo
+        :param repo: the name of the repo
+        """
+        getRepoSQL = s.sql.text("""
+            SELECT repo_id, repo_group_id
+            FROM repo
+            WHERE repo_name = :repo AND repo_path LIKE :owner
+        """)
+
+        results = pd.read_sql(getRepoSQL, self.db, params={'owner': '%{}_'.format(owner), 'repo': repo,})
+
+        return results

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -26,6 +26,15 @@ def create_routes(server):
         
     server.updateMetricMetadata(function=augur_db.downloaded_repos, endpoint='/{}/repos'.format(server.api_version), metric_type='git')
 
+    @server.app.route('/{}/repos/<owner>/<repo>'.format(server.api_version))
+    def get_repo(owner, repo):
+        a = [owner, repo]
+        gre = server.transform(augur_db.get_repo, args = a)
+        return Response(response=gre,
+                        status=200,
+                        mimetype="application/json")
+
+    server.updateMetricMetadata(function=augur_db.get_repo, endpoint='/{}/repos/<owner>/<repo>'.format(server.api_version), metric_type='git')
 
     #####################################
     ###           EVOLUTION           ###

--- a/augur/datasources/augur_db/test_augur_db.py
+++ b/augur/datasources/augur_db/test_augur_db.py
@@ -147,3 +147,7 @@ def test_contributors_new(augur_db):
 
     assert augur_db.contributors_new(24, repo_id=21524, period='year', begin_date='2019-1-1 00:00:00',
                                      end_date='2019-12-31 23:59:59').isin([pd.Timestamp('2019-01-01 00:00:00', tz='UTC')]).any().any()
+
+
+def test_get_repo(augur_db):
+    assert augur_db.get_repo_by_name('Comcast','zucchini').iloc[0].repo_id == 21116

--- a/frontend/app/Augur.js
+++ b/frontend/app/Augur.js
@@ -41,8 +41,6 @@ export default function Augur () {
       tab: 'gmd',
       baseRepo: null,
       gitRepo: null,
-      repoID: null,
-      repoGroupID: null,
       comparedRepos: [],
       trailingAverage: 180,
       startDate: new Date('1 February 2011'),
@@ -87,10 +85,6 @@ export default function Augur () {
           // state.tab = 'git'
           state.gitRepo = repo.gitURL
           state.tab = state.tab ? state.tab : 'git'
-        }
-        if (repo.repoID && repo.repoGroupID) {
-          state.repoID = repo.repoID,
-          state.repoGroupID = repo.repoGroupID
         }
       },
       // removeComparedRepo (state, payload) {

--- a/frontend/app/AugurAPI.js
+++ b/frontend/app/AugurAPI.js
@@ -127,6 +127,7 @@ export default class AugurAPI {
     })
   }
 
+
   Repo (repo) {
     if (repo.githubURL) {
       let splitURL = repo.githubURL.split('/')
@@ -149,6 +150,21 @@ export default class AugurAPI {
         repo.owner = splitURL[0]
         repo.name = splitURL[1]
       }
+    }
+
+    if (repo.repo_id == null || repo.repo_group_id == null){
+      let res = []
+      $.ajax({
+        type:"GET",
+        url:this._version+ '/repos/'+repo.owner+'/'+repo.name,
+        async:false,
+        success:function (data)
+        {
+          res = data;
+        }
+      })
+      repo.repo_id = res[0].repo_id
+      repo.repo_group_id = res[0].repo_group_id
     }
 
     repo.toString = () => {
@@ -206,12 +222,12 @@ export default class AugurAPI {
     }
 
     var addRepoMetric = (r, jsName, endpoint) => {
-      var url = this.__endpointURL('repo-groups/'+ repo.repoGroupID + '/repos'+ repo.repoID + '/' + endpoint)
+      var url = this.__endpointURL('repo-groups/'+ repo.repo_group_id + '/repos'+ repo.repo_id + '/' + endpoint)
       return __Endpoint(r, jsName, url)
     }
 
     var addRepoGroupMetric = (r, jsName, endpoint) => {
-      var url = this.__endpointURL('repo-groups/'+ repo.repoGroupID + '/' + endpoint)
+      var url = this.__endpointURL('repo-groups/'+ repo.repo_group_id + '/' + endpoint)
       return __Endpoint(r, jsName, url)
     }
 
@@ -312,7 +328,7 @@ export default class AugurAPI {
       GitEndpoint(repo, 'facadeProject', 'facade_project')
     }
 
-    if (repo.repoGroupID && repo.repoID) {
+    if (repo.repo_group_id && repo.repo_id) {
       addRepoMetric(repo, 'codeChanges', 'code-changes')
       addRepoMetric(repo, 'codeChangesLines', 'code-changes-lines')
       addRepoMetric(repo, 'issueNew', 'issues-new')
@@ -326,7 +342,7 @@ export default class AugurAPI {
       addRepoMetric(repo, 'contributorsNew', 'contributors-new')
     }
 
-    if (repo.repoGroupID && repo.repoID == null) {
+    if (repo.repo_group_id && repo.repo_id == null) {
       addRepoGroupMetric(repo, 'codeChanges', 'code-changes')
       addRepoGroupMetric(repo, 'codeChangesLines', 'code-changes-lines')
       addRepoGroupMetric(repo, 'issueNew', 'issues-new')

--- a/frontend/app/components/DownloadedReposCard.vue
+++ b/frontend/app/components/DownloadedReposCard.vue
@@ -55,6 +55,7 @@ module.exports = {
     loaded: false,
     ascending: false,
     sortColumn: '',
+    group_id_name_map: {},
   }},
   methods: {
     sortTable(col) {
@@ -105,8 +106,8 @@ module.exports = {
       }
       this.$store.commit('setRepo', {
         gitURL: e.url,
-        repoID: e.repo_id,
-        repoGroupID: e.repo_group_id
+        repo_id: e.repo_id,
+        repo_group_id: e.repo_group_id
       })
 
       this.$store.commit('setTab', {
@@ -115,7 +116,7 @@ module.exports = {
 
       this.$router.push({
         name: 'git',
-        params: {repo: e.url, repoID: e.repo_id, repoGroupID: e.repo_group_id}
+        params: {repo: e.url}
       })
     },
     getDownloadedRepos() {
@@ -138,6 +139,7 @@ module.exports = {
           this.repo_groups = data
           //move down between future relation endpoint
           this.repo_groups.forEach((group) => {
+            this.group_id_name_map[group.rg_name] = group.repo_group_id  
             this.repo_relations[group.rg_name] = this.repos.filter(function(repo){
               return repo.rg_name == group.rg_name
             })
@@ -149,6 +151,7 @@ module.exports = {
             if (repo.issues_all_time == null) 
               repo.issues_all_time = 0
             repo.repo_count = this.repo_relations[repo.rg_name].length
+            repo.repo_group_id = this.group_id_name_map[repo.rg_name]
           })
           console.log("LOADED repo groups", this.repo_relations)
           this.loaded = true


### PR DESCRIPTION
In the frontend,  function `Repo(repo)` called to construct repo. 

https://github.com/chaoss/augur/blob/d2ba1806c8f510d5ea122d510cdb0322dc3f6da7/frontend/app/Augur.js#L70-L71

But `repo_group_id` and `repo_id` are not always passed, it usually only commit `girurl` or `githuburl` by Vuex. For example:
https://github.com/chaoss/augur/blob/d2ba1806c8f510d5ea122d510cdb0322dc3f6da7/frontend/app/Augur.js#L219-L222

I added a new function in function `Repo` to fetch `repo_group_id` and `repo_id`. It will query `repo_group_id` and `repo_id` from `augur_db` by `owner` and `name`.


