### PR TITLE
Add setup.py to gh_repo_info_worker & API Docs update

### DIFF
--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -1840,7 +1840,7 @@ def create_routes(server):
     """
     @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-new-repo-in-repo-group Annual Commit Count Ranked by New Repo in Repo Group(Repo Group)
     @apiName annual-commit-count-ranked-by-new-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:
@@ -1864,7 +1864,7 @@ def create_routes(server):
     """
     @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-new-repo-in-repo-group Annual Commit Count Ranked by New Repo in Repo Group(Repo)
     @apiName annual-commit-count-ranked-by-new-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:
@@ -1888,7 +1888,7 @@ def create_routes(server):
     """
     @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-repo-in-repo-group Annual Commit Count Ranked by Repo in Repo Group(Repo Group)
     @apiName annual-commit-count-ranked-by-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:
@@ -1912,7 +1912,7 @@ def create_routes(server):
     """
      @api {get} /repo-groups/:repo_group_id/annual-commit-count-ranked-by-repo-in-repo-group Annual Commit Count Ranked by Repo in Repo Group(Repo)
     @apiName annual-commit-count-ranked-by-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:
@@ -1933,11 +1933,11 @@ def create_routes(server):
     """
     server.addRepoMetric(augur_db.annual_commit_count_ranked_by_repo_in_repo_group,'annual-commit-count-ranked-by-repo-in-repo-group')
 
-    
+
     """
     @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-new-repo-in-repo-group Annual Lines of Code Ranked by New Repo in Repo Group(Repo Group)
     @apiName annual-lines-of-code-count-ranked-by-new-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:
@@ -1961,7 +1961,7 @@ def create_routes(server):
     """
     @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-new-repo-in-repo-group Annual Lines of Code Ranked by New Repo in Repo Group(Repo)
     @apiName annual-lines-of-code-count-ranked-by-new-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:
@@ -1985,7 +1985,7 @@ def create_routes(server):
     """
     @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-repo-in-repo-group Annual Lines of Code Ranked by Repo in Repo Group(Repo Group)
     @apiName annual-lines-of-code-count-ranked-by-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:
