### PR TITLE
Stabilization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ clean:
 	@ scripts/control/clean.sh
 
 rebuild:
-	@ scripts/control/rebuild.sh
+	@ scripts/control/rebuild.sh prod
+
+rebuild-dev:
+	@ scripts/control/rebuild.sh dev
 
 
 #
@@ -185,14 +188,14 @@ docker-build-testing-database:
 
 
 docker-run-backend:
-	@ docker run -d -p 5000:5000 --name augur_backend --env-file augur_env.txt augurlabs/augur:backend
+	@ docker run -p 5000:5000 --name augur_backend --env-file augur_env.txt augurlabs/augur:backend
 
 docker-run-frontend:
-	@ docker run -d -p 8080:8080 --name augur_frontend augurlabs/augur:frontend
+	@ docker run -p 8080:8080 --name augur_frontend augurlabs/augur:frontend
 
 docker-run-database:
-	@ docker run -d -p 5432:5432 --name augur_database augurlabs/augur:database
+	@ docker run -p 5432:5432 --name augur_database augurlabs/augur:database
 
 docker-run-testing-database:
-	@ docker run -d -p 5432:5432 --name augur_test_database augurlabs/augur:testing-database
+	@ docker run -p 5432:5432 --name augur_test_database augurlabs/augur:testing-database
 

