### PR TITLE
Implement Facade metrics in augur_db database 

### DIFF
--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -1478,7 +1478,101 @@ class Augur(object):
         "repo_id": repo_id, "calendar_year": calendar_year})
         return results
 
-    
+    @annotate(tag='annual-commit-count-ranked-by-repo-in-repo-group')
+    def annual_commit_count_ranked_by_repo_in_repo_group(self, repo_group_id, repo_id=None, timeframe=None):
+        """
+        For each repository in a collection of repositories being managed, each REPO's total commits during the current Month, 
+        Year or Week. Result ranked from highest number of commits to lowest by default. 
+        :param repo_group_id: The repository's repo_group_id
+        :param repo_id: The repository's repo_id, defaults to None
+        :param calendar_year: the calendar year a repo is created in to be considered "new"
+        """    
+        if timeframe == None:
+            timeframe = 'all'
+        
+        cdRgTpRankedCommitsSQL = None
+
+        if repo_id:
+            if timeframe == 'all':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = (select repo.repo_group_id from repo where repo.repo_id = :repo_id)
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+            elif timeframe == 'year':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = (select repo.repo_group_id from repo where repo.repo_id = :repo_id)
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+            elif timeframe == 'month':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_monthly, repo, repo_groups
+                    WHERE repo.repo_group_id = (select repo.repo_group_id from repo where repo.repo_id = :repo_id)
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_monthly.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    AND date_part('month', repo_added) = date_part('month', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+        else: 
+            if timeframe == 'all':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = :repo_group_id
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+            elif timeframe == "year":
+                cdRgTpRankedCommitsSQL = s.sql.text(
+                    """
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = :repo_group_id
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                    """
+                )
+            elif timeframe == 'month':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = :repo_group_id
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    AND date_part('month', repo_added) = date_part('month', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+
+
+        results = pd.read_sql(cdRgTpRankedCommitsSQL, self.db, params={ "repo_group_id": repo_group_id,
+        "repo_id": repo_id})
+        return results
 
 
 #####################################

--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -1574,6 +1574,146 @@ class Augur(object):
         "repo_id": repo_id})
         return results
 
