### PR TITLE
Remove comparison options button / noise

### DIFF
--- a/frontend/src/components/ReposInGroup.vue
+++ b/frontend/src/components/ReposInGroup.vue
@@ -8,7 +8,7 @@
       </div>
     </div>
 
-    
+
 
     <div class="row">
       <div class="col">
@@ -21,13 +21,13 @@
             <table style="table-layout:fixed;" class="table mb-0">
               <thead class="bg-light">
                 <tr>
-                  <th width="20%" scope="col" class="border-0" v-on:click="sortTable('url')"> 
+                  <th width="20%" scope="col" class="border-0" v-on:click="sortTable('url')">
                     <div class="row">
                       <div class="col col-9">URL</div>
                       <div class="arrow" v-bind:class="ascending ? 'arrow_up' : 'arrow_down'" v-if="'url' == sortColumn"></div>
                     </div>
                   </th>
-                  <th scope="col" class="border-0" v-on:click="sortTable('rg_name')"> 
+                  <th scope="col" class="border-0" v-on:click="sortTable('rg_name')">
                     <div class="row">
                       <div class="col col-9">Repo Group Name</div>
                       <div class="arrow" v-bind:class="ascending ? 'arrow_up' : 'arrow_down'" v-if="'rg_name' == sortColumn"></div>
@@ -63,7 +63,7 @@
                       <div class="col col-2 arrow" v-bind:class="ascending ? 'arrow_up' : 'arrow_down'" v-if="'repo_status' == sortColumn"></div>
                     </div>
                   </th> -->
-                  <th scope="col" class="border-0">Options</th>
+                  <!-- <th scope="col" class="border-0">Options</th> -->
                 </tr>
               </thead>
               <tbody>
@@ -72,12 +72,12 @@
                     <a href="#" @click="onGitRepo(repo)">{{ repo.url }}</a>
                   </td>
                   <td>{{ repo.rg_name }}</td>
-                  <td>{{ repo.description }}</td>
-                  <td>{{ repo.repo_count }}</td>
+                  <!-- <td>{{ repo.description }}</td> -->
+                  <!-- <td>{{ repo.repo_count }}</td> -->
                   <td>{{ repo.commits_all_time }}</td>
                   <td>{{ repo.issues_all_time }}</td>
                   <!-- <td>{{ repo.repo_status }}</td> -->
-                  <td>
+                  <!-- <td>
                     <div class="row">
                       <button :id="'favorite'+index" class="nav-link col col-2" style="margin-left: 2rem; margin-right: 1rem; padding: 0;border: none; background: none;">
                         <i class="material-icons" style="color:#007bff;">star_rate</i>
@@ -97,7 +97,7 @@
                         Add this repo group to your current compared repos
                       </d-tooltip>
                     </div>
-                  </td>
+                  </td> -->
                 </tr>
               </tbody>
             </table>
