### PR TITLE
Mentioned recommended node version in the Installation guide.

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -69,7 +69,7 @@ You will need:
 
 -  `Vue.js <https://vuejs.org/>`__
 -  `vue-cli <https://cli.vuejs.org/>`__
--  `node <https://nodejs.org/en/>`__
+-  `node <https://nodejs.org/en/>`__ (node 8 recommended. Versions greater than node 8 aren't supported)
 -  `npm <https://www.npmjs.com/>`__
 
 .. note::


### PR DESCRIPTION
Hi Augur Devs,

I've had a prolonged experience of installing augur.
I ran into a couple of [issues](https://github.com/chaoss/augur/issues/551) mostly because of incompatibility of augur dependencies (such as canvas which augur tends to install when you run the `make install` command) with my node version.

I think it would be helpful for NDE if we recommend a working version in the installation guide.