### PR TITLE
Add config for release worker

### DIFF
--- a/augur/cli/configure.py
+++ b/augur/cli/configure.py
@@ -164,6 +164,11 @@ default_config = {
                 "switch": 1,
                 "workers": 1
             },
+            "release_worker": {
+                "port": 51100,
+                "switch": 1,
+                "workers": 1
+            },
         },
         "Facade": {
             "check_updates": 1,

--- a/docs/source/getting-started/collecting-data.rst
+++ b/docs/source/getting-started/collecting-data.rst
@@ -25,6 +25,7 @@ Here are the workers that ship ready to work with Augur by default:
 - ``github_worker`` (collects issue and contributor data from the GitHub API)
 - ``pull_request_worker`` (collects pull request data from the GitHub API)
 - ``repo_info_worker`` (collects repository statistics from the GitHub API)
+- ``release_worker`` (collects release data from the GitHub API)
 - ``linux_badge_worker`` (collects `CII <https://bestpractices.coreinfrastructure.org/en>`_ data from the CII API)
 - ``insight_worker`` (queries Augur's metrics API to find interesting anomalies in the collected data)
 

--- a/util/docker/docker.config.json
+++ b/util/docker/docker.config.json
@@ -23,6 +23,9 @@
             },
             "repo_info_worker": {
                 "switch": 1
+            },
+            "release_worker": {
+                "switch": 1
             }
         }
 }


### PR DESCRIPTION
Release worker was previosly missing in the configuration and not enabled

Resolves #736

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>