@@ -2009,7 +2009,7 @@ def create_routes(server):
     """
     @api {get} /repo-groups/:repo_group_id/annual-lines-of-code-count-ranked-by-repo-in-repo-group Annual Lines of Code Ranked by Repo in Repo Group(Repo)
     @apiName annual-lines-of-code-count-ranked-by-repo-in-repo-group
-    @apiGroup Experiment
+    @apiGroup Experimental
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: Git Repository
     @apiParam {String} repo_url_base Base64 version of the URL of the GitHub repository as it appears in the Facade DB
     @apiSuccessExample {json} Success-Response:

--- a/augur/datasources/downloads/routes.py
+++ b/augur/datasources/downloads/routes.py
@@ -34,7 +34,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/downloads Downloads
     @apiName downloads
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="https://developer.github.com/">GitHub API</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository

--- a/augur/datasources/ghtorrent/routes.py
+++ b/augur/datasources/ghtorrent/routes.py
@@ -20,7 +20,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/issues/closed Closed Issues
     @apiName closed-issues
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/issues-closed.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -44,7 +44,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/commits?group_by=:group_by Code Commits
     @apiName code-commits
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="com/chaoss/metrics/blob/master/activity-metrics/code-commits.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -68,7 +68,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/code_review_iteration Code Review Iteration
     @apiName code-review-iteration
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="com/chaoss/metrics/blob/master/activity-metrics/code-review-iteration.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -91,7 +91,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/contribution_acceptance Contribution Acceptance
     @apiName contribution-acceptance
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://www.github.com/chaoss/metrics/blob/master/activity-metrics/contribution-acceptance.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -114,7 +114,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/contributing_github_organizations Contributing Github Organizations
     @apiName contributing-github-organizations
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="com/chaoss/metrics/blob/master/activity-metrics/contributing-organizations.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -151,7 +151,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/issues/response_time First Response To Issue Duration
     @apiName first-response-to-issue-duration
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/first-response-to-issue-duration.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -180,7 +180,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/forks?group_by=:group_by Forks
     @apiName forks
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiParam {String} group_by (Default to week) Allows for results to be grouped by day, week, month, or year
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/forks.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
@@ -204,7 +204,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/pulls/maintainer_response_time Maintainer Response to Merge Request Duration
     @apiName maintainer-response-to-merge-request-duration
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/augurlabs/metrics/blob/master/activity-metrics/maintainer-response-to-merge-request-duration.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -227,7 +227,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/pulls/new_contributing_github_organizations New Contributing Github Organizations
     @apiName new-github-contributing-organizations
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/augurlabs/metrics/blob/master/activity-metrics/new-contributing-organizations.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -250,7 +250,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/issues Open Issues
     @apiName open-issues
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/open-issues.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {string} group_by (default to week) allows for results to be grouped by day, week, month, or year
@@ -274,7 +274,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/pulls/comments?group_by=:group_by Pull Request Comments
     @apiName pull-request-comments
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/pull-request-comments.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -298,7 +298,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/pulls Pull Requests Open
     @apiName pull-requests-open
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/pull-requests-open.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -321,7 +321,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/pulls/closed Pull Requests Closed
     @apiName pull-requests-closed
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/pull-requests-closed.md">CHAOSS Metric Definition</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -344,7 +344,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/pulls/response_time Most Recent Response To Pull Requests Duration
     @apiName pull-request-comment-duration'
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/wg-gmd/blob/master/metrics/pull-requests-comment-duration.md>CHAOSS Metric Definition</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -389,7 +389,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/issue_comments Issue Comments
     @apiName issue-comments
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/issue-comments.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -412,7 +412,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/pulls/made_closed Pull Requests Made/Closed
     @apiName pull-requests-made-closed
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/pull-requests-made-closed.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -435,7 +435,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/watchers Watchers
     @apiName watchers
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription <a href="https://github.com/chaoss/metrics/blob/master/activity-metrics/activity-metrics-list.md">CHAOSS Metric Definition</a>. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -462,7 +462,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/commits100 Commits100
     @apiName commits100
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -485,7 +485,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/commits/comments Commit Comments
     @apiName commit-comments
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -509,7 +509,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/committer_locations Committer Locations
     @apiName committer-locations
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -534,7 +534,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/total_committers Total Committers
     @apiName total-committers
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -557,7 +557,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/issues/activity Issue Activity
     @apiName issue-activity
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -613,7 +613,7 @@ def create_routes(server):
     @api {get} /:owner/:repo/timeseries/pulls/acceptance_rate Pull Request Acceptance Rate
     @apiDeprecated This endpoint was removed. Please use (#Experimental:community-engagement)
     @apiName pull-request-acceptance-rate
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -636,7 +636,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/community_age Community Age
     @apiName community-age
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally.
                     Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
@@ -662,7 +662,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/community_engagement Community Engagement
     @apiName community-engagement
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -717,7 +717,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/contributors Total Contributions by User
     @apiName contributors
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -752,7 +752,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/contributions Contributions
     @apiName contributions
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -798,7 +798,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/project_age Project Age
     @apiName project-age
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -818,7 +818,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/fakes Fakes
     @apiName fakes
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -841,7 +841,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/new_watchers New Watchers
     @apiName new_watchers
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -864,7 +864,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/total_watchers Total Watchers
     @apiName total-watchers
-    @apiGroup GHTorrent (Legacy)
+    @apiGroup _GHTorrent (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="http://ghtorrent.org/">GHTorrent</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository

--- a/augur/datasources/githubapi/routes.py
+++ b/augur/datasources/githubapi/routes.py
@@ -18,10 +18,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/githubapi/issues/closed Closed Issues
     @apiName githubapi-closed-issues
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/chaoss/wg-gmd/blob/master/metrics/issues-closed.md">CHAOSS Metric Definition</a>
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -42,10 +42,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/githubapi/commits Code Commits
     @apiName githubapi-code-commits
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/chaoss/wg-gmd/blob/master/activity-metrics/code-commits.md">CHAOSS Metric Definition</a>
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -66,10 +66,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/githubapi/contributors List of Contributors & their Contributions
     @apiName githubapi-contributors
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/chaoss/wg-gmd/blob/master/metrics/contributors.md">CHAOSS Metric Definition</a>
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -90,10 +90,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/lines_changed Lines of Code Changed
     @apiName lines-of-code-changed
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/augurlabs/metrics/blob/master/activity-metrics/lines-of-code-changed.md">CHAOSS Metric Definition</a>.  Source: <a href="https://developer.github.com/">GitHub API</a>
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -114,10 +114,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/githubapi/issues Issues Opened
     @apiName githubapi-issues-opened
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/chaoss/wg-gmd/blob/master/metrics/issues-open.md">CHAOSS Metric Definition</a>
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -138,10 +138,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/githubapi/pull_requests_closed Pull Requests Closed
     @apiName githubapi-pull-requests-Closed
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/ComputationalMystics/wg-gmd/blob/master/activity-metrics/pull-requests-closed.md">CHAOSS Metric Definition</a>
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -153,10 +153,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/githubapi/pull_requests_merged Pull Requests Merged
     @apiName githubapi-pull-requests-merged
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription Count of pull requests merged.
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -168,10 +168,10 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/githubapi/pull_requests_open Pull Requests Open
     @apiName githubapi-pull-requests-open
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/ComputationalMystics/wg-gmd/blob/master/activity-metrics/pull-requests-open.md">CHAOSS Metric Definition</a>
 
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiParam {String} owner Username of the owner of the GitHub repository
     @apiParam {String} repo Name of the GitHub repository
 
@@ -195,7 +195,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/githubapi/repository_size Repository Size
     @apiName repository-size
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription <a href="https://github.com/chaoss/wg-gmd/blob/master/metrics/archived_metrics/repository-size.md">CHAOSS Metric Definition</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -220,7 +220,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/bus_factor Bus Factor
     @apiName bus-factor
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="https://developer.github.com/">GitHub API</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -240,7 +240,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/tags/major Major Tags
     @apiName major-tags
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="https://developer.github.com/">GitHub API</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -263,7 +263,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/timeseries/tags/major Tages
     @apiName tags
-    @apiGroup GitHub API (Legacy)
+    @apiGroup _GitHub API (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="https://developer.github.com/">GitHub API</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository

--- a/augur/datasources/librariesio/routes.py
+++ b/augur/datasources/librariesio/routes.py
@@ -34,7 +34,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/dependencies Dependencies
     @apiName dependencies
-    @apiGroup Libraries.io (Legacy)
+    @apiGroup _Libraries.io (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="https://libraries.io/">LibrariesIO</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -125,7 +125,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/dependency_stats Dependency Stats
     @apiName dependency-stats
-    @apiGroup Libraries.io (Legacy)
+    @apiGroup _Libraries.io (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="https://libraries.io/">LibrariesIO</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository
@@ -145,7 +145,7 @@ def create_routes(server):
     """
     @api {get} /:owner/:repo/dependents Dependents
     @apiName dependents