+    @annotate(tag='annual-lines-of-code-count-ranked-by-new-repo-in-repo-group')
+    def annual_lines_of_code_count_ranked_by_new_repo_in_repo_group(self, repo_group_id, repo_id = None, calendar_year=None):
+        """
+        For each repository in a collection of repositories being managed, each REPO that first appears in the parameterized
+    calendar year (a new repo in that year), show all commits for that year (total for year by repo).
+        Result ranked from highest number of commits to lowest by default.
+
+        :param repo_url: the repository's URL
+        :param calendar_year: the calendar year a repo is created in to be considered "new"
+        :param repo_group: the group of repositories to analyze
+        """
+        if calendar_year == None:
+            calendar_year = 2019
+        
+        cdRgNewrepRankedCommitsSQL = None
+
+        if not repo_id:
+            cdRgNewrepRankedCommitsSQL = s.sql.text("""
+                SELECT repo.repo_id, sum(cast(added as INTEGER) - cast(removed as INTEGER) - cast(whitespace as INTEGER)) as net, patches, repo_name
+                FROM dm_repo_annual, repo, repo_groups
+                where  repo.repo_group_id = :repo_group_id
+                and dm_repo_annual.repo_id = repo.repo_id
+                and date_part('year', repo.repo_added) = :calendar_year
+                and repo.repo_group_id = repo_groups.repo_group_id
+                group by repo.repo_id, patches, rg_name
+                ORDER BY net desc
+                LIMIT 10
+            """)
+        else: 
+            cdRgNewrepRankedCommitsSQL = s.sql.text("""
+                SELECT repo.repo_id, sum(cast(added as INTEGER) - cast(removed as INTEGER) - cast(whitespace as INTEGER)) as net, patches, repo_name
+                FROM dm_repo_annual, repo, repo_groups
+                where  repo.repo_group_id = (select repo.repo_group_id from repo where repo.repo_id = :repo_id)
+                and dm_repo_annual.repo_id = repo.repo_id
+                and date_part('year', repo.repo_added) = :calendar_year
+                and repo.repo_group_id = repo_groups.repo_group_id
+                group by repo.repo_id, patches, rg_name
+                ORDER BY net desc
+                LIMIT 10
+            """)
+        results = pd.read_sql(cdRgNewrepRankedCommitsSQL, self.db, params={ "repo_group_id": repo_group_id,
+        "repo_id": repo_id, "calendar_year": calendar_year})
+        return results
+
+    @annotate(tag='annual-lines-of-code-count-ranked-by-repo-in-repo-group')
+    def annual_lines_of_code_count_ranked_by_repo_in_repo_group(self, repo_group_id, repo_id=None, timeframe=None):
+        """
+        For each repository in a collection of repositories being managed, each REPO's total commits during the current Month, 
+        Year or Week. Result ranked from highest number of commits to lowest by default. 
+        :param repo_group_id: The repository's repo_group_id
+        :param repo_id: The repository's repo_id, defaults to None
+        :param calendar_year: the calendar year a repo is created in to be considered "new"
+        """    
+        if timeframe == None:
+            timeframe = 'all'
+        
+        cdRgTpRankedCommitsSQL = None
+
+        if repo_id:
+            if timeframe == 'all':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = (select repo.repo_group_id from repo where repo.repo_id = :repo_id)
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+            elif timeframe == 'year':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = (select repo.repo_group_id from repo where repo.repo_id = :repo_id)
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+            elif timeframe == 'month':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_monthly, repo, repo_groups
+                    WHERE repo.repo_group_id = (select repo.repo_group_id from repo where repo.repo_id = :repo_id)
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_monthly.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    AND date_part('month', repo_added) = date_part('month', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+        else: 
+            if timeframe == 'all':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = :repo_group_id
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+            elif timeframe == "year":
+                cdRgTpRankedCommitsSQL = s.sql.text(
+                    """
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = :repo_group_id
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                    """
+                )
+            elif timeframe == 'month':
+                cdRgTpRankedCommitsSQL = s.sql.text("""
+                    SELECT repo.repo_id, repo_name as name, SUM(added - removed - whitespace) as net, patches
+                    FROM dm_repo_annual, repo, repo_groups
+                    WHERE repo.repo_group_id = :repo_group_id
+                    AND repo.repo_group_id = repo_groups.repo_group_id
+                    AND dm_repo_annual.repo_id = repo.repo_id
+                    AND date_part('year', repo_added) = date_part('year', CURRENT_DATE)
+                    AND date_part('month', repo_added) = date_part('month', CURRENT_DATE)
+                    group by repo.repo_id, patches
+                    order by net desc
+                    LIMIT 10
+                """)
+
+
+        results = pd.read_sql(cdRgTpRankedCommitsSQL, self.db, params={ "repo_group_id": repo_group_id,
+        "repo_id": repo_id})
+        return results
+
 
 #####################################
 ###           UTILITIES           ###

--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -1462,48 +1462,7 @@ class Augur(object):
         results = pd.read_sql(cdRgNewrepRankedCommitsSQL, self.db, params={ "repo_group_id": repo_group_id, "calendar_year": calendar_year})
         return results
 
-    @annotate(tag="get-issues")
-    def get_issues(self, repo_group_id, repo_id=None):
-        if not repo_id:
-            issuesSQL = s.sql.text("""
-                SELECT issue_title,
-                    issues.issue_id,
-                    issues.repo_id,
-                    issues.html_url,
-                    issue_state                                 AS STATUS,
-                    issues.created_at                           AS DATE,
-                    count(issue_events.event_id),
-                    MAX(issue_events.created_at)                AS LAST_EVENT_DATE,
-                    EXTRACT(DAY FROM NOW() - issues.created_at) AS OPEN_DAY
-                FROM issues,
-                    issue_events
-                WHERE issues.repo_id IN (SELECT repo_id FROM repo WHERE repo_group_id = :repo_group_id)
-                AND issues.issue_id = issue_events.issue_id
-                GROUP BY issues.issue_id
-                ORDER by OPEN_DAY DESC
-            """)
-            results = pd.read_sql(issuesSQL, self.db, params={'repo_group_id': repo_group_id})
-            return results
-        else:
-            issuesSQL = s.sql.text("""
-                SELECT issue_title,
-                    issues.issue_id,
-                    issues.repo_id,
-                    issues.html_url,
-                    issue_state                                 AS STATUS,
-                    issues.created_at                           AS DATE,
-                    count(issue_events.event_id),
-                    MAX(issue_events.created_at)                AS LAST_EVENT_DATE,
-                    EXTRACT(DAY FROM NOW() - issues.created_at) AS OPEN_DAY,
-                    repo_name
-                FROM issues JOIN repo ON issues.repo_id = repo.repo_id, issue_events
-                WHERE issues.repo_id = :repo_id
-                AND issues.issue_id = issue_events.issue_id
-                GROUP BY issues.issue_id, repo_name
-                ORDER by OPEN_DAY DESC
-            """)
-            results = pd.read_sql(issuesSQL, self.db, params={'repo_id': repo_id})
-            return results
+    
 
 
 #####################################
@@ -1629,3 +1588,46 @@ class Augur(object):
 
         results = pd.read_sql(get_repos_for_dosocs_SQL, self.db)
         return results
+
+    @annotate(tag="get-issues")
+    def get_issues(self, repo_group_id, repo_id=None):
+        if not repo_id:
+            issuesSQL = s.sql.text("""
+                SELECT issue_title,
+                    issues.issue_id,
+                    issues.repo_id,
+                    issues.html_url,
+                    issue_state                                 AS STATUS,
+                    issues.created_at                           AS DATE,
+                    count(issue_events.event_id),
+                    MAX(issue_events.created_at)                AS LAST_EVENT_DATE,
+                    EXTRACT(DAY FROM NOW() - issues.created_at) AS OPEN_DAY
+                FROM issues,
+                    issue_events
+                WHERE issues.repo_id IN (SELECT repo_id FROM repo WHERE repo_group_id = :repo_group_id)
+                AND issues.issue_id = issue_events.issue_id
+                GROUP BY issues.issue_id
+                ORDER by OPEN_DAY DESC
+            """)
+            results = pd.read_sql(issuesSQL, self.db, params={'repo_group_id': repo_group_id})
+            return results
+        else:
+            issuesSQL = s.sql.text("""
+                SELECT issue_title,
+                    issues.issue_id,
+                    issues.repo_id,
+                    issues.html_url,
+                    issue_state                                 AS STATUS,
+                    issues.created_at                           AS DATE,
+                    count(issue_events.event_id),
+                    MAX(issue_events.created_at)                AS LAST_EVENT_DATE,
+                    EXTRACT(DAY FROM NOW() - issues.created_at) AS OPEN_DAY,
+                    repo_name
+                FROM issues JOIN repo ON issues.repo_id = repo.repo_id, issue_events
+                WHERE issues.repo_id = :repo_id
+                AND issues.issue_id = issue_events.issue_id
+                GROUP BY issues.issue_id, repo_name
+                ORDER by OPEN_DAY DESC
+            """)
+            results = pd.read_sql(issuesSQL, self.db, params={'repo_id': repo_id})
+            return results

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -1536,7 +1536,7 @@ def create_routes(server):
 
 
     """
-    @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-new-repo-in-repo-group Annual Commit Count Ranked by New Repo in Repo Group
+    @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-new-repo-in-repo-group Annual Commit Count Ranked by New Repo in Repo Group(Repo Group)
     @apiName annual-commit-count-ranked-by-new-repo-in-repo-group
     @apiGroup Experiment
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
@@ -1547,14 +1547,38 @@ def create_routes(server):
                                 "repos_id": 1,
                                 "net": 2479124,
                                 "patches": 1,
-                                "name": "twemoji"
+                                "repo_name": "twemoji"
                             },
                             {
                                 "repos_id": 63,
                                 "net": 2477911,
                                 "patches": 1,
-                                "name": "twemoji-1"
+                                "repo_name": "twemoji-1"
                             }
                         ]
     """
     server.addRepoGroupMetric(augur_db.annual_commit_count_ranked_by_new_repo_in_repo_group,'annual-commit-count-ranked-by-new-repo-in-repo-group')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-new-repo-in-repo-group Annual Commit Count Ranked by New Repo in Repo Group(Repo)
+    @apiName annual-commit-count-ranked-by-new-repo-in-repo-group
+    @apiGroup Experiment
+    @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
+    @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
+    @apiSuccessExample {json} Success-Response:
+                        [
+                            {
+                                "repos_id": 1,
+                                "net": 2479124,
+                                "patches": 1,
+                                "repo_name": "twemoji"
+                            },
+                            {
+                                "repos_id": 63,
+                                "net": 2477911,
+                                "patches": 1,
+                                "repo_name": "twemoji-1"
+                            }
+                        ]
+    """
+    server.addRepoMetric(augur_db.annual_commit_count_ranked_by_new_repo_in_repo_group,'annual-commit-count-ranked-by-new-repo-in-repo-group')

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -1630,3 +1630,100 @@ def create_routes(server):
                         ]
     """
     server.addRepoMetric(augur_db.annual_commit_count_ranked_by_repo_in_repo_group,'annual-commit-count-ranked-by-repo-in-repo-group')
+
+    
+    """
+    @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-new-repo-in-repo-group Annual Lines of Code Ranked by New Repo in Repo Group(Repo Group)
+    @apiName annual-lines-of-code-count-ranked-by-new-repo-in-repo-group
+    @apiGroup Experiment
+    @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
+    @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
+    @apiSuccessExample {json} Success-Response:
+                        [
+                            {
+                                "repos_id": 1,
+                                "net": 2479124,
+                                "patches": 1,
+                                "repo_name": "twemoji"
+                            },
+                            {
+                                "repos_id": 63,
+                                "net": 2477911,
+                                "patches": 1,
+                                "repo_name": "twemoji-1"
+                            }
+                        ]
+    """
+    server.addRepoGroupMetric(augur_db.annual_lines_of_code_count_ranked_by_new_repo_in_repo_group,'annual-lines-of-code-count-ranked-by-new-repo-in-repo-group')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-new-repo-in-repo-group Annual Lines of Code Ranked by New Repo in Repo Group(Repo)
+    @apiName annual-lines-of-code-count-ranked-by-new-repo-in-repo-group
+    @apiGroup Experiment
+    @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
+    @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
+    @apiSuccessExample {json} Success-Response:
+                        [
+                            {
+                                "repos_id": 1,
+                                "net": 2479124,
+                                "patches": 1,
+                                "repo_name": "twemoji"
+                            },
+                            {
+                                "repos_id": 63,
+                                "net": 2477911,
+                                "patches": 1,
+                                "repo_name": "twemoji-1"
+                            }
+                        ]
+    """
+    server.addRepoMetric(augur_db.annual_lines_of_code_count_ranked_by_new_repo_in_repo_group,'annual-lines-of-code-count-ranked-by-new-repo-in-repo-group')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-repo-in-repo-group Annual Lines of Code Ranked by Repo in Repo Group(Repo Group)
+    @apiName annual-lines-of-code-count-ranked-by-repo-in-repo-group
+    @apiGroup Experiment
+    @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
+    @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
+    @apiSuccessExample {json} Success-Response:
+                        [
+                            {
+                                "repos_id": 1,
+                                "net": 2479124,
+                                "patches": 1,
+                                "repo_name": "twemoji"
+                            },
+                            {
+                                "repos_id": 63,
+                                "net": 2477911,
+                                "patches": 1,
+                                "repo_name": "twemoji-1"
+                            }
+                        ]
+    """
+    server.addRepoGroupMetric(augur_db.annual_lines_of_code_count_ranked_by_repo_in_repo_group,'annual-lines-of-code-count-ranked-by-repo-in-repo-group')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-repo-in-repo-group Annual Lines of Code Ranked by Repo in Repo Group(Repo)
+    @apiName annual-lines-of-code-count-ranked-by-repo-in-repo-group
+    @apiGroup Experiment
+    @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
+    @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
+    @apiSuccessExample {json} Success-Response:
+                        [
+                            {
+                                "repos_id": 1,
+                                "net": 2479124,
+                                "patches": 1,
+                                "name": "twemoji"
+                            },
+                            {
+                                "repos_id": 63,
+                                "net": 2477911,
+                                "patches": 1,
+                                "name": "twemoji-1"
+                            }
+                        ]
+    """
+    server.addRepoMetric(augur_db.annual_lines_of_code_count_ranked_by_repo_in_repo_group,'annual-lines-of-code-count-ranked-by-repo-in-repo-group')

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -1582,3 +1582,51 @@ def create_routes(server):
                         ]
     """
     server.addRepoMetric(augur_db.annual_commit_count_ranked_by_new_repo_in_repo_group,'annual-commit-count-ranked-by-new-repo-in-repo-group')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-repo-in-repo-group Annual Commit Count Ranked by Repo in Repo Group(Repo Group)
+    @apiName annual-commit-count-ranked-by-repo-in-repo-group
+    @apiGroup Experiment
+    @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
+    @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
+    @apiSuccessExample {json} Success-Response:
+                        [
+                            {
+                                "repos_id": 1,
+                                "net": 2479124,
+                                "patches": 1,
+                                "repo_name": "twemoji"
+                            },
+                            {
+                                "repos_id": 63,
+                                "net": 2477911,
+                                "patches": 1,
+                                "repo_name": "twemoji-1"
+                            }
+                        ]
+    """
+    server.addRepoGroupMetric(augur_db.annual_commit_count_ranked_by_repo_in_repo_group,'annual-commit-count-ranked-by-repo-in-repo-group')
+
+    """
+     @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-repo-in-repo-group Annual Commit Count Ranked by Repo in Repo Group(Repo)
+    @apiName annual-commit-count-ranked-by-repo-in-repo-group
+    @apiGroup Experiment
+    @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
+    @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
+    @apiSuccessExample {json} Success-Response:
+                        [
+                            {
+                                "repos_id": 1,
+                                "net": 2479124,
+                                "patches": 1,
+                                "name": "twemoji"
+                            },
+                            {
+                                "repos_id": 63,
+                                "net": 2477911,
+                                "patches": 1,
+                                "name": "twemoji-1"
+                            }
+                        ]
+    """
+    server.addRepoMetric(augur_db.annual_commit_count_ranked_by_repo_in_repo_group,'annual-commit-count-ranked-by-repo-in-repo-group')

--- a/augur/datasources/augur_db/test_augur_db.py
+++ b/augur/datasources/augur_db/test_augur_db.py
@@ -248,3 +248,23 @@ def test_issues_maintainer_response_duration(augur_db):
     assert augur_db.issues_maintainer_response_duration(20).iloc[0].average_days_comment > 0
     assert augur_db.issues_maintainer_response_duration(20, 21000).iloc[0].average_days_comment > 0
 
+
+def test_annual_lines_of_code_count_ranked_by_repo_in_repo_group(augur_db):
+    assert augur_db.annual_lines_of_code_count_ranked_by_repo_in_repo_group(20).iloc[0].net > 0
+    assert augur_db.annual_lines_of_code_count_ranked_by_repo_in_repo_group(20, timeframe = 'year').iloc[0].net > 0
+    assert augur_db.annual_lines_of_code_count_ranked_by_repo_in_repo_group(20, 21000).iloc[0].net > 0
+    assert augur_db.annual_lines_of_code_count_ranked_by_repo_in_repo_group(20, 21000,timeframe = 'year').iloc[0].net > 0
+
+def test_annual_lines_of_code_count_ranked_by_new_repo_in_repo_group(augur_db):
+    assert augur_db.annual_lines_of_code_count_ranked_by_new_repo_in_repo_group(20).iloc[0].net > 0 
+    assert augur_db.annual_lines_of_code_count_ranked_by_new_repo_in_repo_group(20, 21000).iloc[0].net > 0 
+
+def test_annual_commit_count_ranked_by_repo_in_repo_group(augur_db):
+    assert augur_db.annual_commit_count_ranked_by_repo_in_repo_group(20).iloc[0].net > 0
+    assert augur_db.annual_commit_count_ranked_by_repo_in_repo_group(20, timeframe = 'year').iloc[0].net > 0
+    assert augur_db.annual_commit_count_ranked_by_repo_in_repo_group(20, 21000).iloc[0].net > 0
+    assert augur_db.annual_commit_count_ranked_by_repo_in_repo_group(20, 21000,timeframe = 'year').iloc[0].net > 0
+
+def test_annual_commit_count_ranked_by_new_repo_in_repo_group(augur_db):
+    assert augur_db.annual_commit_count_ranked_by_new_repo_in_repo_group(20).iloc[0].net > 0 
+    assert augur_db.annual_commit_count_ranked_by_new_repo_in_repo_group(20, 21000).iloc[0].net > 0 

--- a/augur/datasources/augur_db/test_augur_db_routes.py
+++ b/augur/datasources/augur_db/test_augur_db_routes.py
@@ -370,3 +370,61 @@ def test_license_declared_by_repo(augur_db_routes):
     assert len(data) >= 1
     assert data[0]["license"] == 'Apache-2.0'
 
+def test_annual_commit_count_ranked_by_new_repo_in_repo_group_by_repo(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/repos/21000/annual-commit-count-ranked-by-new-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0
+
+def test_annual_commit_count_ranked_by_new_repo_in_repo_group_by_group(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/annual-commit-count-ranked-by-new-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0
+
+
+def test_annual_commit_count_ranked_by_repo_in_repo_group_by_repo(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/repos/21000/annual-commit-count-ranked-by-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0
+
+def test_annual_commit_count_ranked_by_repo_in_repo_group_by_group(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/annual-commit-count-ranked-by-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0
+
+
+def test_annual_lines_of_code_count_ranked_by_new_repo_in_repo_group_by_repo(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/repos/21000/annual-lines-of-code-count-ranked-by-new-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0
+
+def test_annual_lines_of_code_count_ranked_by_new_repo_in_repo_group_by_group(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/annual-lines-of-code-count-ranked-by-new-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0
+
+
+def test_annual_lines_of_code_count_ranked_by_repo_in_repo_group_by_repo(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/repos/21000/annual-lines-of-code-count-ranked-by-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0
+
+def test_annual_lines_of_code_count_ranked_by_repo_in_repo_group_by_group(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/annual-lines-of-code-count-ranked-by-repo-in-repo-group')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+    assert data[0]["net"] > 0


### PR DESCRIPTION
Implement four Facade Metrics in new schema`augur_db`: 
- annual-commit-count-ranked-by-new-repo-in-repo-group
- annual-commit-count-ranked-by-repo-in-repo-group' 
- annual-lines-of-code-count-ranked-by-repo-in-repo-group
- annual-lines-of-code-count-ranked-by-new-repo-in-repo-group