### PR TITLE
dev: Add GitHub Repo Info Worker

### DIFF
--- a/workers/gh_repo_info_worker/LICENSE
+++ b/workers/gh_repo_info_worker/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Augur Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/workers/gh_repo_info_worker/README.rst
+++ b/workers/gh_repo_info_worker/README.rst
@@ -1,0 +1,45 @@
+GitHub Repo Info Worker
+===================
+
+.. image:: https://img.shields.io/pypi/v/augur_worker_github.svg
+    :target: https://pypi.python.org/pypi/augur_worker_github
+    :alt: Latest PyPI version
+
+.. image:: False.png
+   :target: False
+   :alt: Latest Travis CI build status
+
+Augur Worker that collects GitHub Repo Info data
+
+**Note:**
+This is a work in progress Worker.
+Currently it is not integrated as a Augur Worker but can be used independently.
+This version gets the repo info of all repos stored in the ``repo`` table.
+
+Usage
+-----
+1. Activate Augur's virtualenv.
+2. Open your python shell.
+3. In your python shell:
+
+.. code:: python
+
+    # Create a config dict
+    config = {'connection_string': 'sqlite:///:memory:',
+                'host': '<host>',
+                'name': '<db_name>',
+                'password': '<db_password>',
+                'port': '<db_port>',
+                'schema': '<db_schema>',
+                'user': '<db_user>',
+                'key': '<github_token>'
+    }
+
+    # Import Worker
+    from gh_repo_info_worker.worker import GHRepoInfoWorker
+
+    # Create a worker instance
+    worker = GHRepoInfoWorker(config)
+
+    # Begin collecting data
+    worker.collect()

--- a/workers/gh_repo_info_worker/gh_repo_info_worker/__init__.py
+++ b/workers/gh_repo_info_worker/gh_repo_info_worker/__init__.py
@@ -1,0 +1,5 @@
+"""gh_repo_info_worker - Augur Worker that collects GitHub Repo Info data"""
+
+__version__ = '0.0.0'
+__author__ = 'Augur Team <s@goggins.com>'
+__all__ = []