-    @apiGroup Libraries.io (Legacy)
+    @apiGroup _Libraries.io (Legacy)
     @apiDescription This is an Augur-specific metric. We are currently working to define these more formally. Source: <a href="https://libraries.io/">LibrariesIO</a>
 
     @apiParam {String} owner Username of the owner of the GitHub repository

--- a/workers/gh_repo_info_worker/README.rst
+++ b/workers/gh_repo_info_worker/README.rst
@@ -17,6 +17,15 @@ This worker is integrated into Augur's worker architecture and can receieve task
 Usage
 -----
 
+Installing the Worker
+********
+
+To install this worker execute the following command
+
+.. code:: bash
+
+    pip install -e .
+
 Running this Worker
 ********
 
@@ -24,7 +33,7 @@ To run this worker execute the following command
 
 .. code:: bash
 
-    python -m gh_repo_info_worker.runtime
+    repo_info_worker
 
 
 **Note:** Make sure the broker is running before running the worker

--- a/workers/gh_repo_info_worker/setup.py
+++ b/workers/gh_repo_info_worker/setup.py
@@ -1,0 +1,45 @@
+import io
+import os
+import re
+
+from setuptools import find_packages
+from setuptools import setup
+
+
+def read(filename):
+    filename = os.path.join(os.path.dirname(__file__), filename)
+    text_type = type(u"")
+    with io.open(filename, mode="r", encoding='utf-8') as fd:
+        return re.sub(text_type(r':[a-z]+:`~?(.*?)`'), text_type(r'``\1``'), fd.read())
+
+
+setup(
+    name="gh_repo_info_worker",
+    version="0.1.0",
+    url="https://github.com/chaoss/augur",
+    license='MIT',
+
+    author="Augur Team",
+    author_email="s@goggins.com",
+
+    description="Augur Worker that collects GitHub data",
+    long_description=read("README.rst"),
+
+    packages=find_packages(exclude=('tests',)),
+
+    install_requires=['flask', 'requests', 'psycopg2-binary', 'click'],
+
+    entry_points={
+        'console_scripts': [
+            'repo_info_worker=gh_repo_info_worker.runtime:main',
+        ],
+    },
+
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+    ],
+)


### PR DESCRIPTION
Added a `setup.py` to `gh_repo_info_worker`

This allows you to install the worker and run it by invoking the command `repo_info_worker`

Updated API docs. Moved all legacy API endpoints to the bottom of the sidebar