### PR TITLE
PR metric implementations & PR worker bug fixes

### DIFF
--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -809,6 +809,65 @@ class Augur(object):
                                           'begin_date': begin_date, 'end_date': end_date})
             return results
 
+    @annotate(tag='reviews-declined')
+    def reviews_declined(self, repo_group_id, repo_id=None, period='day', begin_date=None, end_date=None):
+        """ Returns a time series of reivews declined
+
+        :param repo_group_id: The repository's repo_group_id
+        :param repo_id: The repository's repo_id, defaults to None
+        :param period: To set the periodicity to 'day', 'week', 'month' or 'year', defaults to 'day'
+        :param begin_date: Specifies the begin date, defaults to '1970-1-1 00:00:00'
+        :param end_date: Specifies the end date, defaults to datetime.now()
+        :return: DataFrame of declined reviews/period
+        """
+        if not begin_date:
+            begin_date = '1970-1-1'
+        if not end_date:
+            end_date = datetime.datetime.now().strftime('%Y-%m-%d')
+
+        if not repo_id:
+            reviews_declined_SQL = s.sql.text("""
+                SELECT
+                    pull_requests.repo_id,
+                    repo.repo_name,
+                    DATE_TRUNC(:period, pull_requests.pr_closed_at) AS date,
+                    COUNT(pr_src_id) AS pull_requests
+                FROM pull_requests JOIN repo ON pull_requests.repo_id = repo.repo_id
+                WHERE pull_requests.repo_id IN
+                    (SELECT repo_id FROM repo WHERE repo_group_id = :repo_group_id)
+                AND pr_src_state = 'closed' AND pr_merged_at IS NULL
+                AND pr_closed_at
+                    BETWEEN to_timestamp(:begin_date, 'YYYY-MM-DD')
+                    AND to_timestamp(:end_date, 'YYYY-MM-DD')
+                GROUP BY pull_requests.repo_id, repo_name, date
+                ORDER BY pull_requests.repo_id, date
+            """)
+
+            results = pd.read_sql(reviews_declined_SQL, self.db,
+                                  params={'period': period, 'repo_group_id': repo_group_id,
+                                          'begin_date': begin_date, 'end_date': end_date })
+            return results
+        else:
+            reviews_declined_SQL = s.sql.text("""
+                SELECT
+                    repo.repo_name,
+                    DATE_TRUNC(:period, pull_requests.pr_closed_at) AS date,
+                    COUNT(pr_src_id) AS pull_requests
+                FROM pull_requests JOIN repo ON pull_requests.repo_id = repo.repo_id
+                WHERE pull_requests.repo_id = :repo_id
+                AND pr_src_state = 'closed' AND pr_merged_at IS NULL
+                AND pr_closed_at
+                    BETWEEN to_timestamp(:begin_date, 'YYYY-MM-DD')
+                    AND to_timestamp(:end_date, 'YYYY-MM-DD')
+                GROUP BY date, repo.repo_name
+                ORDER BY date
+            """)
+
+            results = pd.read_sql(reviews_declined_SQL, self.db,
+                                  params={'period': period, 'repo_id': repo_id,
+                                          'begin_date': begin_date, 'end_date': end_date})
+            return results
+
     @annotate(tag='issues-new')
     def issues_new(self, repo_group_id, repo_id=None, period='day', begin_date=None, end_date=None):
         """Returns a timeseries of new issues opened.

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -433,6 +433,72 @@ def create_routes(server):
     server.addRepoMetric(augur_db.reviews_accepted, 'reviews-accepted')
 
     """