@@ -159,20 +159,20 @@ export default class ReposInGroup extends Vue{
   getRepoRelations!: any
   sortedRepos!:any
   loadRepos!:any;
-  
+
   addRepo!:any;
   setBaseRepo!:any;
   addComparedRepo!:any;
 
 
   created() {
-    
+
     this.loadRepos().then(() => {
       this.loadedRepos = true
     })
 
   }
-  
+
   sortTable(col: string) {
       if (this.sortColumn === col) {
         this.ascending = !this.ascending;

--- a/frontend/src/components/common/CompareControl.vue
+++ b/frontend/src/components/common/CompareControl.vue
@@ -6,7 +6,7 @@
           <d-col cols="12" lg="2">
             <div class="text-center text-lg-center ">Compare from your repos:</div>
           </d-col>
-          <d-col cols="12" lg="3">
+          <d-col cols="12" lg="4">
             <multiselect v-model="selectedGroups" :options="GroupOptions"
                          placeholder="Select Group" :close-on-select="false" :clear-on-select="false"
                          :preserve-search="true"  :multiple="isGroup">
@@ -15,7 +15,7 @@
               </template>
             </multiselect>
           </d-col>
-          <d-col cols="12" lg="3" v-if="!isGroup">
+          <d-col cols="12" lg="4" v-if="!isGroup">
             <multiselect v-model="selectedRepos" :multiple="true" :close-on-select="false" :clear-on-select="false"
                          :preserve-search="true" :options="RepoOptions"
                          :disabled="getSelectedGroups.length === 0" placeholder="Select Repo" >
@@ -33,15 +33,17 @@
               <d-button @click="onReset">Reset</d-button>
             </d-button-group>
           </d-col>
+          <!--
           <d-col cols="12" lg="3" :class="{'offset-md-3':isGroup}">
             <div v-d-toggle.my-collapse variant="primary" size="small" class="float-right"
                  @click="isCollpase = !isCollpase">
-              <div v-if="isCollpase">More configuration options<i class="material-icons" style="font-size: 1.3rem
+               <div v-if="isCollpase">More configuration options<i class="material-icons" style="font-size: 1.3rem
 ">keyboard_arrow_down</i></div>
-              <div v-if="!isCollpase">Less configuration options<i class="material-icons" style="font-size: 1.3rem">keyboard_arrow_up</i>
+               <div v-if="!isCollpase">Less configuration options<i class="material-icons" style="font-size: 1.3rem">keyboard_arrow_up</i>
               </div>
             </div>
           </d-col>
+          -->
         </d-row>
         <d-row>
             <d-badge theme="primary" v-if="!isGroup" pill class="mx-2 mt-2" v-for="item in getSelectedRepos">
@@ -254,8 +256,8 @@
     startDate!: Date;
     endDate!: Date;
     isGroup!: boolean;
-    
-    
+
+
     comparedRepoGroups!:any;
     comparedRepos!:any;
     comparisionSize!:any;
@@ -398,7 +400,7 @@
           console.log(repo)
           if (i == 0)
             comparedRepoIds += String(repo.repo_id)
-          else 
+          else
             comparedRepoIds += "," + String(repo.repo_id)
           i++
         }
@@ -415,7 +417,7 @@
             }
           })
         })
-        
+
       } else {
         router.push({
           name: 'group_overview_compare',
@@ -464,7 +466,7 @@
       let index = this.selectedRepos.indexOf(e);
       if (index !== -1) this.selectedRepos.splice(index, 1);
     }
-    
+
     removeSelectedGroups(e:any) {
       let index = this.selectedGroups.indexOf(e);
       if (index !== -1) this.selectedGroups.splice(index, 1);

--- a/frontend/src/views/Repos.vue
+++ b/frontend/src/views/Repos.vue
@@ -8,7 +8,7 @@
       </div>
     </div>
 
-    
+
 
     <div class="row">
       <div class="col">
@@ -20,18 +20,18 @@
           <d-card-body v-if="!loadedRepos">
             <spinner></spinner>
           </d-card-body>
-          
+
           <div v-if="loadedRepos" class="card-body p-0 pb-3 text-center">
             <table style="table-layout:fixed;" class="table mb-0">
               <thead class="bg-light">
                 <tr>
-                  <th scope="col" class="border-0" v-on:click="sortTable('url')"> 
+                  <th scope="col" class="border-0" v-on:click="sortTable('url')">
                     <div class="row">
                       <div class="col col-9">URL</div>
                       <div class="arrow" v-bind:class="ascending ? 'arrow_up' : 'arrow_down'" v-if="'url' == sortColumn"></div>
                     </div>
                   </th>
-                  <th scope="col" class="border-0" v-on:click="sortTable('rg_name')"> 
+                  <th scope="col" class="border-0" v-on:click="sortTable('rg_name')">
                     <div class="row">
                       <div class="col col-9">Repo Group Name</div>
                       <div class="arrow" v-bind:class="ascending ? 'arrow_up' : 'arrow_down'" v-if="'rg_name' == sortColumn"></div>
@@ -160,20 +160,20 @@ export default class Repos extends Vue{
   getRepoRelations!: any
   sortedRepos!:any
   loadRepos!:any;
-  
+
   addRepo!:any;
   setBaseRepo!:any;
   addComparedRepo!:any;
 
 
   created() {
-    
+
     this.loadRepos().then(() => {
       this.loadedRepos = true
     })
 
   }
-  
+
   sortTable(col: string) {
       if (this.sortColumn === col) {
         this.ascending = !this.ascending;


### PR DESCRIPTION
I found some columns that should have been deleted on the comparison bar + repo listings. This PR should take care of that.

Signed-off-by: Matt Snell <msnell@unomaha.edu>