--- a/augur/cli/configure.py
+++ b/augur/cli/configure.py
@@ -121,11 +121,13 @@ default_config = {
             },
             "insight_worker": {
                 "port": 50300,
+                "metrics": {"issues-new": "issues", "code-changes": "commit_count", "code-changes-lines": "added", 
+                           "reviews": "pull_requests", "contributors-new": "new_contributors"},
+                "contamination": 0.041,
                 "switch": 0,
                 "workers": 1,
                 "training_days": 365,
-                "anomaly_days": 90,
-                "confidence_interval": 95
+                "anomaly_days": 2
             },
             "linux_badge_worker": {
                 "port": 50400,
@@ -199,7 +201,9 @@ def generate(db_name, db_host, db_user, db_port, db_password, github_api_key, fa
             print(f"Error opening {rc_config_file}: {str(e)}")
 
     if db_name is not None:
-        config['Database']['database'] = db_name
+        config['Database']['database'] = db_name # this is for backwards compatibility
+    if db_name is not None:
+        config['Database']['name'] = db_name
     if db_host is not None:
         config['Database']['host'] = db_host
     if db_port is not None:

--- a/augur/cli/util.py
+++ b/augur/cli/util.py
@@ -4,7 +4,7 @@ Miscellaneous Augur library commands for controlling the backend components
 """
 
 import os
-import subprocess
+from subprocess import call
 import click
 import pandas as pd
 import sqlalchemy as s
@@ -38,14 +38,26 @@ def kill():
     """
     Kill running augur processes
     """
-    run_control_script("../../scripts/control/kill.sh")
+    run_control_script("scripts/control/kill.sh")
 
 @cli.command('list', short_help='List running Augur processes')
 def list():
     """
     List currently running augur processes
     """
-    run_control_script("../../scripts/control/processes.sh")
+    run_control_script("scripts/control/processes.sh")
+
+@cli.command('status', short_help='List running Augur processes')
+@click.option('--interactive', is_flag=True, help='Display all log files simultaneously with less')
+def list(interactive):
+    """
+    List currently running augur processes
+    """
+    if not interactive:
+        run_control_script("scripts/control/status.sh", "quick")
+    else:
+        run_control_script("scripts/control/status.sh", "interactive")
+
 
 @cli.command('repo-reset', short_help='Reset Repo Collection')
 @click.pass_context
@@ -60,6 +72,9 @@ def repo_reset(ctx):
 
     print("Repos successfully reset.")
 
-def run_control_script(relative_script_path):
-    os.chdir(os.path.dirname(os.path.realpath(__file__)))
-    subprocess.call(relative_script_path)
+def run_control_script(relative_script_path, flag=None):
+    os.chdir(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
+    if flag:
+        call(["./{}".format(relative_script_path), flag])
+    else:
+        call(relative_script_path)

--- a/augur/server.py
+++ b/augur/server.py
@@ -101,7 +101,6 @@ class Server(object):
             """
             status = {
                 'status': 'OK',
-                'plugins': [p for p in self._augur._loaded_plugins]
             }
             return Response(response=json.dumps(status),
                             status=200,

--- a/database-compose.yml
+++ b/database-compose.yml
@@ -1,9 +1,7 @@
 version: '3'
 services:
    database:
-    image: augurlabs/augur:database-dev
+    image: augurlabs/augur:database
     restart: unless-stopped
-    volumes:
-     - .:/augur_data
     ports:
      - 5432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
        env_file: augur_env.txt
 
       frontend:
-        image: augurlabs/augur:frontend-dev
+        image: augurlabs/augur:frontend
         restart: unless-stopped
         ports:
           - 8080:8080

--- a/schema/generate/5-seed-data.sql
+++ b/schema/generate/5-seed-data.sql
@@ -21,7 +21,7 @@ INSERT INTO "augur_data"."settings" VALUES (12, 'database_version', '7', '2019-0
 INSERT INTO "augur_data"."settings" VALUES (13, 'results_visibility', 'show', '2019-05-07 12:47:26');
 INSERT INTO "augur_data"."settings" VALUES (1, 'start_date', '2001-01-01', '1900-01-22 20:34:51');
 INSERT INTO "augur_data"."settings" VALUES (4, 'log_level', 'Debug', '2019-05-07 12:47:26');
-INSERT INTO "augur_data"."settings" VALUES (2, 'repo_directory', '/home/sean/github/augur-worker-test/repos', '2019-05-07 12:47:26');
+INSERT INTO "augur_data"."settings" VALUES (2, 'repo_directory', '/augur/repos/', '2019-05-07 12:47:26');
 INSERT INTO "augur_data"."settings" VALUES (8, 'affiliations_processed', '2001-08-26 10:03:29.815013+00', '1900-01-22 20:36:27');
 INSERT INTO "augur_data"."settings" VALUES (9, 'aliases_processed', '2001-08-26 10:03:29.815013+00', '1900-01-22 20:36:27');
 INSERT INTO "augur_data"."settings" VALUES (7, 'working_author', 'done', '1900-01-22 20:23:43');

--- a/schema/generate/8-schema_update_10.sql
+++ b/schema/generate/8-schema_update_10.sql
@@ -10,6 +10,4 @@ COMMENT ON COLUMN "augur_data"."pull_requests"."pr_src_id" IS 'The pr_src_id is 
 
 COMMENT ON COLUMN "augur_data"."pull_requests"."pr_src_number" IS 'The pr_src_number is unique within a repository.';
 
-INSERT INTO "augur_operations"."augur_settings"("id", "setting", "value", "last_modified") VALUES (1, 'augur_data_version', '10', '2019-11-18 08:41:51');
-
 update "augur_operations"."augur_settings" set value = 10 where setting = 'augur_data_version'; 

--- a/schema/generate/9-schema_update_11_pr_commits.sql
+++ b/schema/generate/9-schema_update_11_pr_commits.sql
@@ -45,4 +45,4 @@ CREATE INDEX "repos_id,statusops" ON "augur_data"."repos_fetch_log" USING btree 
 );
 
 
-update "augur_operations"."augur_settings" set value = 9 where setting = 'augur_data_version'; 
+update "augur_operations"."augur_settings" set value = 11 where setting = 'augur_data_version'; 

--- a/scripts/control/kill.sh
+++ b/scripts/control/kill.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
-set -euo pipefail
 
 if [[ "$VIRTUAL_ENV" ]]; then
     echo "Killing augur processes..."
-     ps aux | grep -ie $VIRTUAL_ENV/ |   awk '{print "kill -9 " $2}'
-     ps -ef | grep -ie $VIRTUAL_ENV/ | grep -v grep | awk '{print $2}' | xargs kill
+     ps -efx | grep -ie $VIRTUAL_ENV/ | grep -v grep | awk '{print "Killing PID " $2 ": " $8 }'
+     ps -efx | grep -ie $VIRTUAL_ENV/ | grep -v grep | awk '{print $2}' | xargs kill
 
     echo "Killing worker processes..."
-     ps aux | grep -ie $VIRTUAL_ENV/ | grep -ie bin | grep worker  |  awk '{print "kill -9 " $2}'
-     ps -ef | grep -ie $VIRTUAL_ENV/ | grep -v grep | awk '{print $2}' | xargs kill
+     ps -efx | grep -ie $VIRTUAL_ENV/ | grep -v grep | grep worker | awk '{print "Killing PID " $2 ": " $8 }'
+     ps -efx | grep -ie $VIRTUAL_ENV/ | grep -v grep | awk '{print $2}' | xargs kill
 else
     echo "We noticed you're not in a virtual environment. Please activate your augur virtual environment and run the command again."
 fi

--- a/scripts/control/processes.sh
+++ b/scripts/control/processes.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-set -euo pipefail
 
 if [[ "$VIRTUAL_ENV" ]]; then
     echo "Listing augur processes..."
-     ps -ef | grep -ie $VIRTUAL_ENV/ | grep -v grep | awk '{print $2}'
+     ps -efx | grep -ie $VIRTUAL_ENV/ | grep -v grep | awk '{print "PID " $2 ": " $8}'
 
     echo "Listing worker processes..."
-     ps aux | grep -ie $VIRTUAL_ENV/ | grep -ie bin | grep worker | awk '{print $2}'
+     ps -efx | grep -ie $VIRTUAL_ENV/ | grep -v grep | grep worker | awk '{print "PID " $2 ": " $8}'
 else
     echo "We noticed you're not in a virtual environment. Please activate your augur virtual environment and run the command again."
 fi

--- a/scripts/control/status.sh
+++ b/scripts/control/status.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-set -euo pipefail
 
 monitor=${1-quick}
 
-echo "augur logs"
-echo "*****************************"
 
 if [[ $monitor == "quick" ]]; then
-  tail -n 20 logs/augur.log
+  if [[ -d logs/augur.log ]]; then
+    echo "augur logs"
+    echo "*****************************"
+    tail -n 20 logs/augur.log
+  fi
 
   for WORKER in $(ls -d workers/*/)
   do
@@ -29,5 +30,5 @@ if [[ $monitor == "quick" ]]; then
       fi
   done
 else
-  less +F logs/augur.log workers/**/*.log
+  less -F logs/augur.log workers/**/*.log
 fi

--- a/util/docker/backend/Dockerfile
+++ b/util/docker/backend/Dockerfile
@@ -8,20 +8,22 @@ LABEL version="0.1.0"
 
 WORKDIR /augur
 
-# setup.py requires the README.md for the description 
-COPY ./README.md . 
-
+COPY ./README.md .
 COPY ./requirements.txt .
-COPY ./setup.py .
+COPY ./dev_requirements.txt .
 COPY ./augur/ ./augur/
+COPY ./scripts/ ./scripts/
+COPY ./util/ ./util/
+COPY ./metadata.py .
+COPY ./tox.ini .
+COPY ./setup.py .
+COPY ./workers/ ./workers/
+
 RUN pip install .
+RUN ./scripts/install/workers.sh prod
 
 RUN mkdir repos/;
-COPY ./workers/ ./workers/
-COPY ./scripts/install/workers.sh .
-
 COPY ./util/docker/docker.config.json .
 RUN augur configure generate --rc-config-file docker.config.json
-RUN ./workers.sh
 
 CMD augur run

--- a/util/docker/backend/Dockerfile
+++ b/util/docker/backend/Dockerfile
@@ -10,20 +10,16 @@ WORKDIR /augur
 
 COPY ./README.md .
 COPY ./requirements.txt .
-COPY ./dev_requirements.txt .
-COPY ./augur/ ./augur/
-COPY ./scripts/ ./scripts/
-COPY ./util/ ./util/
+COPY ./augur/ augur/
 COPY ./metadata.py .
-COPY ./tox.ini .
 COPY ./setup.py .
-COPY ./workers/ ./workers/
+COPY ./scripts/ scripts/
+COPY ./workers/ workers/
 
 RUN pip install .
 RUN ./scripts/install/workers.sh prod
 
-RUN mkdir repos/;
 COPY ./util/docker/docker.config.json .
-RUN augur configure generate --rc-config-file docker.config.json
+RUN augur configure generate --rc-config-file docker.config.json; mkdir repos/;
 
-CMD augur run
+CMD augur db update-repo-directory /augur/repos/; augur run

--- a/util/docker/backend/install_packages.sh
+++ b/util/docker/backend/install_packages.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
+# Tell apt-get we're never going to be able to give manual
+# feedback:
+export DEBIAN_FRONTEND=noninteractive
+
 apt-get update
 apt-get -y upgrade
 apt-get -y install --no-install-recommends procps
+apt-get -y install --no-install-recommends git
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/workers/facade_worker/facade_worker/facade01config.py
+++ b/workers/facade_worker/facade_worker/facade01config.py
@@ -215,7 +215,7 @@ class Config:
             # Set up the database
             db_user = read_config('Database', 'user', 'AUGUR_DB_USER', 'augur')
             db_pass = read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'augur')
-            db_name = read_config('Database', 'database', 'AUGUR_DB_NAME', 'augur')
+            db_name = read_config('Database', 'name', 'AUGUR_DB_NAME', 'augur')
             db_host = read_config('Database', 'host', 'AUGUR_DB_HOST', 'localhost')
             db_port = read_config('Database', 'port', 'AUGUR_DB_PORT', 5432)
             db_user_people = db_user

--- a/workers/facade_worker/facade_worker/facade03analyzecommit.py
+++ b/workers/facade_worker/facade_worker/facade03analyzecommit.py
@@ -201,7 +201,7 @@ def analyze_commit(cfg, repo_id, repo_loc, commit, multithreaded):
 
 	db_user = read_config('Database', 'user', 'AUGUR_DB_USER', 'augur')
 	db_pass = read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'augur')
-	db_name = read_config('Database', 'database', 'AUGUR_DB_NAME', 'augur')
+	db_name = read_config('Database', 'name', 'AUGUR_DB_NAME', 'augur')
 	db_host = read_config('Database', 'host', 'AUGUR_DB_HOST', 'localhost')
 	db_port = read_config('Database', 'port', 'AUGUR_DB_PORT', 5432)
 	db_user_people = db_user

--- a/workers/facade_worker/facade_worker/runtime.py
+++ b/workers/facade_worker/facade_worker/runtime.py
@@ -79,7 +79,7 @@ def main(augur_url, host, port):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
             "display_name": "",
             "description": "",

--- a/workers/github_worker/github_worker/runtime.py
+++ b/workers/github_worker/github_worker/runtime.py
@@ -82,7 +82,7 @@ def main(augur_url, host, port):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
             "display_name": "",
             "description": "",

--- a/workers/insight_worker/insight_worker/runtime.py
+++ b/workers/insight_worker/insight_worker/runtime.py
@@ -80,7 +80,7 @@ def main(augur_url, host, port):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
             "anomaly_days": worker_info['anomaly_days'] if 'anomaly_days' in worker_info else 2,
             "training_days": worker_info['training_days'] if 'training_days' in worker_info else 365,

--- a/workers/insight_worker/insight_worker/worker.py
+++ b/workers/insight_worker/insight_worker/worker.py
@@ -191,7 +191,7 @@ class InsightWorker:
         record_model_process(self, repo_id, 'insights')
 
         """ Collect data """   
-        base_url = 'http://localhost:5002/api/unstable/repo-groups/9999/repos/{}/'.format(repo_id)
+        base_url = 'http://{}:{}/api/unstable/repo-groups/9999/repos/{}/'.format(self.config['broker_host'], self.config['broker_port'], repo_id)
         
         # Dataframe to hold all endpoint results
         # Subtract configurable amount of time

--- a/workers/linux_badge_worker/linux_badge_worker/runtime.py
+++ b/workers/linux_badge_worker/linux_badge_worker/runtime.py
@@ -80,7 +80,7 @@ def main(augur_url, host, port):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json?pq=",
             "display_name": "",
             "description": "",

--- a/workers/metric_status_worker/metric_status_worker/runtime.py
+++ b/workers/metric_status_worker/metric_status_worker/runtime.py
@@ -83,7 +83,7 @@ def main(augur_url, host, port):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
             "display_name": "",
             "description": "",

--- a/workers/pull_request_worker/pull_request_worker/runtime.py
+++ b/workers/pull_request_worker/pull_request_worker/runtime.py
@@ -81,7 +81,7 @@ def main(augur_url, host, port):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
             "display_name": "",
             "description": "",

--- a/workers/repo_info_worker/repo_info_worker/runtime.py
+++ b/workers/repo_info_worker/repo_info_worker/runtime.py
@@ -79,7 +79,7 @@ def main(augur_url, host, port):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
             "display_name": "",
             "description": "",

--- a/workers/value_worker/value_worker/runtime.py
+++ b/workers/value_worker/value_worker/runtime.py
@@ -95,7 +95,7 @@ def main(augur_url, host, port, scc_bin):
             "password": read_config('Database', 'password', 'AUGUR_DB_PASSWORD', 'password'),
             "port": read_config('Database', 'port', 'AUGUR_DB_PORT', 'port'),
             "user": read_config('Database', 'user', 'AUGUR_DB_USER', 'user'),
-            "database": read_config('Database', 'database', 'AUGUR_DB_NAME', 'database'),
+            "database": read_config('Database', 'name', 'AUGUR_DB_NAME', 'database'),
             "endpoint": "https://bestpractices.coreinfrastructure.org/projects.json",
             'scc_bin': worker_info['scc_bin'],
             "display_name": "",


### PR DESCRIPTION
This PR introduces some new features and fixes intended to help stabilize Augur and prepare for the upcoming release. 

## Changeset
- Workers now use the newly renamed `name` key under the `Database` section of the config
- `backend` Docker image refactored to ensure workers are installed correctly
- Deprecated plugin status check removed from metrics API health check endpoint
- Required Git dependency was added to backend Docker image
- `insight_worker` has been refactored to dynamically discover the metrics API
- `augur util status` is a new command that will display the last 20 lines of the log files, or display all the files with `less` if passed the `--interactive` flag
- The default `facade_repo_directory` setting has been updated to `/augur/repos` for the Docker image (regular users will always overwrite this when they install) 
- Prototype `testing-database` image was moved to an alternate repository & recreated with updated data
