### PR TITLE
Remove stdout redirect from DB setup script

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -38,7 +38,7 @@ scripts/install/workers.sh $target > logs/workers-installation.log 2>&1
 echo "Done!"
 
 echo "Generating a config file..."
-scripts/install/config.sh > logs/config-generation.log 2>&1
+scripts/install/config.sh
 echo "Done!"
 
 

--- a/scripts/install/setup_db.sh
+++ b/scripts/install/setup_db.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 PS3="
 Please type the number corresponding to your selection and then press the Enter/Return key.


### PR DESCRIPTION
I forgot that the DB setup script is interactive, so redirecting the output to a file doesn't work. Whoops!