### PR TITLE
Fixed tooltip  click issue

### DIFF
--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -59,7 +59,6 @@
                         <d-tooltip 
                           :target="'#inspect' + idx"
                           container=".shards-demo--example--tooltip-01"
-                          placement="right"
                           offset="20">
                           Click to see more about this insight.
                         </d-tooltip>


### PR DESCRIPTION
I think #581 can be resolved by removing the placement option of the tooltip.
This causes the tooltip to appear above the button, but no issue in clicking the button.