### PR TITLE
Fix Risk page

### DIFF
--- a/frontend/src/Augur.ts
+++ b/frontend/src/Augur.ts
@@ -68,7 +68,8 @@ export default function Augur() {
         rg_name: to.params.group,
         repo_name: to.params.repo,
         repo_group_id: to.params.repo_group_id,
-        repo_id: to.params.repo_id
+        repo_id: to.params.repo_id,
+        gitURL: to.params.url
       }).then(() => {
         NProgress.set(0.8);
         if(to.params.compares) {

--- a/frontend/src/components/charts/CountBlock.vue
+++ b/frontend/src/components/charts/CountBlock.vue
@@ -23,19 +23,20 @@
     computed: {
       ...mapGetters('compare',[
         'comparedRepos',
-        'baseRepo'
+        'base'
       ]),
     },
   })
   export default class CountBlock extends AppProps{
 
     // compare.getter
-    baseRepo!:any
+    base!:any
     comparedRepos!:any
 
 
     get count(){
-      return this.data[this.baseRepo][this.source][0][this.field]
+      console.log(this.data)
+      return this.data[this.source][0][this.field]
     }
 
   }

--- a/frontend/src/components/charts/LicenseTable.vue
+++ b/frontend/src/components/charts/LicenseTable.vue
@@ -33,19 +33,19 @@
     computed: {
       ...mapGetters('compare',[
         'comparedRepos',
-        'baseRepo'
+        'base'
       ]),
     },
   })
   export default class CountBlock extends AppProps{
 
     // compare.getter
-    baseRepo!:any
+    base!:any
     comparedRepos!:any
 
 
     get values(){
-      return this.data[this.baseRepo][this.source]
+      return this.data[this.source]
     }
 
   }

--- a/frontend/src/components/charts/LineChart.vue
+++ b/frontend/src/components/charts/LineChart.vue
@@ -25,19 +25,19 @@
     computed: {
       ...mapGetters('compare',[
         'comparedRepos',
-        'baseRepo'
+        'base',
       ]),
     },
   })
   export default class LineChart extends AppProps{
 
     // compare.getter
-    baseRepo!:any
+    base!:any
     comparedRepos!:any
 
     get values(){
-      console.log(this.data[this.baseRepo][this.source])
-      return this.data[this.baseRepo][this.source]
+      console.log(this.data[this.source])
+      return this.data[this.source]
     }
     get encoding() {
       return {

--- a/frontend/src/views/Repos.vue
+++ b/frontend/src/views/Repos.vue
@@ -181,7 +181,7 @@ export default class Repos extends Vue{
   onGitRepo (e: any) {
     this.$router.push({
       name: 'repo_overview',
-      params: {group:e.rg_name, repo:e.repo_name, repo_group_id: e.repo_group_id, repo_id: e.repo_id}
+      params: {group:e.rg_name, repo:e.repo_name, repo_group_id: e.repo_group_id, repo_id: e.repo_id, url:e.url}
     })
   }
 }

--- a/frontend/src/views/RiskMetrics.vue
+++ b/frontend/src/views/RiskMetrics.vue
@@ -16,24 +16,24 @@
 
     <div class="row mb-5" v-if="loaded_rsik_1">
       <div class="col-3">
-        <count-block title="Forks" :data="values1" source="forkCount" field="forks"></count-block>
+        <count-block title="Forks" :data="values" source="forkCount" field="forks"></count-block>
       </div>
     </div>
 
     <div class="row mb-5" v-if="loaded_rsik_2">
       <div class="col-6">
-        <line-chart title="Forks Count by Week" :data="values2" source="getForks" filedTime="date" fieldCount="forks">
+        <line-chart title="Forks Count by Week" :data="values" source="getForks" filedTime="date" fieldCount="forks">
         </line-chart>
       </div>
       <div class="col-6">
-        <line-chart title="Committers by week" :data="values2" source="committers" filedTime="date"
+        <line-chart title="Committers by week" :data="values" source="committers" filedTime="date"
                     fieldCount="count"></line-chart>
       </div>
     </div>
 
     <div class="row mb-5" v-if="loaded_rsik_1">
       <div class="col-6">
-        <license-table :data="values1" source="licenseDeclared"  :headers="['Short Name','Note']"
+        <license-table :data="values" source="licenseDeclared"  :headers="['Short Name','Note']"
                        :fields="['short_name','note']"  title="License Declared"></license-table>
       </div>
     </div>
@@ -89,8 +89,7 @@
     loaded_rsik_1:boolean = false;
     loaded_rsik_2:boolean = false;
 
-    values1 = {}
-    values2 = {}
+    values = {}
 
     // deflare vuex action, getter, mutations
     groupsInfo!: any;
@@ -108,12 +107,17 @@
     risk_endpoints_2 = ['getForks', 'committers']
 
     created() {
+      console.log('####', this.base)
       this.endpoint({endpoints:this.risk_endpoints_1,repos:[this.base]}).then((tuples:any) => {
-        this.values1 = tuples;
+        Object.keys(tuples[this.base.rg_name][this.base.url]).forEach((endpoint) => {
+        this.values[endpoint] = tuples[this.base.rg_name][this.base.url][endpoint]
+        })
         this.loaded_rsik_1 = true
       })
       this.endpoint({endpoints:this.risk_endpoints_2,repos:[this.base]}).then((tuples:any) => {
-        this.values2 = tuples;
+        Object.keys(tuples[this.base.rg_name][this.base.url]).forEach((endpoint) => {
+        this.values[endpoint] = tuples[this.base.rg_name][this.base.url][endpoint]
+        })
         this.loaded_rsik_2 = true
       })
 


### PR DESCRIPTION
- Fix risk page in new API endpoints cache structure  
  - use url as key instead of `Repo.toString`