+    @api {get} /repo-groups/:repo_group_id/reviews-declined Reviews Declined (Repo Group)
+    @apiName reviews-declined-repo-group
+    @apiGroup Evolution
+    @apiDescription Time series of number of declined reviews / pull requests opened within a certain period.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID
+    @apiParam {string=day, week, month, year} [period="day"] Periodicity specification.
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_id": 21035,
+                            "repo_name": "prototype-ujs",
+                            "date": "2010-01-01T00:00:00.000Z",
+                            "pull_requests": 1
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "date": "2011-01-01T00:00:00.000Z",
+                            "pull_requests": 3
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "date": "2012-01-01T00:00:00.000Z",
+                            "pull_requests": 6
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.reviews_declined, 'reviews-declined')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/reviews-declined Reviews Declined (Repo)
+    @apiName reviews-declined-repo
+    @apiGroup Evolution
+    @apiDescription Time series of number of declined reviews / pull requests opened within a certain period.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID.
+    @apiParam {string} repo_id Repository ID.
+    @apiParam {string=day, week, month, year} [period="day"] Periodicity specification.
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2016-01-01T00:00:00.000Z",
+                            "pull_requests": 11
+                        },
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2017-01-01T00:00:00.000Z",
+                            "pull_requests": 16
+                        },
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2018-01-01T00:00:00.000Z",
+                            "pull_requests": 4
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.reviews_declined, 'reviews-declined')
+
+    """
     @api {get} /repo-groups/:repo_group_id/issues-new Issues New (Repo Group)
     @apiName issues-new-repo-group
     @apiGroup Evolution

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -367,6 +367,72 @@ def create_routes(server):
     server.addRepoMetric(augur_db.reviews, 'reviews')
 
     """
+    @api {get} /repo-groups/:repo_group_id/reviews-accepted Reviews Accepted (Repo Group)
+    @apiName reviews-accepted-repo-group
+    @apiGroup Evolution
+    @apiDescription Time series of number of accepted reviews / pull requests opened within a certain period.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID
+    @apiParam {string=day, week, month, year} [period="day"] Periodicity specification.
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_id": 21035,
+                            "repo_name": "prototype-ujs",
+                            "date": "2010-01-01T00:00:00.000Z",
+                            "pull_requests": 1
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "date": "2011-01-01T00:00:00.000Z",
+                            "pull_requests": 4
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "date": "2012-01-01T00:00:00.000Z",
+                            "pull_requests": 4
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.reviews_accepted, 'reviews-accepted')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/reviews-accepted Reviews Accepted (Repo)
+    @apiName reviews-accepted-repo
+    @apiGroup Evolution
+    @apiDescription Time series of number of accepted reviews / pull requests opened within a certain period.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID.
+    @apiParam {string} repo_id Repository ID.
+    @apiParam {string=day, week, month, year} [period="day"] Periodicity specification.
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2016-01-01T00:00:00.000Z",
+                            "pull_requests": 30
+                        },
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2017-01-01T00:00:00.000Z",
+                            "pull_requests": 37
+                        },
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2018-01-01T00:00:00.000Z",
+                            "pull_requests": 46
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.reviews_accepted, 'reviews-accepted')
+
+    """
     @api {get} /repo-groups/:repo_group_id/issues-new Issues New (Repo Group)
     @apiName issues-new-repo-group
     @apiGroup Evolution

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -697,6 +697,75 @@ def create_routes(server):
     server.addRepoMetric(augur_db.issues_closed, 'issues-closed')
 
     """
