### PR TITLE
Moving the repetitive tests to a common function (DRY)

### DIFF
--- a/test/api/test_util_routes.py
+++ b/test/api/test_util_routes.py
@@ -5,39 +5,27 @@ import pytest
 def metrics():
     pass
 
-def test_downloaded_repos(metrics):
-    response = requests.get('http://localhost:5000/api/unstable/repos')
+def test_common(endpoint="http://localhost:5000/api/unstable/repos"):
+    response = requests.get(endpoint)
     data = response.json()
     assert response.status_code == 200
     assert len(data) >= 1
+
+def test_downloaded_repos(metrics):
+    return test_common(endpoint='http://localhost:5000/api/unstable/repos')
 
 def test_repo_groups(metrics):
-    response = requests.get('http://localhost:5000/api/unstable/repo-groups')
-    data = response.json()
-    assert response.status_code == 200
-    assert len(data) >= 1
+    return test_common(endpoint='http://localhost:5000/api/unstable/repo-groups')
 
 def test_repos_in_repo_groups(metrics):
-    response = requests.get('http://localhost:5000/api/unstable/repo-groups')
-    data = response.json()
-    assert response.status_code == 200
-    assert len(data) >= 1
+    return test_common(endpoint='http://localhost:5000/api/unstable/repo-groups')
 
 def test_get_repo_for_dosocs(metrics):
-    response = requests.get('http://localhost:5000/api/unstable/dosocs/repos')
-    data = response.json()
-    assert response.status_code == 200
-    assert len(data) >= 1
+    return test_common(endpoint='http://localhost:5000/api/unstable/dosocs/repos')
 
 def test_aggregate_summary_by_repo(metrics):
-    response = requests.get('http://localhost:5000/api/unstable/repo-groups/10/repos/25430/aggregate-summary')
-    data = response.json()
-    assert response.status_code == 200
-    assert len(data) >= 1
+    return test_common(endpoint='http://localhost:5000/api/unstable/repo-groups/10/repos/25430/aggregate-summary')
 
 def test_aggregate_summary_by_group(metrics):
-    response = requests.get('http://localhost:5000/api/unstable/repo-groups/10/aggregate-summary')
-    data = response.json()
-    assert response.status_code == 200
-    assert len(data) >= 1
+    return test_common(endpoint='http://localhost:5000/api/unstable/repo-groups/10/aggregate-summary')
 


### PR DESCRIPTION
To enforce DRY principles, moved the repetitive code to a common function. It also promotes code reusability.