### PR TITLE
Frontend Router and Risk Metric Implemntation

### DIFF
--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -2623,8 +2623,8 @@ class Augur(object):
         results = pd.read_sql(repos_in_repo_groups_SQL, self.db, params={'repo_group_id': repo_group_id})
         return results
 
-    @annotate(tag='get-repo')
-    def get_repo(self, owner, repo):
+    @annotate(tag='get-repo-by-git-name')
+    def get_repo_by_git_name(self, owner, repo):
         """
         Returns repo id and repo group id by owner and repo
 
@@ -2640,6 +2640,25 @@ class Augur(object):
 
         results = pd.read_sql(getRepoSQL, self.db, params={'owner': '%{}_'.format(owner), 'repo': repo,})
 
+        return results
+
+    @annotate(tag='get-repo-by-name')
+    def get_repo_by_name(self, rg_name, repo_name):
+        """
+        Returns repo id and repo group id by rg_name and repo_name
+
+        :param owner: the owner of the repo
+        :param repo: the name of the repo
+        """
+
+        repoSQL = s.sql.text("""
+            SELECT repo_id, repo.repo_group_id, repo_git
+            FROM repo, repo_groups
+            WHERE repo.repo_group_id = repo_groups.repo_group_id
+            AND LOWER(rg_name) = LOWER(:rg_name)
+            AND LOWER(repo_name) = LOWER(:repo_name)
+        """)
+        results = pd.read_sql(repoSQL, self.db, params={'rg_name': rg_name, 'repo_name': repo_name})
         return results
 
     # @annotate(tag='dosocs-repos')

--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -2652,13 +2652,14 @@ class Augur(object):
         """
 
         repoSQL = s.sql.text("""
-            SELECT repo_id, repo.repo_group_id, repo_git
+            SELECT repo_id, repo.repo_group_id, repo_git as url
             FROM repo, repo_groups
             WHERE repo.repo_group_id = repo_groups.repo_group_id
             AND LOWER(rg_name) = LOWER(:rg_name)
             AND LOWER(repo_name) = LOWER(:repo_name)
         """)
         results = pd.read_sql(repoSQL, self.db, params={'rg_name': rg_name, 'repo_name': repo_name})
+        results['url'] = results['url'].apply(lambda datum: datum.split('//')[1])
         return results
 
     # @annotate(tag='dosocs-repos')

--- a/augur/datasources/augur_db/augur_db.py
+++ b/augur/datasources/augur_db/augur_db.py
@@ -1840,7 +1840,7 @@ class Augur(object):
         return results
 
     @annotate(tag='committers')
-    def committers(self, repo_group_id, repo_id=None, begin_date=None, end_date=None, period='day'):
+    def committers(self, repo_group_id, repo_id=None, begin_date=None, end_date=None, period='week'):
 
         if not begin_date:
             begin_date = '1970-1-1 00:00:01'

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -1895,8 +1895,8 @@ def create_routes(server):
     server.addRepoMetric(augur_db.languages, 'languages')
 
     """
-    @api {get} /repo-groups/:repo_group_id/license-declared License Declared (Repo Group)
-    @apiName license-declared-repo-group
+    @api {get} /repo-groups/:repo_group_id/license-count License Declared (Repo Group)
+    @apiName license-count-repo-group
     @apiGroup Risk
     @apiDescription The declared software package license (fetched from CII Best Practices badging data).
                     <a href="https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md">CHAOSS Metric Definition</a>
@@ -1904,22 +1904,22 @@ def create_routes(server):
     @apiSuccessExample {json} Success-Response:
                     [
                         {
-                            "repo_id": 21252,
-                            "repo_name": "php-legal-licenses",
-                            "license": "Apache-2.0"
+                            "name": "ActorServiceRegistry",
+                            "number_of_license": 2,
+                            "file_without_licenses": true
                         },
                         {
-                            "repo_id": 21277,
-                            "repo_name": "trickster",
-                            "license": "Apache-2.0"
-                        }
+                            "name": "adyen-api",
+                            "number_of_license": 1,
+                            "file_without_licenses": true
+                        },
                     ]
     """
-    server.addRepoGroupMetric(augur_db.license_declared, 'license-declared')
+    server.addRepoGroupMetric(augur_db.license_declared, 'license-count')
 
     """
-    @api {get} /repo-groups/:repo_group_id/license-declared License Declared (Repo)
-    @apiName license-declared-repo
+    @api {get} /repo-groups/:repo_group_id/license-count License Declared (Repo)
+    @apiName license-count-repo
     @apiGroup Risk
     @apiDescription The declared software package license (fetched from CII Best Practices badging data).
                     <a href="https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md">CHAOSS Metric Definition</a>
@@ -1927,17 +1927,20 @@ def create_routes(server):
     @apiParam {string} repo_id Repository ID.
     @apiSuccessExample {json} Success-Response:
                     [
-                        {
-                            "repo_name":"php-legal-licenses",
-                            "license": "Apache-2.0"
-                        }
+                        [
+                            {
+                                "name": "zucchini",
+                                "number_of_license": 2,
+                                "file_without_licenses": true
+                            }
+                        ]
                     ]
     """
-    server.addRepoMetric(augur_db.license_declared, 'license-declared')
+    server.addRepoMetric(augur_db.license_count, 'license-count')
 
     """
-    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/committers Committers
-    @apiName committers(Repo)
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/committers Committers(Repo)
+    @apiName committers-repo
     @apiGroup Risk
     @apiDescription Number of persons contributing with an accepted commit for the first time.
                 <a href="https://github.com/chaoss/wg-risk/blob/master/metrics/Committers.md">CHAOSS Metric Definition</a>
@@ -1970,8 +1973,8 @@ def create_routes(server):
 
     """
     @api {get} /repo-groups/:repo_group_id/Committers (Repo Group)
-    @apiName committers(Repo Group)
-    @apiGroup []
+    @apiName committers-repo-group
+    @apiGroup Risk
     @apiDescription Number of persons opening an issue for the first time.
                     <a href="https://github.com/chaoss/wg-risk/blob/master/metrics/Committers.md">CHAOSS Metric Definition</a>
     @apiParam {string} repo_group_id Repository Group ID

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -1895,7 +1895,7 @@ def create_routes(server):
     server.addRepoMetric(augur_db.languages, 'languages')
 
     """
-    @api {get} /repo-groups/:repo_group_id/license-count License Declared (Repo Group)
+    @api {get} /repo-groups/:repo_group_id/license-count License Count (Repo Group)
     @apiName license-count-repo-group
     @apiGroup Risk
     @apiDescription The declared software package license (fetched from CII Best Practices badging data).
@@ -1915,10 +1915,10 @@ def create_routes(server):
                         },
                     ]
     """
-    server.addRepoGroupMetric(augur_db.license_declared, 'license-count')
+    server.addRepoGroupMetric(augur_db.license_count, 'license-count')
 
     """
-    @api {get} /repo-groups/:repo_group_id/license-count License Declared (Repo)
+    @api {get} /repo-groups/:repo_group_id/license-count License Count (Repo)
     @apiName license-count-repo
     @apiGroup Risk
     @apiDescription The declared software package license (fetched from CII Best Practices badging data).
@@ -2004,7 +2004,7 @@ def create_routes(server):
         augur_db.committers, 'committers')
 
     """
-    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/license-coverage
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/license-coverage License Coverage(Repo)
     @apiName license-coverage-repo
     @apiGroup Risk
     @apiDescription Number of persons contributing with an accepted commit for the first time.
@@ -2024,7 +2024,7 @@ def create_routes(server):
     server.addRepoMetric(augur_db.license_coverage, 'license-coverage')
 
     """
-    @api {get} /repo-groups/:repo_group_id/license-coverage
+    @api {get} /repo-groups/:repo_group_id/license-coverage License Coverage(Repo Group)
     @apiName license-coverage-repo-group
     @apiGroup Risk
     @apiDescription Number of persons opening an issue for the first time.
@@ -2048,6 +2048,49 @@ def create_routes(server):
     """
 
     server.addRepoGroupMetric(augur_db.license_coverage, 'license-coverage')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/license-declared License Declared(Repo)
+    @apiName license-declared-repo
+    @apiGroup Risk
+    @apiDescription Number of persons contributing with an accepted commit for the first time.
+                <a href="https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID.
+    @apiParam {string} repo_id Repository ID.
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "name": "trickster",
+                            "short_name": "Apache-2.0",
+                            "note": ""
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.license_declared, 'license-declared')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/license-declared License Declared(Repo Group)
+    @apiName license-declared-repo-group
+    @apiGroup Risk
+    @apiDescription Number of persons opening an issue for the first time.
+                    <a href="https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID
+    @apiSuccessExample {json} Success-Response:
+                    [
+                       {
+                            "name": "trickster",
+                            "short_name": "Apache-2.0",
+                            "note": ""
+                        },
+                        {
+                            "name": "dialyzex",
+                            "short_name": "Apache-2.0",
+                            "note": ""
+                        }
+                    ]
+    """
+
+    server.addRepoGroupMetric(augur_db.license_declared, 'license-declared')
 
 
 

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -126,7 +126,7 @@ def create_routes(server):
     server.addRepoGroupMetric(augur_db.repos_in_repo_groups, 'repos')
 
     """
