### PR TITLE
Repo Info Worker: Fix rate limit exceeded error

### DIFF
--- a/workers/repo_info_worker/repo_info_worker/worker.py
+++ b/workers/repo_info_worker/repo_info_worker/worker.py
@@ -414,7 +414,7 @@ class GHRepoInfoWorker:
         logger.info(f"[Rate Limit]: Updated rate limit, you have: {self.rate_limit} requests remaining")
         if self.rate_limit <= 0:
             reset_time = response.headers['X-RateLimit-Reset']
-            time_diff = datetime.datetime.fromtimestamp(int(reset_time)) - datetime.datetime.now()
+            time_diff = datetime.fromtimestamp(int(reset_time)) - datetime.now()
             logger.info(f"[Rate Limit]: Rate limit exceeded, waiting {time_diff.total_seconds()} seconds")
             time.sleep(time_diff.total_seconds())
             self.rate_limit = int(response.headers['X-RateLimit-Limit'])

--- a/workers/repo_info_worker/repo_info_worker/worker.py
+++ b/workers/repo_info_worker/repo_info_worker/worker.py
@@ -373,7 +373,7 @@ class GHRepoInfoWorker:
                 else:
                     url = r.links['next']['url']
         except Exception:
-            logger.exceptioin('An error occured while querying contributor count')
+            logger.exception('An error occured while querying contributor count')
 
         return committers
 


### PR DESCRIPTION
Should fix #377 

On carefully going through the log (https://pastebin.com/pE71B71R), I realized that the worker was trying to go to sleep but couldn't calculate the sleeping time, consequently, raising an exception  (See line no 522 onwards).

Since the `datetime` module is imported as `from datetime import datetime`, changing `datetime.datetime.now()` to `datetime.now()` and `datetime.datetime.fromtimestamp` to `datetime.fromtimestamp` should allow the worker to calculate the sleeping time and fix this problem.

Also, there was a typo [line no: 376] that was raising an exception while the worker tried to handle the previous exception.

This PR fixes all these typos and should allow the worker to go to sleep when the rate limit exceeds.