--- a/workers/gh_repo_info_worker/gh_repo_info_worker/runtime.py
+++ b/workers/gh_repo_info_worker/gh_repo_info_worker/runtime.py
@@ -1,0 +1,149 @@
+#############################################################
+# This file is a copy of the augur_worker_github/runtime.py #
+#############################################################
+
+
+from flask import Flask, jsonify, request, Response
+import click, os, json, requests, logging
+from augur_worker_github.worker import GitHubWorker
+logging.basicConfig(filename='worker.log', filemode='w', level=logging.INFO)
+
+
+def create_server(app, gw):
+    """ Consists of AUGWOP endpoints for the broker to communicate to this worker
+    Can post a new task to be added to the workers queue
+    Can retrieve current status of the worker
+    Can retrieve the workers config object
+    """
+
+    @app.route("/AUGWOP/task", methods=['POST', 'GET'])
+    def augwop_task():
+        """ AUGWOP endpoint that gets hit to add a task to the workers queue or is used to get the heartbeat/status of worker
+        """
+        if request.method == 'POST': #will post a task to be added to the queue
+            logging.info("Sending to work on task: {}".format(str(request.json)))
+            app.gh_worker.task = request.json
+
+            #set task
+            return Response(response=request.json,
+                        status=200,
+                        mimetype="application/json")
+        if request.method == 'GET': #will retrieve the current tasks/status of the worker
+            return jsonify({
+                "status": "success"
+            })
+        return Response(response=request.json,
+                        status=200,
+                        mimetype="application/json")
+
+    @app.route("/AUGWOP/config")
+    def augwop_config():
+        """ Retrieve worker's config
+        """
+        return app.gh_worker.config
+
+@click.command()
+@click.option('--augur-url', default='http://localhost:5000/', help='Augur URL')
+@click.option('--host', default='localhost', help='Host')
+@click.option('--port', default=51236, help='Port')
+def main(augur_url, host, port):
+    """ Declares singular worker and creates the server and flask app that it will be running on
+    """
+    app = Flask(__name__)
+
+    #load credentials
+    credentials = read_config("Database", use_main_config=1)
+    server = read_config("Server", use_main_config=1)
+
+    config = {
+            "id": "com.augurlabs.core.github_worker",
+            "broker_port": server['port'],
+            "zombie_id": credentials["zombie_id"],
+            "host": credentials["host"],
+            "key": credentials["key"],
+            "password": credentials["password"],
+            "port": credentials["port"],
+            "user": credentials["user"],
+            "database": credentials["database"],
+            "table": "repo_badging",
+            "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
+            "display_name": "",
+            "description": "",
+            "required": 1,
+            "type": "string"
+        }
+
+    #create instance of the worker
+
+    app.gh_worker = GitHubWorker(config) # declares the worker that will be running on this server with specified config
+
+    create_server(app, None)
+    logging.info("Starting Flask App with pid: " + str(os.getpid()) + "...")
+    app.run(debug=app.debug, host=host, port=port)
+    if app.gh_worker._child is not None:
+        app.gh_worker._child.terminate()
+    try:
+        requests.post('http://localhost:{}/api/unstable/workers/remove'.format(server['port']), json={"id": config['id']})
+    except:
+        pass
+
+    logging.info("Killing Flask App: " + str(os.getpid()))
+    os.kill(os.getpid(), 9)
+
+
+
+def read_config(section, name=None, environment_variable=None, default=None, config_file='augur.config.json', no_config_file=0, use_main_config=0):
+    """
+    Read a variable in specified section of the config file, unless provided an environment variable
+
+    :param section: location of given variable
+    :param name: name of variable
+    """
+
+
+    __config_bad = False
+    if use_main_config == 0:
+        __config_file_path = os.path.abspath(os.getenv('AUGUR_CONFIG_FILE', config_file))
+    else:
+        __config_file_path = os.path.abspath(os.path.dirname(os.path.dirname(os.getcwd())) + '/augur.config.json')
+
+    __config_location = os.path.dirname(__config_file_path)
+    __export_env = os.getenv('AUGUR_ENV_EXPORT', '0') == '1'
+    __default_config = { 'Database': {"host": "nekocase.augurlabs.io"} }
+
+    if os.getenv('AUGUR_ENV_ONLY', '0') != '1' and no_config_file == 0:
+        try:
+            __config_file = open(__config_file_path, 'r+')
+        except:
+            # logger.info('Couldn\'t open {}, attempting to create. If you have a augur.cfg, you can convert it to a json file using "make to-json"'.format(config_file))
+            if not os.path.exists(__config_location):
+                os.makedirs(__config_location)
+            __config_file = open(__config_file_path, 'w+')
+            __config_bad = True
+
+
+        # Options to export the loaded configuration as environment variables for Docker
+
+        if __export_env:
+
+            export_filename = os.getenv('AUGUR_ENV_EXPORT_FILE', 'augur.cfg.sh')
+            __export_file = open(export_filename, 'w+')
+            # logger.info('Exporting {} to environment variable export statements in {}'.format(config_file, export_filename))
+            __export_file.write('#!/bin/bash\n')
+
+        # Load the config file and return [section][name]
+        try:
+            config_text = __config_file.read()
+            __config = json.loads(config_text)
+            if name is not None:
+                return(__config[section][name])
+            else:
+                return(__config[section])
+
+        except json.decoder.JSONDecodeError as e:
+            if not __config_bad:
+                __using_config_file = False
+                # logger.error('%s could not be parsed, using defaults. Fix that file, or delete it and run this again to regenerate it. Error: %s', __config_file_path, str(e))
+
+            __config = __default_config
+            return(__config[section][name])