-    @api {get} /repos/:owner/:repo Get Repo
+    @api {get} /owner/:owner/repo/:repo Get Repo
     @apiName get-repo
     @apiGroup Utility
     @apiDescription Get the `repo_group_id` & `repo_id` of a particular repo.
@@ -142,15 +142,35 @@ def create_routes(server):
                         }
                     ]
     """
-    @server.app.route('/{}/repos/<owner>/<repo>'.format(server.api_version))
-    def get_repo(owner, repo):
+    @server.app.route('/{}/owner/<owner>/name/<repo>'.format(server.api_version))
+    def get_repo_by_git_name(owner, repo):
         a = [owner, repo]
-        gre = server.transform(augur_db.get_repo, args = a)
+        gre = server.transform(augur_db.get_repo_by_git_name, args = a)
         return Response(response=gre,
                         status=200,
                         mimetype="application/json")
 
-    server.updateMetricMetadata(function=augur_db.get_repo, endpoint='/{}/repos/<owner>/<repo>'.format(server.api_version), metric_type='git')
+    """
+    @api {get} /rg-names/:rg_name/repo-name/:repo_name Get Repo
+    @apiName get-repo
+    @apiGroup Utility
+    @apiDescription Get the `repo_group_id` & `repo_id` of a particular repo.
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_id": 21000,
+                            "repo_group_id": 20,
+                            "repo_git":"https://github.com/rails/rails.git"
+                        },
+                    ]
+    """
+    @server.app.route('/{}/rg-name/<rg_name>/repo-name/<repo_name>'.format(server.api_version))
+    def get_repo_by_name(rg_name, repo_name):
+        arg = [rg_name, repo_name]
+        gre = server.transform(augur_db.get_repo_by_name, args=arg)
+        return Response(response=gre,
+                        status=200,
+                        mimetype="application/json")
 
     @server.app.route('/{}/dosocs/repos'.format(server.api_version))
     def get_repos_for_dosocs():

--- a/augur/datasources/augur_db/routes.py
+++ b/augur/datasources/augur_db/routes.py
@@ -2003,6 +2003,52 @@ def create_routes(server):
     server.addRepoGroupMetric(
         augur_db.committers, 'committers')
 
+    """
+    @api {get} /repo-groups/:repo_group_id/repos/:repo_id/license-coverage
+    @apiName license-coverage-repo
+    @apiGroup Risk
+    @apiDescription Number of persons contributing with an accepted commit for the first time.
+                <a href="https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID.
+    @apiParam {string} repo_id Repository ID.
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "repo_name": "zucchini",
+                            "total_files": 95,
+                            "license_declared_file": 33,
+                            "coverage": 0.347
+                        }
+                    ]
+    """
+    server.addRepoMetric(augur_db.license_coverage, 'license-coverage')
+
+    """
+    @api {get} /repo-groups/:repo_group_id/license-coverage
+    @apiName license-coverage-repo-group
+    @apiGroup Risk
+    @apiDescription Number of persons opening an issue for the first time.
+                    <a href="https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md">CHAOSS Metric Definition</a>
+    @apiParam {string} repo_group_id Repository Group ID
+    @apiSuccessExample {json} Success-Response:
+                    [
+                        {
+                            "name": "ActorServiceRegistry",
+                            "total_files": 51,
+                            "license_declared_files": 19,
+                            "coverage": 0.373
+                        },
+                        {
+                            "name": "adyen-api",
+                            "total_files": 92,
+                            "license_declared_files": 55,
+                            "coverage": 0.598
+                        }
+                    ]
+    """
+
+    server.addRepoGroupMetric(augur_db.license_coverage, 'license-coverage')
+
 
 
     #####################################

--- a/augur/datasources/augur_db/test_augur_db.py
+++ b/augur/datasources/augur_db/test_augur_db.py
@@ -244,12 +244,6 @@ def test_languages(augur_db):
     # TODO
     pass
 
-def test_license_declared(augur_db):
-    # TODO need more data
-    pass
-    # assert augur_db.license_declared(21, 21252).isin(['Apache-2.0']).any().any()
-
-
 def test_issues_maintainer_response_duration(augur_db):
     assert augur_db.issues_maintainer_response_duration(20, 21000).iloc[0].average_days_comment > 0
     assert augur_db.issues_maintainer_response_duration(20).iloc[0].average_days_comment > 0
@@ -300,3 +294,15 @@ def test_pull_request_acceptance_rate(augur_db):
     assert augur_db.pull_request_acceptance_rate(24).iloc[0]['rate'] > 0
     assert augur_db.pull_request_acceptance_rate(24,21000,begin_date='2018-1-1 00:00:00',
                                      end_date='2019-12-31 23:59:59',group_by='year').iloc[0]['rate'] > 0
+
+def test_license_declared(augur_db):
+    assert augur_db.license_declared(21).iloc[0]['name']
+    assert augur_db.license_declared(21, 21116).iloc[0]['name']
+
+def test_license_count(augur_db):
+    assert augur_db.license_count(21).iloc[0]['number_of_license'] >= 1
+    assert augur_db.license_count(21, 21116).iloc[0]['number_of_license'] >= 1
+
+def test_license_coverage(augur_db):
+    assert augur_db.license_coverage(21).iloc[0]['total_files'] >= 1
+    assert augur_db.license_coverage(21, 21116).iloc[0]['total_files'] >= 1

--- a/augur/datasources/augur_db/test_augur_db_routes.py
+++ b/augur/datasources/augur_db/test_augur_db_routes.py
@@ -365,21 +365,16 @@ def test_languages_by_repo(augur_db_routes):
     pass
 
 def test_license_declared_by_group(augur_db_routes):
-    # TODO need more daa
-    pass
-    # response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/license-declared')
-    # data = response.json()
-    # assert response.status_code == 200
-    # assert len(data) >= 1
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/license-declared')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
 
 def test_license_declared_by_repo(augur_db_routes):
-    # TODO need more daa
-    pass
-    # response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/repos/21252/license-declared')
-    # data = response.json()
-    # assert response.status_code == 200
-    # assert len(data) >= 1
-    # assert data[0]["license"] == 'Apache-2.0'
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/repos/21116/license-declared')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
 
 def test_annual_commit_count_ranked_by_new_repo_in_repo_group_by_repo(augur_db_routes):
     response = requests.get('http://localhost:5000/api/unstable/repo-groups/20/repos/21000/annual-commit-count-ranked-by-new-repo-in-repo-group')
@@ -477,3 +472,27 @@ def test_aggregate_summary_by_group(augur_db_routes):
     data = response.json()
     assert response.status_code == 200
     assert len(data) >= 1    
+
+def test_license_coverage_by_group(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/license-coverage')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+
+def test_license_coverage_by_repo(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/repos/21116/license-coverage')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+
+def test_license_count_by_group(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/license-count')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1
+
+def test_license_count_by_repo(augur_db_routes):
+    response = requests.get('http://localhost:5000/api/unstable/repo-groups/21/repos/21116/license-count')
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) >= 1

--- a/frontend/src/Augur.ts
+++ b/frontend/src/Augur.ts
@@ -46,7 +46,7 @@ Vue.use(VueVega);
 export default function Augur () {
   // AugurApp.store = store
   // Object.defineProperty(AugurApp, 'store', store);
-  
+
 
   // router.beforeEach((to:any, from:any, next:any) => {
   //   if (to.params.repo || to.params.groupid){

--- a/frontend/src/AugurAPI.ts
+++ b/frontend/src/AugurAPI.ts
@@ -462,6 +462,7 @@ class Repo extends BaseRepo{
     this.addRepoMetric('forkCount','fork-count')
     this.addRepoMetric('languages','languages')
     this.addRepoMetric('committers','committers')
+    this.addRepoMetric('licenseDeclared','license-declared')
   }
 }
 
@@ -503,6 +504,8 @@ class RepoGroup extends BaseRepo {
       this.addRepoGroupMetric('forkCount','fork-count')
       this.addRepoGroupMetric('languages','languages')
       this.addRepoGroupMetric('committers','committers')
+      this.addRepoGroupMetric('licenseDeclared','license-declared')
+
     }
   }
 }

--- a/frontend/src/AugurAPI.ts
+++ b/frontend/src/AugurAPI.ts
@@ -298,9 +298,13 @@ class Repo extends BaseRepo{
     this.rg_name = metadata.rg_name || undefined
     this.repo_name = metadata.repo_name || undefined
     this.url = this.gitURL || this.githubURL || undefined
-    this.getRepoNameAndID()
-    this.initialLegacyMetric()
     this.initialMetric()
+  }
+
+   initialMetric(){
+    this.getRepoNameAndID()
+    this.initialDBMetric()
+    this.initialLegacyMetric()
   }
 
   toString(){
@@ -318,35 +322,34 @@ class Repo extends BaseRepo{
     }
 
     if (this.rg_name && this.repo_name) {
-      return $.ajax({
-        type: 'GET',
-        url: this.__endpointURL('rg-name/' + this.rg_name + '/repo-name/' + this.repo_name),
-        async: false,
-      }).then((data:any) => {
-        if (data.length != 0){
-          this.repo_id = data[0].repo_id
-          this.repo_group_id = data[0].repo_group_id
-          this.gitURL = data[0].repo_git
-        }
-        this.parseURL();
-        return
-      })
-    }
-
-    this.parseURL();
-    if (this.owner && this.name) {
-      return $.ajax({
-        type: "GET",
-        async: false,
-        url: this.__endpointURL('owner/' + this.owner + '/repo/' + this.name),
-      }).then((data:any)=>{
-        if (data.length != 0) {
-          this.repo_id = data[0].repo_id
-          this.repo_group_id = data[0].repo_group_id
-          this.rg_name = data[0].rg_name
-        }
-        return
-      })
+        $.ajax({
+          type: 'GET',
+          url: this.__endpointURL('rg-name/' + this.rg_name + '/repo-name/' + this.repo_name),
+          async: false,
+          success: (data:any) => {
+            this.repo_id = data[0].repo_id
+            this.repo_group_id = data[0].repo_group_id
+            this.gitURL = data[0].url
+            this.url = data[0].url
+            this.parseURL();
+          }
+        })
+    } else {
+      this.parseURL();
+      if(this.owner && this.name) {
+         $.ajax({
+           type: "GET",
+           async: false,
+           url: this.__endpointURL('owner/' + this.owner + '/repo/' + this.name),
+           success: (data:any) => {
+             if (data.length != 0) {
+               this.repo_id = data[0].repo_id
+               this.repo_group_id = data[0].repo_group_id
+               this.rg_name = data[0].rg_name
+             }
+           }
+        })
+      }
     }
   }
 
@@ -437,7 +440,7 @@ class Repo extends BaseRepo{
       this.Timeseries('tags', 'tags')
     }
   }
-  initialMetric(){
+  initialDBMetric(){
     this.addRepoMetric('codeChanges', 'code-changes')
     this.addRepoMetric('codeChangesLines', 'code-changes-lines')
     this.addRepoMetric('issueNew', 'issues-new')

--- a/frontend/src/AugurAPI.ts
+++ b/frontend/src/AugurAPI.ts
@@ -154,7 +154,7 @@ export default class AugurAPI {
         if (Array.isArray(data)) {
           data.forEach((response) => {
             if (response.status === 200 && reverseMap[response.path]) {
-              processedData[reverseMap[response.path].owner] = {}
+              processedData[reverseMap[response.path].owner] = processedData[reverseMap[response.path].owner] || {}
               processedData[reverseMap[response.path].owner][reverseMap[response.path].name] = []
               processedData[reverseMap[response.path].owner][reverseMap[response.path].name] = JSON.parse(response.response)
               console.log("pdata after response", processedData, typeof (reverseMap[response.path].owner), typeof (reverseMap[response.path].name), JSON.parse(response.response), response.response)
@@ -458,6 +458,10 @@ class Repo extends BaseRepo{
     this.addRepoMetric('issuesClosedResolutionDuration', 'issues-closed-resolution-duration')
     this.addRepoMetric('issueActive', 'issues-active')
     this.addRepoMetric('getIssues', 'get-issues')
+    this.addRepoMetric('getForks','forks')
+    this.addRepoMetric('forkCount','fork-count')
+    this.addRepoMetric('languages','languages')
+    this.addRepoMetric('committers','committers')
   }
 }
 
@@ -495,6 +499,10 @@ class RepoGroup extends BaseRepo {
       this.addRepoGroupMetric('issuesClosedResolutionDuration','issues-closed-resolution-duration')
       this.addRepoGroupMetric('issueActive', 'issues-active')
       this.addRepoGroupMetric('getIssues', 'get-issues')
+      this.addRepoGroupMetric('getForks','forks')
+      this.addRepoGroupMetric('forkCount','fork-count')
+      this.addRepoGroupMetric('languages','languages')
+      this.addRepoGroupMetric('committers','committers')
     }
   }
 }

--- a/frontend/src/components/charts/CountBlock.vue
+++ b/frontend/src/components/charts/CountBlock.vue
@@ -1,0 +1,42 @@
+<template>
+  <d-card>
+    <d-card-body :title="title" class="text-center">
+      <span style="font-size:1.3em">{{count}}</span>
+    </d-card-body>
+    </d-card>
+    </template>
+
+    <script lang="ts">
+  import  { Component, Vue } from 'vue-property-decorator';
+  import {mapActions, mapGetters} from "vuex";
+
+  const AppProps = Vue.extend({
+    props: {
+      title: String,
+      data: Object,
+      source: String,
+      field: String,
+    }
+  })
+
+  @Component({
+    computed: {
+      ...mapGetters('compare',[
+        'comparedRepos',
+        'baseRepo'
+      ]),
+    },
+  })
+  export default class CountBlock extends AppProps{
+
+    // compare.getter
+    baseRepo!:any
+    comparedRepos!:any
+
+
+    get count(){
+      return this.data[this.baseRepo][this.source][0][this.field]
+    }
+
+  }
+</script>

--- a/frontend/src/components/charts/LicenseTable.vue
+++ b/frontend/src/components/charts/LicenseTable.vue
@@ -1,13 +1,52 @@
 <template>
-  $END$
+  <d-card>
+    <d-card-body :title="title" class="text-center">
+      <table style="width: 100%">
+        <thead class="bg-light">
+          <th v-for="header in headers">{{header}}</th>
+        </thead>
+        <tbody>
+          <tr v-for="el in values">
+            <td v-for="field in fields">{{el[field]}}</td>
+          </tr>
+        </tbody>
+      </table>
+    </d-card-body>
+  </d-card>
 </template>
 
-<script>
-  export default {
-    name: "LicenseTable"
+<script lang="ts">
+  import  { Component, Vue } from 'vue-property-decorator';
+  import {mapActions, mapGetters} from "vuex";
+
+  const AppProps = Vue.extend({
+    props: {
+      title: String,
+      data: Object,
+      source: String,
+      headers: Array,
+      fields: Array,
+    }
+  })
+
+  @Component({
+    computed: {
+      ...mapGetters('compare',[
+        'comparedRepos',
+        'baseRepo'
+      ]),
+    },
+  })
+  export default class CountBlock extends AppProps{
+
+    // compare.getter
+    baseRepo!:any
+    comparedRepos!:any
+
+
+    get values(){
+      return this.data[this.baseRepo][this.source]
+    }
+
   }
 </script>
-
-<style scoped>
-
-</style>

--- a/frontend/src/components/charts/LicenseTable.vue
+++ b/frontend/src/components/charts/LicenseTable.vue
@@ -1,0 +1,13 @@
+<template>
+  $END$
+</template>
+
+<script>
+  export default {
+    name: "LicenseTable"
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/charts/LineChart.vue
+++ b/frontend/src/components/charts/LineChart.vue
@@ -1,0 +1,54 @@
+<template>
+  <d-card>
+    <d-card-body :title="title" class="text-center">
+      <vega-lite :encoding="encoding" :data="values" :width="340" :height="320" :mark="mark"></vega-lite>
+    </d-card-body>
+  </d-card>
+</template>
+
+<script lang="ts">
+  import  { Component, Vue } from 'vue-property-decorator';
+  import {mapActions, mapGetters} from "vuex";
+
+  const AppProps = Vue.extend({
+    props: {
+      title: String,
+      data: Object,
+      source: String,
+      field: String,
+      filedTime: String,
+      fieldCount: String
+    }
+  })
+
+  @Component({
+    computed: {
+      ...mapGetters('compare',[
+        'comparedRepos',
+        'baseRepo'
+      ]),
+    },
+  })
+  export default class LineChart extends AppProps{
+
+    // compare.getter
+    baseRepo!:any
+    comparedRepos!:any
+
+    get values(){
+      console.log(this.data[this.baseRepo][this.source])
+      return this.data[this.baseRepo][this.source]
+    }
+    get encoding() {
+      return {
+        x: {field: this.filedTime, type: 'temporal'},
+        y: {field: this.fieldCount, type: 'quantitative'}
+      }
+    }
+
+    get mark() {
+      return 'line'
+    }
+
+  }
+</script>

--- a/frontend/src/components/charts/PieChart.vue
+++ b/frontend/src/components/charts/PieChart.vue
@@ -1,0 +1,13 @@
+<template>
+  $END$
+</template>
+
+<script>
+  export default {
+    name: "PieChart"
+  }
+</script>
+
+<style scoped>
+
+</style>

--- a/frontend/src/components/layout/MainSidebar/MainSidebar.vue
+++ b/frontend/src/components/layout/MainSidebar/MainSidebar.vue
@@ -55,11 +55,11 @@
                 </div>
 
                 <div class="comp_info">
-                  {{ base.name || base.rg_name || 'No base repo/group selected'}}
+                  {{  base.repo_name? base.rg_name+'/'+base.repo_name : base.rg_name || 'No base repo/group selected'}}
                 </div>
 
                 <div class="comp_info">
-                  {{comparisionSize}} comparison(s) selected
+                  {{comparisionSize == 0? 'No': comparisionSize}} comparison(s) selected
                 </div>
               </div>
               

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -129,10 +129,10 @@ const routes = [
                         },
                   },
             ],
-            beforeEnter: (to:any, from:any, next:any) => {
+            beforeEnter: async (to:any, from:any, next:any) => {
                   let repo = to.params.repo;
                   let group = to.params.group;
-                  store.dispatch('compare/setBaseRepo',{rg_name:group,repo_name:repo});
+                  await store.dispatch('compare/setBaseRepo',{rg_name:group,repo_name:repo});
                   next()
             }
       },
@@ -150,12 +150,12 @@ const routes = [
           },
         },
       ],
-      beforeEnter: (to:any, from:any, next:any) => {
+      beforeEnter: async (to:any, from:any, next:any) => {
         let repo = to.params.repo;
         let group = to.params.group;
-        store.dispatch('compare/setBaseRepo',{rg_name:group,repo_name:repo});
+        await store.dispatch('compare/setBaseRepo',{rg_name:group,repo_name:repo});
         let compares = to.params.compares === ''? [] : to.params.compares.split(',');
-        store.dispatch('compare/setComparedRepos',compares);
+        await store.dispatch('compare/setComparedRepos',compares);
         next()
       }
     },

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -9,7 +9,7 @@ var AugurAPIModule = require('@/AugurAPI').default;
 var AugurAPI = new AugurAPIModule();
 // import MetricsStatusCard from './components/MetricsStatusCard.vue';
 // import BaseRepoActivityCard from './components/BaseRepoActivityCard.vue';
-// import BaseRepoEcosystemCard from './components/BaseRepoEcosystemCard.vue';
+// import BaseRepoEcosystemCard  from './components/BaseRepoEcosystemCard.vue';
 // import GrowthMaturityDeclineCard from './components/GrowthMaturityDeclineCard.vue';
 // import RiskCard from './components/RiskCard.vue';
 // import ValueCard from './components/ValueCard.vue';
@@ -38,6 +38,7 @@ import MainNavbar from './components/layout/MainNavbar/MainNavbar.vue';
 import RepoOverview from './views/RepoOverview.vue';
 import RepoGroups from './views/RepoGroups.vue';
 import Repos from './views/Repos.vue';
+import RiskMetrics from "@/views/RiskMetrics.vue";
 
 const routes = [
       {
@@ -120,12 +121,21 @@ const routes = [
             component: Default,
             children: [
                   {
-                        path: '',
+                        path: 'overview',
                         name: 'repo_overview',
                         components: {
                               sidebar: MainSidebar,
                               navbar: MainNavbar,
                               content: RepoOverview,
+                        },
+                  },
+                  {
+                        path: 'risk',
+                        name: 'risk',
+                        components: {
+                          sidebar: MainSidebar,
+                          navbar: MainNavbar,
+                          content: RiskMetrics,
                         },
                   },
             ],

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -2,6 +2,7 @@
 /* tslint:disable */
 import Vue from 'vue';
 import Router from 'vue-router';
+import store from '@/store/store';
 Vue.use(Router);
 import _ from 'lodash';
 var AugurAPIModule = require('@/AugurAPI').default;
@@ -128,7 +129,36 @@ const routes = [
                         },
                   },
             ],
+            beforeEnter: (to:any, from:any, next:any) => {
+                  let repo = to.params.repo;
+                  let group = to.params.group;
+                  store.dispatch('compare/setBaseRepo',{rg_name:group,repo_name:repo});
+                  next()
+            }
       },
+    {
+      path: '/repo/:group/:repo/comparedTo/:compares',
+      component: Default,
+      children: [
+        {
+          path: '',
+          name: 'repo_overview_compare',
+          components: {
+            sidebar: MainSidebar,
+            navbar: MainNavbar,
+            content: RepoOverview,
+          },
+        },
+      ],
+      beforeEnter: (to:any, from:any, next:any) => {
+        let repo = to.params.repo;
+        let group = to.params.group;
+        store.dispatch('compare/setBaseRepo',{rg_name:group,repo_name:repo});
+        let compares = to.params.compares === ''? [] : to.params.compares.split(',');
+        store.dispatch('compare/setComparedRepos',compares);
+        next()
+      }
+    },
     {
       path: '/blog-overview',
       name: 'blog-overview',

--- a/frontend/src/store/modules/common/actions.ts
+++ b/frontend/src/store/modules/common/actions.ts
@@ -175,7 +175,6 @@ export default {
                     rg_name: rg_name,
                     repo_name: repo_name
                 })
-
                 context.commit('mutateAPIRepo', {repo: repo, name: repo.toString()})
                 resolve(repo)
             }, 2000)

--- a/frontend/src/store/modules/common/actions.ts
+++ b/frontend/src/store/modules/common/actions.ts
@@ -41,8 +41,10 @@ export default {
                                 console.log(data)
                                 tempCache = {...tempCache, ...data};
                                 payload.repos.forEach((repo: any) => {
-                                    tempCache[repo.toString()] = {...tempCache[repo.url], ...data[repo.url]};
+                                    tempCache[repo.toString()] = {...tempCache[repo.toString()], ...data[repo.toString()]};
                                 });
+                                console.log(tempCache)
+                                resolve(tempCache)
                             });
                     }
                     if ('repoGroups' in payload) {
@@ -53,6 +55,8 @@ export default {
                                     tempCache[group.rg_name] = {...tempCache[group.rg_name],
                                         ...data[group.rg_name]};
                                 });
+                                console.log(tempCache)
+                                resolve(tempCache)
                             });
                     }
                     if (!('repos' in payload) && !('repoGroups' in payload)) {
@@ -60,12 +64,14 @@ export default {
                             console.log(endpoint)
                             context.state.AugurAPI[endpoint]().then((data: object[]) => {
                                 tempCache[endpoint] = data;
+                                console.log(tempCache)
+                                resolve(tempCache)
                             });
                         });
                     }
                 }
-                console.log(tempCache)
-                resolve(tempCache)
+                // console.log(tempCache)
+                // resolve(tempCache)
                 // context.commit('mutate', {
                 //     property: 'cache',
                 //     with: tempCache,

--- a/frontend/src/store/modules/common/actions.ts
+++ b/frontend/src/store/modules/common/actions.ts
@@ -41,7 +41,7 @@ export default {
                                 console.log(data)
                                 tempCache = {...tempCache, ...data};
                                 payload.repos.forEach((repo: any) => {
-                                    tempCache[repo.url] = {...tempCache[repo.url], ...data[repo.url]};
+                                    tempCache[repo.toString()] = {...tempCache[repo.url], ...data[repo.url]};
                                 });
                             });
                     }
@@ -159,19 +159,27 @@ export default {
     //         }, 2000)
     //     })
     // },
-    async addRepo(context:any, payload:any) {
-         return new Promise((resolve, reject) => {
-             setTimeout(()=>{
+    async addRepo(context: any, payload: any) {
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
                 let rg_name = payload.rg_name || undefined
+                let repo_name = payload.repo_name || undefined
                 let repo_id = payload.repo_id || undefined
                 let repo_group_id = payload.repo_group_id || undefined
                 let gitURL = payload.url || undefined
-                let repo:Repo = context.state.AugurAPI.Repo({gitURL:gitURL,repo_id:repo_id,repo_group_id:repo_group_id})
-                
-                context.commit('mutateAPIRepo', {repo:repo, url: gitURL})
+
+                let repo: Repo = context.state.AugurAPI.Repo({
+                    gitURL: gitURL,
+                    repo_id: repo_id,
+                    repo_group_id: repo_group_id,
+                    rg_name: rg_name,
+                    repo_name: repo_name
+                })
+
+                context.commit('mutateAPIRepo', {repo: repo, name: repo.toString()})
                 resolve(repo)
-             },2000)
-         })
+            }, 2000)
+        })
     },
     async addRepoGroup(context:any, payload:any) {
         return new Promise((resolve,reject)=>{

--- a/frontend/src/store/modules/common/mutations.ts
+++ b/frontend/src/store/modules/common/mutations.ts
@@ -96,7 +96,7 @@ export default {
     }
   },
   mutateAPIRepo(state:any, payload:any) {
-    Vue.set(state.apiRepos, payload.url, payload.repo)
+    Vue.set(state.apiRepos, payload.name, payload.repo)
   },
   mutateAPIGroup(state:any, payload:any) {
     Vue.set(state.apiGroups, payload.rg_name, payload.group)

--- a/frontend/src/store/modules/compare/actions.ts
+++ b/frontend/src/store/modules/compare/actions.ts
@@ -1,3 +1,5 @@
+import {forEach} from "vega-lite/build/src/encoding";
+
 export default {
     async addComparedRepo(context:any, payload:any) {
 
@@ -9,12 +11,12 @@ export default {
         context.state.compare = 'zcore';
 
         if (context.state.baseRepo == ''){
-            context.commit('setBaseRepo', payload)
+            context.state.baseRepo = payload.url
         }
         if(!(context.state.comparedRepos.includes(payload.url) && context.state.baseRepo == payload.url)) {
-            context.commit('addComparedRepo', payload.url)
+            context.state.comparedRepos.push(payload.url)
         }
-        if (!(payload.rg_name in context.rootGetters['common/apiRepos'])) {
+        if (!(payload.url in context.rootGetters['common/apiRepos'])) {
             context.dispatch('common/addRepo',payload,{root:true})
         }
     },
@@ -26,17 +28,52 @@ export default {
         }
         context.state.compare = 'zcore';
         if (context.state.baseGroup == ''){
-            context.commit('setBaseGroup', payload)
+            context.state.baseGroup = payload.rg_name
         }
         if(!context.state.comparedRepoGroups.includes(payload.rg_name) && context.state.baseGroup != payload.rg_name) {
-            context.commit('addComparedRepoGroups', payload.rg_name)
+            context.state.comparedRepoGroups.push(payload.rg_name)
         }
-        console.log('#####', context.rootGetters['common/apiGroups'])
         if (!(payload.rg_name in context.rootGetters['common/apiGroups'])) {
             context.dispatch('common/addRepoGroup',payload,{root:true})
         }
     },
 
+    async setBaseRepo(context: any, payload: any) {
+
+        context.state.baseRepo = payload.rg_name && payload.repo_name? payload.rg_name + '/' + payload.repo_name : payload.url
+
+        if (!(context.state.baseRepo in context.rootGetters['common/apiRepos'])) {
+            console.log("fetch repo")
+            context.dispatch('common/addRepo',payload,{root:true})
+        }
+    },
+
+    async setBaseGroup(context: any, payload:any) {
+        context.state.baseGroup = payload.rg_name
+
+        if (!(payload.rg_name in context.rootGetters['common/apiGroups'])) {
+            context.dispatch('common/addRepoGroup',payload,{root:true})
+        }
+    },
+
+    async setComparedRepos(context:any, payload:any) {
+        context.state.comparedRepos = payload
+        payload.forEach((repo:any) => {
+            if (!(repo in context.rootGetters['common/apiGroups'])) {
+                let split:string[]= repo.split('/');
+                context.dispatch('common/addRepo',{repo_name:split[1],rg_name:split[0]},{root:true})
+            }
+        })
+    },
+
+    async setComparedGroup(context:any, payload:any) {
+        context.state.comparedRepoGroups = payload
+        payload.forEach((group:any) => {
+            if (!(group in context.rootGetters['common/apiGroups'])) {
+                context.dispatch('common/addRepoGroup',{rg_name: group},{root:true})
+            }
+        })
+    }
 }
 
 

--- a/frontend/src/store/modules/compare/actions.ts
+++ b/frontend/src/store/modules/compare/actions.ts
@@ -1,6 +1,3 @@
-import {forEach} from "vega-lite/build/src/encoding";
-import {data} from "vega-lite";
-
 export default {
     async addComparedRepo(context:any, payload:any) {
 

--- a/frontend/src/store/modules/compare/actions.ts
+++ b/frontend/src/store/modules/compare/actions.ts
@@ -1,4 +1,5 @@
 import {forEach} from "vega-lite/build/src/encoding";
+import {data} from "vega-lite";
 
 export default {
     async addComparedRepo(context:any, payload:any) {
@@ -39,30 +40,54 @@ export default {
     },
 
     async setBaseRepo(context: any, payload: any) {
-
-        context.state.baseRepo = payload.rg_name && payload.repo_name? payload.rg_name + '/' + payload.repo_name : payload.url
-
-        if (!(context.state.baseRepo in context.rootGetters['common/apiRepos'])) {
-            console.log("fetch repo")
-            context.dispatch('common/addRepo',payload,{root:true})
-        }
+        return new Promise((resolve:any, reject:any)=>{
+            setTimeout(()=>{
+                let baseRepo = payload.rg_name && payload.repo_name? payload.rg_name + '/' + payload.repo_name : payload.url
+                if (!(baseRepo in context.rootGetters['common/apiRepos'])) {
+                    context.dispatch('common/addRepo',payload,{root:true}).then((data:any) =>{
+                        context.state.baseRepo = baseRepo
+                        resolve(data)
+                    })
+                } else{
+                    context.state.baseRepo = baseRepo
+                    resolve({})
+                }
+            },2000)
+        })
     },
 
     async setBaseGroup(context: any, payload:any) {
-        context.state.baseGroup = payload.rg_name
-
-        if (!(payload.rg_name in context.rootGetters['common/apiGroups'])) {
-            context.dispatch('common/addRepoGroup',payload,{root:true})
-        }
+        return new Promise((resolve:any, reject:any)=>{
+            setTimeout(()=>{
+                if (!(payload.rg_name in context.rootGetters['common/apiGroups'])) {
+                    context.dispatch('common/addRepoGroup',payload,{root:true}).then((data:any) => {
+                        context.state.baseGroup = payload.rg_name
+                        resolve(data)
+                    })
+                } else {
+                    context.state.baseGroup = payload.rg_name
+                    resolve({})
+                }
+            },2000)
+        })
     },
 
     async setComparedRepos(context:any, payload:any) {
-        context.state.comparedRepos = payload
-        payload.forEach((repo:any) => {
-            if (!(repo in context.rootGetters['common/apiGroups'])) {
-                let split:string[]= repo.split('/');
-                context.dispatch('common/addRepo',{repo_name:split[1],rg_name:split[0]},{root:true})
-            }
+        return new Promise((resolve:any, reject:any)=>{
+            setTimeout(()=>{
+                let promises:any[] = [];
+                for(let repo of payload) {
+                    if (!(repo in context.rootGetters['common/apiGroups'])) {
+                        let split:string[]= repo.split('/');
+                        promises.push(context.dispatch('common/addRepo',{repo_name:split[1],rg_name:split[0]},{root:true}))
+                    }
+                }
+                 Promise.all(promises).then( (values:any) => {
+                     context.state.comparedRepos = payload
+                     resolve(values)
+                  }
+                )
+            },2000)
         })
     },
 

--- a/frontend/src/store/modules/compare/getters.ts
+++ b/frontend/src/store/modules/compare/getters.ts
@@ -1,4 +1,6 @@
 import construct = Reflect.construct;
+import Repo from '@/AugurAPI'
+import RepoGroups from "@/views/RepoGroups.vue";
 
 export default {
     comparisonType: (state:any) => {
@@ -40,6 +42,26 @@ export default {
             return rootGetters['common/apiGroups'][state.baseGroup] || {'url': 'No base repo/group selected'}
         }
         return {}
+    },
+
+    comparedAPIRepos: (state:any, getters:any, rootState:any, rootGetters:any) => {
+        let compares: Repo[] = []
+        for (let repo of state.comparedRepos) {
+          if (rootGetters['common/apiRepos'][repo]) {
+            compares.push(rootGetters['common/apiRepos'][repo])
+          }
+        }
+        return compares
+    },
+
+    comparedAPIGroups: (state:any, getters:any, rootState:any, rootGetters:any) => {
+      let compares: RepoGroups[] = []
+      for (let group of state.comparedRepoGroups) {
+        if (rootGetters['common/apiGroups'][group]) {
+          compares.push(rootGetters['common/apiGroups'][group])
+        }
+      }
+      return compares
     },
 
     isGroup: (state:any, getters:any, rootState:any, rootGetters:any) => {

--- a/frontend/src/store/modules/compare/getters.ts
+++ b/frontend/src/store/modules/compare/getters.ts
@@ -39,12 +39,11 @@ export default {
         } else if (state.baseGroup) {
             return rootGetters['common/apiGroups'][state.baseGroup] || {'url': 'No base repo/group selected'}
         }
-
         return {}
     },
 
     isGroup: (state:any, getters:any, rootState:any, rootGetters:any) => {
-        if(state.baseGroup != ''){
+        if (state.baseGroup != ''){
             return true
         } else {
             return false
@@ -57,7 +56,7 @@ export default {
         } else if (state.comparedRepoGroups.length) {
             return state.comparedRepoGroups.length
         }
-        return  'No'
+        return 0
     },
     compare: (state:any) => {
         return state.compare

--- a/frontend/src/store/modules/compare/getters.ts
+++ b/frontend/src/store/modules/compare/getters.ts
@@ -116,4 +116,7 @@ export default {
     comparedRepos: (state:any) => {
         return state.comparedRepos
     },
+    baseRepo: (state:any) => {
+        return state.baseRepo
+    }
 };

--- a/frontend/src/store/modules/compare/mutations.ts
+++ b/frontend/src/store/modules/compare/mutations.ts
@@ -3,35 +3,31 @@ import Vue from 'vue';
 import router from '@/router';
 
 export default {
-    setBaseRepo(state: any, payload: any) {
+    mutateBaseRepo(state: any, payload: any) {
         // pass url into function
-        state.baseRepo = payload.url
+            state.baseRepo = payload.url
     },
 
-    setBaseGroup(state: any, payload: any) {
+    mutateBaseGroup(state: any, payload: any) {
         // pass url into function
         state.baseGroup = payload.rg_name
     },
 
-    addComparedRepo(state:any, payload:any) {
-        state.comparedRepos.push(payload)
-    },
-
-    addComparedRepoGroups(state:any, payload:any) {
-        if(payload != null){
-            state.comparedRepoGroups.push(payload)
-        }
-    },
-
     mutateComparedRepo(state:any, payload:any) {
         if(payload != null){
-            state.comparedRepos = payload
+            state.comparedRepos = []
+            payload.forEach( (repo:any) => {
+              state.comparedRepos.push(repo)
+            });
         }
     },
 
     mutateComparedGroup(state:any, payload:any) {
         if(payload != null){
-            state.comparedRepoGroups = payload
+            state.comparedRepoGroups = []
+            payload.forEach((group:any) => {
+              state.comparedRepoGroups.push(group)
+            })
         }
     },
 

--- a/frontend/src/styles/augur.styl
+++ b/frontend/src/styles/augur.styl
@@ -542,48 +542,7 @@ div.checkbox_select .select_input
     display: none;
 }
 
-.multiselect__input {
-      padding-left: 32px !important
-}
 
-.multiselect__tags input {
-  width: 150px !important
-}
-
-.multiselect__content-wrapper ul { list-style: none; }
-.multiselect__content-wrapper { z-index: 1000000 !important }
-
-.multiselect__content-wrapper ul li .multiselect__option { display:block; text-decoration:none; color:#000000; background-color:#FFFFFF; line-height:30px;
-  border-bottom-style:solid; border-bottom-width:1px; border-bottom-color:#CCCCCC; padding-left:10px; cursor:pointer; }
-
-.multiselect__content-wrapper ul li .multiselect__option:hover { background-color:#EEEEEE; background-image:url('~/assets/images/hover.png'); background-repeat:repeat-x; }
-.multiselect__content-wrapper ul li .multiselect__option strong { margin-right:10px; }
-
-.multiselect__content-wrapper {
-  overflow-y: scroll
-
-}
-
-.multiselect__content {
-  margin: 0;
-  width: 150px;
-}
-
-.multiselect__option--selected {
-  background-color:#00FF00 !important
-}
-
-.multiselect__option--selected:hover {
-  background-color:#00FF00 !important
-}
-
-.multiselect__content-wrapper ul li span {
-
-}
-
-.multiselect__tags-wrap {
-  display: none
-}
 
 .repolisting {
   margin-left:1.25em;

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -160,7 +160,7 @@ export default class Dashboard extends Vue {
   // 'created' lifecycle hook
   // Gets ran on component initialization, data collection should be handled here
   created () {
-    function sleep(ms) {
+    function sleep(ms:number) {
       return new Promise(resolve => setTimeout(resolve, ms));
     }
     // Load the data we need

--- a/frontend/src/views/RepoOverview.vue
+++ b/frontend/src/views/RepoOverview.vue
@@ -1,8 +1,8 @@
 <template>
   <d-container fluid class="main-content-container px-4">
     <d-breadcrumb style="margin:0; padding-top: 26px; padding-left: 0px">
-      <d-breadcrumb-item :active="false" :text="base.owner" href="#" />
-      <d-breadcrumb-item :active="true" :text="base.name" href="#" />
+      <d-breadcrumb-item :active="false" :text="base.rg_name" href="#" />
+      <d-breadcrumb-item :active="true" :text="base.repo_name" href="#" />
     </d-breadcrumb>
     <!-- Page Header -->
     <!-- <div class="page-header row no-gutters py-4">
@@ -53,7 +53,7 @@
     <spinner :v-show="!loaded_evolution"></spinner>
     
     <!-- <div class="row" :v-show="loaded_evolution"> -->
-    <div class="row" v-if="false">
+    <div class="row" v-if="true">
 
       <div class="col col-6">
         <dynamic-line-chart source="issuesClosed"
@@ -234,229 +234,35 @@ import CompareControl from '../components/common/CompareControl.vue'
   },
 })
 
-export default class RepoOverview extends Vue{
-  colors =  ["#343A40", "#24a2b7", "#159dfb", "#FF3647", "#4736FF","#3cb44b","#ffe119","#f58231","#911eb4","#42d4f4","#f032e6"]
+export default class RepoOverview extends Vue {
+  colors = ["#343A40", "#24a2b7", "#159dfb", "#FF3647", "#4736FF", "#3cb44b", "#ffe119", "#f58231", "#911eb4", "#42d4f4", "#f032e6"]
   testEndpoints = ['closedIssues', 'openIssues', 'codeCommits']
   testTimeframes = ['past 1 month', 'past 3 months', 'past 2 weeks']
   repos = {}
   projects = []
-  themes= ['dark', 'info', 'royal-blue', 'warning']
-  project= null
-  loaded_overview= false
-  loaded_evolution= false
-  loaded_issues= false
-  loaded_experimental= false
-  loaded_activity= false
+  themes = ['dark', 'info', 'royal-blue', 'warning']
+  project = null
+  loaded_overview = false
+  loaded_evolution = false
+  loaded_issues = false
+  loaded_experimental = false
+  loaded_activity = false
+  values = {'issuesClosed':{}}
 
   // deflare vuex action, getter, mutations
-  groupsInfo!:any;
-  getRepoGroups!:any;
-  repo_groups!:any[];
-  sorted_repo_groups!:any[];
-  base!:any;
+  groupsInfo!: any;
+  getRepoGroups!: any;
+  repo_groups!: any[];
+  sorted_repo_groups!: any[];
+  base!: any;
+  // actions
+  endpoint!: any;
 
-  getOwner(url:string) {
-      let first = url.indexOf(".")
-      let last = url.lastIndexOf(".")
-      let domain = null
-      let owner = null
-      let repo = null
-      let extension = false
+  created() {
+    this.endpoint({endpoints:this.testEndpoints,repos:[this.base]}).then((tuples:any) => {
 
-      if (first == last){ //normal github
-        domain = url.substring(0, first)
-        owner = url.substring(url.indexOf('/') + 1, url.lastIndexOf('/'))
-        repo = url.slice(url.lastIndexOf('/') + 1)
-        console.log(owner+ "/" + repo)
-        return owner
-      } else if (url.slice(last) == '.git'){ //github with extension
-        domain = url.substring(0, first)
-        extension = true
-        owner = url.substring(url.indexOf('/') + 1, url.lastIndexOf('/'))
-        repo = url.substring(url.lastIndexOf('/') + 1, url.length - 4)
-        return owner
-      } else { //gluster
-        domain = url.substring(first + 1, last)
-        owner = null //url.substring(url.indexOf('/') + 1, url.lastIndexOf('/'))
-        repo = url.slice(url.lastIndexOf('/') + 1)
-        return domain
-    }
-  }
-    
-  getRepo(url:string){
-    let first = url.indexOf(".")
-    let last = url.lastIndexOf(".")
-    let domain = null
-    let owner = null
-    let repo = null
-    let extension = false
-
-    if (first == last){ //normal github
-      domain = url.substring(0, first)
-      owner = url.substring(url.indexOf('/') + 1, url.lastIndexOf('/'))
-      repo = url.slice(url.lastIndexOf('/') + 1)
-      return repo
-    } else if (url.slice(last) == '.git'){ //github with extension
-      domain = url.substring(0, first)
-      extension = true
-      owner = url.substring(url.indexOf('/') + 1, url.lastIndexOf('/'))
-      repo = url.substring(url.lastIndexOf('/') + 1, url.length - 4)
-      return repo
-    } else { //gluster
-      domain = url.substring(first + 1, last)
-      owner = null //url.substring(url.indexOf('/') + 1, url.lastIndexOf('/'))
-      repo = url.slice(url.lastIndexOf('/') + 1)
-      return repo
-    }
-  }
-
-  getColor (idx:number) {
-    if (idx % 2 == 0)
-      return 'color: green'
-    else
-      return 'color: red'
-  }
-  
-  getDirection (idx:number) {
-    if (idx % 2 == 0)
-      return 'arrow_upward'
-    else
-      return 'arrow_downward'
-  }
-
-  getPhrase (idx:number) {
-    if (idx % 2 == 0)
-      return 'increased'
-    else
-      return 'declined'
-  }
-
-  onRepo (e:any) {
-    this.$store.commit('setRepo', {
-      githubURL: e.target.value
-    })
-  }
-
-  onGitRepo (e:any) {
-    let first = e.url.indexOf(".")
-    let last = e.url.lastIndexOf(".")
-    let domain = null
-    let owner = null
-    let repo = null
-    let extension = false
-
-    if (first == last){ //normal github
-      domain = e.url.substring(0, first)
-      owner = e.url.substring(e.url.indexOf('/') + 1, e.url.lastIndexOf('/'))
-      repo = e.url.slice(e.url.lastIndexOf('/') + 1)
-    } else if (e.url.slice(last) == '.git'){ //github with extension
-      domain = e.url.substring(0, first)
-      extension = true
-      owner = e.url.substring(e.url.indexOf('/') + 1, e.url.lastIndexOf('/'))
-      repo = e.url.substring(e.url.lastIndexOf('/') + 1, e.url.length - 4)
-    } else { //gluster
-      domain = e.url.substring(first + 1, last)
-      owner = null //e.url.substring(e.url.indexOf('/') + 1, e.url.lastIndexOf('/'))
-      repo = e.url.slice(e.url.lastIndexOf('/') + 1)
-    }
-    this.$store.commit('setRepo', {
-      gitURL: e.url
-    })
-
-    this.$store.commit('setTab', {
-      tab: 'git'
-    })
-
-    this.$router.push({
-      name: 'git',
-      params: {repo: e.url}
     })
   }
 }
-
-// export default {
-//   components: {
-//     SparkChart,
-//     InsightChart,
-//     TickChart,
-//     LinesOfCodeChart,
-//     NormalizedStackedBarChart,
-//     OneDimensionalStackedBarChart,
-//     HorizontalBarChart,
-//     GroupedBarChart,
-//     DynamicLineChart,
-//     StackedBarChart,
-//     DualLineChart,
-//     Spinner
-//   },
-//   computed: {
-//     repo () {
-//       return this.$store.state.baseRepo
-//     },
-//     gitRepo () {
-//       return this.$store.state.gitRepo
-//     },
-//     values () {
-//       console.log("getting values")
-//       let values = {}
-//       let repo = window.AugurAPI.Repo({ gitURL: this.gitRepo })
-//       repo.issuesClosed().then((data) => {
-//         values['issuesClosed'] = data
-//         this.loaded_overview = true
-//       })
-//       return values
-//     }
-//   },
-//   data() {
-//     return {
-//       colors: ["#343A40", "#24a2b7", "#159dfb", "#FF3647", "#4736FF","#3cb44b","#ffe119","#f58231","#911eb4","#42d4f4","#f032e6"],
-//       testEndpoints: ['closedIssues', 'openIssues', 'codeCommits'],
-//       testTimeframes: ['past 1 month', 'past 3 months', 'past 2 weeks'],
-//       repos: {},
-//       projects: [],
-//       themes: ['dark', 'info', 'royal-blue', 'warning'],
-//       project: null,
-//       loaded_overview: false,
-//       loaded_evolution: false,
-//       loaded_issues: false,
-//       loaded_experimental: false,
-//       loaded_activity: false
-//     };
-//   },
-//   methods: {
-//     
-//     getDownloadedRepos() {
-//       this.downloadedRepos = []
-//       window.AugurAPI.getDownloadedGitRepos().then((data) => {
-//         $(this.$el).find('.spinner').removeClass('loader')
-//         $(this.$el).find('.spinner').removeClass('relative')
-//         this.repos = window._.groupBy(data, 'project_name')
-//         this.projects = Object.keys(this.repos)
-//         let impRepos = []
-//         for (let i = 0; i < this.projects.length; i++) {
-//           impRepos.push(this.repos[this.projects[i]][0])
-//         }
-//         console.log("LOADED")
-//         this.loaded = true
-//         // window.AugurAPI.batchMapped(impRepos, ['codeCommits']).then((data) => {
-//         //   console.log("DATA", data)
-//         // }, () => {
-//         //   //this.renderError()
-//         // }) // end batch request
-//       })
-//     },
-//     btoa(s) {
-//       return window.btoa(s)
-//     }
-//   },
-//   created() {
-//     // this.getDownloadedRepos()
-//     let repo = window.AugurAPI.Repo({ gitURL: this.gitRepo })
-//     this.project = repo.rg_name
-//     // repo.facadeProject().then((data) => {
-//       // this.loaded=true
-//     // })
-//   },
-// }
 </script>
 

--- a/frontend/src/views/RepoOverview.vue
+++ b/frontend/src/views/RepoOverview.vue
@@ -13,6 +13,10 @@
     <!-- Compare Control -->
     <compare-control></compare-control>
 
+    <div class="row">
+      <d-button><d-link :to="{name: 'risk', params: {repo: base.repo_name, group:base.rg_name}}"><span>Risk</span></d-link></d-button>
+    </div>
+
     <!-- Overview Section -->
     <div class="page-header row no-gutters py-4" >
       <div class="col-12 col-sm-4 text-center text-sm-left mb-0">
@@ -50,11 +54,10 @@
       </div>
     </div>
 
-    <spinner :v-show="!loaded_evolution"></spinner>
-    
-    <!-- <div class="row" :v-show="loaded_evolution"> -->
-    <div class="row" v-if="true">
+    <spinner v-show="!loaded_evolution"></spinner>
 
+    <!-- <div class="row" :v-show="loaded_evolution"> -->
+    <div class="row" v-if="loaded_evolution">
       <div class="col col-6">
         <dynamic-line-chart source="issuesClosed"
                       title="Number of issuesClosed"
@@ -86,7 +89,8 @@
     <!-- <spinner :v-show="!loaded_issues"></spinner> -->
     
     <!-- <div class="row" :v-show="loaded_issues"> -->
-    <div class="row" v-if="false">
+    <spinner v-show="!loaded_issues"></spinner>
+    <div class="row" v-if="loaded_issues">
 
       <div class="col col-12" style="padding-right: 35px">
         <dual-line-chart source=""
@@ -95,15 +99,6 @@
           fieldtwo="closed_count">
           <!-- :data="values['repo_issues']"> -->
         </dual-line-chart>
-      </div>
-
-      <div class="col col-12" style="padding-right: 35px">
-        <dual-line-chart source=""
-          :title="'Issue Count History for this Repo Group:  ' + group + ' - Grouped by Week'"
-          fieldone="open_count"
-          fieldtwo="closed_count">
-        </dual-line-chart>
-        <!-- :data="values['group_issues']"></dual-line-chart> -->
       </div>
 
     </div>
@@ -116,9 +111,9 @@
     </div>
 
     <!-- <spinner :v-show="!loaded_experimental"></spinner> -->
-    
+    <spinner v-show="!loaded_experimental"></spinner>
     <!-- <div class="row" :v-show="loaded_experimental"> -->
-    <div class="row" v-if="false">
+    <div class="row" v-if="loaded_experimental">
 
       <div class="col col-6">
         <dynamic-line-chart source="commitComments"
@@ -202,6 +197,7 @@ import DynamicLineChart from '../components/charts/DynamicLineChart.vue'
 import DualLineChart from '../components/charts/DualLineChart.vue'
 import Spinner from '../components/Spinner.vue'
 import CompareControl from '../components/common/CompareControl.vue'
+import router from "@/router";
 
 @Component({
   components: {
@@ -236,7 +232,7 @@ import CompareControl from '../components/common/CompareControl.vue'
 
 export default class RepoOverview extends Vue {
   colors = ["#343A40", "#24a2b7", "#159dfb", "#FF3647", "#4736FF", "#3cb44b", "#ffe119", "#f58231", "#911eb4", "#42d4f4", "#f032e6"]
-  testEndpoints = ['closedIssues', 'openIssues', 'codeCommits']
+  testEndpoints = ['closedIssuesCount']
   testTimeframes = ['past 1 month', 'past 3 months', 'past 2 weeks']
   repos = {}
   projects = []
@@ -259,10 +255,11 @@ export default class RepoOverview extends Vue {
   endpoint!: any;
 
   created() {
-    this.endpoint({endpoints:this.testEndpoints,repos:[this.base]}).then((tuples:any) => {
-
-    })
+    // this.endpoint({endpoints:this.testEndpoints,repos:[this.base]}).then((tuples:any) => {
+    //   this.loaded_evolution = true
+    // })
   }
+
 }
 </script>
 

--- a/frontend/src/views/Repos.vue
+++ b/frontend/src/views/Repos.vue
@@ -126,15 +126,14 @@ import Spinner from '../components/Spinner.vue'
       'addRepo'
     ]),
     ...mapMutations('compare',[
-      'setBaseRepo',
     ]),
     ...mapActions('compare',[
       'addComparedRepo',
+      'setBaseRepo',
     ])
   },
   computed: {
     ...mapGetters('common', [
-      'groupsInfo',
       'sorted_repos',
       'loaded_repos'
     ]),
@@ -154,7 +153,6 @@ export default class Repos extends Vue{
   // loadedRepos: boolean = false;
   ascending:boolean = false;
   sortColumn: string ='commits_all_time';
-  groupsInfo!:any;
   getRepoRelations!: any
   sorted_repos!:any
   loadRepos!:any;
@@ -182,38 +180,8 @@ export default class Repos extends Vue{
   }
 
   onGitRepo (e: any) {
-      let first = e.url.indexOf(".")
-      let last = e.url.lastIndexOf(".")
-      let domain = null
-      let owner = null
-      let repo = null
-      let extension = false
-
-      if (first == last){ //normal github
-        domain = e.url.substring(0, first)
-        owner = e.url.substring(e.url.indexOf('/') + 1, e.url.lastIndexOf('/'))
-        repo = e.url.slice(e.url.lastIndexOf('/') + 1)
-      } else if (e.url.slice(last) == '.git'){ //github with extension
-        domain = e.url.substring(0, first)
-        extension = true
-        owner = e.url.substring(e.url.indexOf('/') + 1, e.url.lastIndexOf('/'))
-        repo = e.url.substring(e.url.lastIndexOf('/') + 1, e.url.length - 4)
-      } else { //gluster
-        domain = e.url.substring(first + 1, last)
-        owner = null //e.url.substring(e.url.indexOf('/') + 1, e.url.lastIndexOf('/'))
-        repo = e.url.slice(e.url.lastIndexOf('/') + 1)
-      }
-      // this.$store.commit('setRepo', {
-      //   gitURL: e.url
-      // })
 
       this.setBaseRepo(e);
-
-      this.addRepo(e);
-
-      // this.$store.commit('setTab', {
-      //   tab: 'git'
-      // })
 
       this.$router.push({
         name: 'repo_overview',

--- a/frontend/src/views/RiskMetrics.vue
+++ b/frontend/src/views/RiskMetrics.vue
@@ -53,7 +53,7 @@
       CompareControl,
       CountBlock,
       LineChart,
-      PieChart,
+      // PieChart,
     },
     methods: {
       ...mapActions('common',[

--- a/frontend/src/views/RiskMetrics.vue
+++ b/frontend/src/views/RiskMetrics.vue
@@ -42,7 +42,7 @@
   import DualLineChart from '../components/charts/DualLineChart.vue'
   import CompareControl from '../components/common/CompareControl.vue'
   import CountBlock from "@/components/charts/CountBlock.vue";
-  // import LineChart from "@/components/charts/LineChart.vue";
+  import LineChart from "@/components/charts/LineChart.vue";
   // import PieChart from "@/components/charts/PieChart.vue";
   import router from "@/router";
 

--- a/frontend/src/views/RiskMetrics.vue
+++ b/frontend/src/views/RiskMetrics.vue
@@ -31,6 +31,13 @@
       </div>
     </div>
 
+    <div class="row mb-5" v-if="loaded_rsik_1">
+      <div class="col-6">
+        <license-table :data="values1" source="licenseDeclared"  :headers="['Short Name','Note']"
+                       :fields="['short_name','note']"  title="License Declared"></license-table>
+      </div>
+    </div>
+
   </d-container>
 </template>
 
@@ -43,6 +50,7 @@
   import CompareControl from '../components/common/CompareControl.vue'
   import CountBlock from "@/components/charts/CountBlock.vue";
   import LineChart from "@/components/charts/LineChart.vue";
+  import LicenseTable from "@/components/charts/LicenseTable.vue";
   // import PieChart from "@/components/charts/PieChart.vue";
   import router from "@/router";
 
@@ -53,6 +61,7 @@
       CompareControl,
       CountBlock,
       LineChart,
+      LicenseTable,
       // PieChart,
     },
     methods: {
@@ -94,7 +103,7 @@
 
 
     // endpoints
-    risk_endpoints_1 = ['forkCount']
+    risk_endpoints_1 = ['forkCount','licenseDeclared']
 
     risk_endpoints_2 = ['getForks', 'committers']
 

--- a/frontend/src/views/RiskMetrics.vue
+++ b/frontend/src/views/RiskMetrics.vue
@@ -1,0 +1,115 @@
+<template>
+  <d-container fluid class="main-content-container px-4">
+    <d-breadcrumb style="margin:0; padding-top: 26px; padding-left: 0px">
+      <d-breadcrumb-item :active="false" :text="base.rg_name" href="#" />
+      <d-breadcrumb-item :active="true" :text="base.repo_name" href="#" />
+    </d-breadcrumb>
+    <compare-control></compare-control>
+
+    <!-- Overview Section -->
+    <div class="page-header row no-gutters py-4" >
+      <div class="col-12 col-sm-4 text-center text-sm-left mb-0">
+        <!-- <span class="text-uppercase page-subtitle">Components</span> -->
+        <h3 class="page-title" style="font-size: 1rem">Risk</h3>
+      </div>
+    </div>
+
+    <div class="row mb-5" v-if="loaded_rsik_1">
+      <div class="col-3">
+        <count-block title="Forks" :data="values1" source="forkCount" field="forks"></count-block>
+      </div>
+    </div>
+
+    <div class="row mb-5" v-if="loaded_rsik_2">
+      <div class="col-6">
+        <line-chart title="Forks Count by Week" :data="values2" source="getForks" filedTime="date" fieldCount="forks">
+        </line-chart>
+      </div>
+      <div class="col-6">
+        <line-chart title="Committers by week" :data="values2" source="committers" filedTime="date"
+                    fieldCount="count"></line-chart>
+      </div>
+    </div>
+
+  </d-container>
+</template>
+
+<script lang="ts">
+  import  { Component, Vue } from 'vue-property-decorator';
+  import {mapActions, mapGetters} from "vuex";
+  import Spinner from '@/components/Spinner.vue'
+
+  import DualLineChart from '../components/charts/DualLineChart.vue'
+  import CompareControl from '../components/common/CompareControl.vue'
+  import CountBlock from "@/components/charts/CountBlock.vue";
+  // import LineChart from "@/components/charts/LineChart.vue";
+  // import PieChart from "@/components/charts/PieChart.vue";
+  import router from "@/router";
+
+  @Component({
+    components: {
+      DualLineChart,
+      Spinner,
+      CompareControl,
+      CountBlock,
+      LineChart,
+      PieChart,
+    },
+    methods: {
+      ...mapActions('common',[
+        'endpoint', // map `this.endpoint({...})` to `this.$store.dispatch('endpoint', {...})`
+                    // uses: this.endpoint({endpoints: [], repos (optional): [], repoGroups (optional): []})
+      ])
+    },
+    computed: {
+      ...mapGetters('common',[
+      ]),
+      ...mapGetters('compare',[
+        'base'
+      ]),
+    },
+  })
+  export default class RiskMetrics extends Vue {
+    colors = ["#343A40", "#24a2b7", "#159dfb", "#FF3647", "#4736FF", "#3cb44b", "#ffe119", "#f58231", "#911eb4", "#42d4f4", "#f032e6"]
+    testTimeframes = ['past 1 month', 'past 3 months', 'past 2 weeks']
+    repos = {}
+    projects = []
+    themes = ['dark', 'info', 'royal-blue', 'warning']
+    project = null
+
+    loaded_rsik_1:boolean = false;
+    loaded_rsik_2:boolean = false;
+
+    values1 = {}
+    values2 = {}
+
+    // deflare vuex action, getter, mutations
+    groupsInfo!: any;
+    getRepoGroups!: any;
+    repo_groups!: any[];
+    sorted_repo_groups!: any[];
+    base!: any;
+    // actions
+    endpoint!: any;
+
+
+    // endpoints
+    risk_endpoints_1 = ['forkCount']
+
+    risk_endpoints_2 = ['getForks', 'committers']
+
+    created() {
+      this.endpoint({endpoints:this.risk_endpoints_1,repos:[this.base]}).then((tuples:any) => {
+        this.values1 = tuples;
+        this.loaded_rsik_1 = true
+      })
+      this.endpoint({endpoints:this.risk_endpoints_2,repos:[this.base]}).then((tuples:any) => {
+        this.values2 = tuples;
+        this.loaded_rsik_2 = true
+      })
+
+    }
+
+  }
+</script>
+


### PR DESCRIPTION
- Front End
  - fix style error 
![image](https://user-images.githubusercontent.com/15957393/62835633-4a089d80-bc8d-11e9-895f-7efc946b06c4.png)
  - Use repo_name instead url in the router 
  - Router for Repo comparison 
URL Example: `http://localhost:8080/repo/Apache/storm-site/comparedTo/Comcast%2Fhadoop,Comcast%2Fcaniuse,Risk%20Workign%20Group%2Fopenbsd,Risk%20Workign%20Group%2Fboringssl/` 
- Risk Metric 
  - refactor license-count
  - refactor license-coverage
  - refactor license-declared 
  - add test for all endpoints in risk metric 

- Add four visualization of risk metrics 
![205251565616838_ pic_hd](https://user-images.githubusercontent.com/15957393/62869452-77675100-bd4a-11e9-8149-ba2e11a42514.jpg)

![image](https://user-images.githubusercontent.com/15957393/62873538-2eb39600-bd52-11e9-8d08-32f62abcec92.png)