+    @api {get} /repo-groups/:repo_group_id/review-duration Review Duration (Repo Group)
+    @apiName review-duration-repo-group
+    @apiGroup Evolution
+    @apiDescription Time since an review/pull request is proposed until it is accepted.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_id": 21035,
+                            "repo_name": "prototype-ujs",
+                            "pull_request_id": 25386,
+                            "created_at": "2010-09-28T19:07:15.000Z",
+                            "merged_at": "2010-09-29T17:46:59.000Z",
+                            "duration": "0 days 22:39:44.000000000"
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "pull_request_id": 25392,
+                            "created_at": "2011-05-18T14:11:23.000Z",
+                            "merged_at": "2011-05-18T19:03:01.000Z",
+                            "duration": "0 days 04:51:38.000000000"
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "pull_request_id": 25396,
+                            "created_at": "2011-05-25T10:09:01.000Z",
+                            "merged_at": "2011-05-25T19:30:01.000Z",
+                            "duration": "0 days 09:21:00.000000000"
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.review_duration, 'review-duration')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/review-duration review Duration (Repo)
+    @apiName review-duration-repo
+    @apiGroup Evolution
+    @apiDescription Time since an review/pull request is proposed until it is accepted.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID.
+    @apiParam {string} repo_id Repository ID.
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_name": "graphql-spec",
+                            "pull_request_id": 25374,
+                            "created_at": "2019-01-02T11:02:08.000Z",
+                            "merged_at": "2019-07-05T09:10:45.000Z",
+                            "duration": "183 days 22:08:37.000000000"
+                        },
+                        {
+                            "repo_name": "graphql-spec",
+                            "pull_request_id": 25378,
+                            "created_at": "2019-03-28T13:44:04.000Z",
+                            "merged_at": "2019-07-03T23:10:36.000Z",
+                            "duration": "97 days 09:26:32.000000000"
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.review_duration, 'review-duration')
+
+    """
     @api {get} /repo-groups/:repo_group_id/issue-duration Issue Duration (Repo Group)
     @apiName issue-duration-repo-group
     @apiGroup Evolution

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -295,6 +295,78 @@ def create_routes(server):
     server.addRepoMetric(augur_db.code_changes_lines, 'code-changes-lines')
 
     """
+    @api {get} /repo-groups/:repo_group_id/reviews Reviews (Repo Group)
+    @apiName reviews-repo-group
+    @apiGroup Evolution
+    @apiDescription Time series of number of new reviews / pull requests opened within a certain period.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/reviews.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID
+    @apiParam {string=day, week, month, year} [period="day"] Periodicity specification.
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_id": 21035,
+                            "repo_name": "prototype-ujs",
+                            "date": "2010-01-01T00:00:00.000Z",
+                            "pull_requests": 1
+                        },
+                        {
+                            "repo_id": 21035,
+                            "repo_name": "prototype-ujs",
+                            "date": "2011-01-01T00:00:00.000Z",
+                            "pull_requests": 5
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "date": "2011-01-01T00:00:00.000Z",
+                            "pull_requests": 16
+                        },
+                        {
+                            "repo_id": 21042,
+                            "repo_name": "pjax_rails",
+                            "date": "2012-01-01T00:00:00.000Z",
+                            "pull_requests": 14
+                        }
+                    ]
+    """
+    server.addRepoGroupMetric(augur_db.reviews, 'reviews')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/reviews Reviews (Repo)
+    @apiName reviews-repo
+    @apiGroup Evolution
+    @apiDescription Time series of number of new reviews / pull requests opened within a certain period.
+                    <a href="https://github.com/chaoss/wg-evolution/blob/master/metrics/reviews.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID.
+    @apiParam {string} repo_id Repository ID.
+    @apiParam {string=day, week, month, year} [period="day"] Periodicity specification.
+    @apiParam {string} [begin_date="1970-1-1 0:0:0"] Beginning date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiParam {string} [end_date="current date"] Ending date specification. E.g. values: `2018`, `2018-05`, `2019-05-01`
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2016-01-01T00:00:00.000Z",
+                            "pull_requests": 37
+                        },
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2017-01-01T00:00:00.000Z",
+                            "pull_requests": 49
+                        },
+                        {
+                            "repo_name": "graphql-spec",
+                            "date": "2018-01-01T00:00:00.000Z",
+                            "pull_requests": 63
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.reviews, 'reviews')
+
+    """
     @api {get} /repo-groups/:repo_group_id/issues-new Issues New (Repo Group)
     @apiName issues-new-repo-group
     @apiGroup Evolution


### PR DESCRIPTION
Implemented the following pull request metrics:
- **Reviews:** Time series of the number of new reviews or pull requests opened within a certain period.
- **Reviews-Accepted:** Time series of the number of accepted reviews or pull requests opened within a certain period.
- **Reviews-Declined:** Time series of the number of declined reviews or pull requests opened within a certain period.
- **Review-Duration:** Time since a review/pull request is proposed until it is accepted.

Pull Request worker bug fixes & minor changes
- Add `repo_id` in pull request records
- Set default `cntrb_id` in pr_events to 1
- Removed error handling for debugging [Temporary]