--- a/workers/gh_repo_info_worker/gh_repo_info_worker/worker.py
+++ b/workers/gh_repo_info_worker/gh_repo_info_worker/worker.py
@@ -1,0 +1,258 @@
+from multiprocessing import Process, Queue
+from urllib.parse import urlparse
+import requests
+import pandas as pd
+import sqlalchemy as s
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy import MetaData
+import logging
+import time
+from datetime import datetime
+
+logging.basicConfig(filename='worker.log', level=logging.INFO, filemode='w')
+
+
+class CollectorTask:
+    """ Worker's perception of a task in its queue
+    Holds a message type (EXIT, TASK, etc) so the worker knows how to process the queue entry
+    and the github_url given that it will be collecting data for
+    """
+    def __init__(self, message_type='TASK', entry_info=None):
+        self.type = message_type
+        self.entry_info = entry_info
+
+def dump_queue(queue):
+    """
+    Empties all pending items in a queue and returns them in a list.
+    """
+    result = []
+    queue.put("STOP")
+    for i in iter(queue.get, 'STOP'):
+        result.append(i)
+    # time.sleep(.1)
+    return result
+
+
+class GHRepoInfoWorker:
+    def __init__(self, config, task=None):
+        self._task = task
+        self._child = None
+        self._queue = Queue()
+        self.config = config
+        self.db = None
+        self.table = None
+        self.API_KEY = self.config['key']
+        self.tool_source = 'GitHub Repo Info Worker'
+        self.tool_version = '0.0.1'
+        self.data_source = 'GitHub API'
+        self.results_counter = 0
+        self.headers = {'Authorization': f'token {self.API_KEY}',
+                        'Accept': 'application/vnd.github.vixen-preview+json'}
+
+        url = 'https://api.github.com'
+        response = requests.get(url, headers=self.headers)
+        self.rate_limit = int(response.headers['X-RateLimit-Remaining'])
+
+        specs = {
+            "id": "com.augurlabs.core.gh_repo_info",
+            "location": "http://localhost:51237",
+            "qualifications":  [
+                {
+                    "given": [["git_url"]],
+                    "models":["repo_info"]
+                }
+            ],
+            "config": [self.config]
+        }
+
+        self.DB_STR = 'postgresql://{}:{}@{}:{}/{}'.format(
+            self.config['user'], self.config['password'], self.config['host'], self.config['port'], self.config['name']
+        )
+
+        logging.info("Making database connections...")
+
+        dbschema = 'augur_data'
+        self.db = s.create_engine(self.DB_STR, poolclass = s.pool.NullPool,
+            connect_args={'options': '-csearch_path={}'.format(dbschema)})
+
+        helper_schema = 'augur_operations'
+        self.helper_db = s.create_engine(self.DB_STR, poolclass = s.pool.NullPool,
+            connect_args={'options': '-csearch_path={}'.format(helper_schema)})
+
+        metadata = MetaData()
+        helper_metadata = MetaData()
+
+        metadata.reflect(self.db, only=['repo_info'])
+        # helper_metadata.reflect(self.helper_db)
+
+        Base = automap_base(metadata=metadata)
+
+        Base.prepare()
+
+        self.repo_info_table = Base.classes.repo_info.__table__
+
+        logging.info('Getting max repo_info_id...')
+        max_repo_info_id_sql = s.sql.text("""
+            SELECT MAX(repo_info_id) AS repo_info_id
+            FROM repo_info
+        """)
+        rs = pd.read_sql(max_repo_info_id_sql, self.db)
+
+        repo_info_start_id = int(rs.iloc[0]['repo_info_id']) if rs.iloc[0]['repo_info_id'] is not None else 1
+
+        if repo_info_start_id == 1:
+            self.info_id_inc = repo_info_start_id
+        else:
+            self.info_id_inc = repo_info_start_id + 1
+
+        # requests.post('http://localhost:5000/api/unstable/workers', json=specs)
+
+    @property
+    def task(self):
+        """ Property that is returned when the worker's current task is referenced """
+        return self._task
+
+    # @task.setter
+    # def task(self, value):
+        # repo_id_sql = s.sql.text("""
+        #     SELECT repo_id, repo_git FROM repo
+        # """)
+
+        # repos = pd.read_sql(repo_id_sql, self.db)
+
+    def cancel(self):
+        """ Delete/cancel current task """
+        self._task = None
+
+    def run(self):
+        logging.info("Running...")
+        self._child = Process(target=self.collect, args=())
+        self._child.start()
+
+    def collect(self, repos=None):
+
+        if repos == None:
+            repo_id_sql = s.sql.text("""
+                SELECT repo_id, repo_git FROM repo
+            """)
+
+            repos = pd.read_sql(repo_id_sql, self.db)
+
+        for _, row in repos.iterrows():
+            owner, repo = self.get_owner_repo(row['repo_git'])
+            self.query_repo_info(row['repo_id'], owner, repo)
+
+
+    def get_owner_repo(self, git_url):
+        split = git_url.split('/')
+
+        owner = split[-2]
+        repo = split[-1]
+
+        if '.git' in repo:
+            repo = repo[:-4]
+
+        return owner, repo
+
+    def query_repo_info(self, repo_id, owner, repo):
+        # url = f'https://api.github.com/repos/{owner}/{repo}'
+        url = 'https://api.github.com/graphql'
+
+        query = """
+            {
+                repository(owner:"%s", name:"%s"){
+                    updatedAt
+                    hasIssuesEnabled
+                    issues(states:OPEN) {
+                        totalCount
+                    }
+                    hasWikiEnabled
+                    forkCount
+                    defaultBranchRef {
+                        name
+                    }
+                    watchers {
+                        totalCount
+                    }
+                    id
+                    licenseInfo {
+                        name
+                        url
+                    }
+                    stargazers {
+                        totalCount
+                    }
+                    codeOfConduct {
+                        name
+                        url
+                    }
+                }
+            }
+        """ % (owner, repo)
+
+        logging.info(f'Hitting endpoint {url}')
+        try:
+            # r = requests.get(url, headers=self.headers)
+            r = requests.post(url, json={'query': query}, headers=self.headers)
+            self.update_rate_limit(r)
+            j = r.json()['data']['repository']
+        except Exception as e:
+            logging.error('Caught Exception:', str(e))
+
+        logging.info(f'Inserting repo info for repo with id:{repo_id}, owner:{owner}, name:{repo}')
+
+        rep_inf = {
+            'repo_info_id': self.info_id_inc,
+            'repo_id': repo_id,
+            'last_updated': j['updatedAt'],
+            'issues_enabled': j['hasIssuesEnabled'],
+            'open_issues': j['issues']['totalCount'],
+            'pull_requests_enabled': None,
+            'wiki_enabled': j['hasWikiEnabled'],
+            'pages_enabled': None,
+            'fork_count': j['forkCount'],
+            'default_branch': j['defaultBranchRef']['name'],
+            'watchers_count': j['watchers']['totalCount'],
+            'UUID': None,
+            'license': j['licenseInfo']['name'] if j['licenseInfo'] else None,
+            'stars_count': j['stargazers']['totalCount'],
+            'committers_count': None,
+            'issue_contributors_count': None,
+            'changelog_file': None,
+            'contributing_file': None,
+            'license_file': j['licenseInfo']['url'] if j['licenseInfo'] else None,
+            'code_of_conduct_file': j['codeOfConduct']['url'] if j['codeOfConduct'] else None,
+            'security_issue_file': None,
+            'security_audit_file': None,
+            'status': None,
+            'keywords': None,
+            'tool_source': self.tool_source,
+            'tool_version': self.tool_version,
+            'data_source': self.data_source,
+            'data_collection_date': datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+        }
+
+        result = self.db.execute(self.repo_info_table.insert().values(rep_inf))
+        logging.info(f"Primary Key inserted into repo_info table: {result.inserted_primary_key}")
+        self.results_counter += 1
+
+        logging.info(f"Inserted info for {owner}/{repo}")
+
+        self.info_id_inc += 1
+
+
+
+    def update_rate_limit(self, response):
+        try:
+            self.rate_limit = int(response.headers['X-RateLimit-Remaining'])
+            logging.info("Recieved rate limit from headers\n")
+        except:
+            self.rate_limit -= 1
+            logging.info("Headers did not work, had to decrement\n")
+        logging.info("Updated rate limit, you have: " + str(self.rate_limit) + " requests remaining.\n")
+        if self.rate_limit <= 0:
+            reset_time = response.headers['X-RateLimit-Reset']
+            time_diff = datetime.datetime.fromtimestamp(int(reset_time)) - datetime.datetime.now()
+            logging.info("Rate limit exceeded, waiting " + str(time_diff.total_seconds()) + " seconds.\n")
+            time.sleep(time_diff.total_seconds())
+            self.rate_limit = int(response.headers['X-RateLimit-Limit'])

--- a/workers/gh_repo_info_worker/tests/test_sample.py
+++ b/workers/gh_repo_info_worker/tests/test_sample.py
@@ -1,0 +1,4 @@
+# Sample Test passing with nose and pytest
+
+def test_pass():
+    assert True, "dummy sample test"


### PR DESCRIPTION
Added a GitHub Repo Info Worker that fetches data such as forks, stargazers, watchers, etc. for the `repo_info` table.

A few things to note about this version of the worker:
- It hasn't been integrated as Augur as of yet.
- It's more of a stand-alone python script.
- It fetches repo info for all repos listed in the `repo` table. That is you cannot specify which repo you want to run it for

**Note:** I've marked this PR as draft as I'm working on implementing a few metrics for fork count, watchers, etc. i.e. metrics that can be implemented from the data in `repo_info`

Signed-off-by: Parth Sharma <parth261297@gmail.com>