### PR TITLE
Fix repo_info_worker for forked data

### DIFF
--- a/workers/repo_info_worker/repo_info_worker/worker.py
+++ b/workers/repo_info_worker/repo_info_worker/worker.py
@@ -226,7 +226,7 @@ class RepoInfoWorker(Worker):
         r = requests.get(url, headers=self.headers)
         self.update_gh_rate_limit(r)
 
-        data = self.get_repo_data(self, url, r)
+        data = self.get_repo_data(url, r)
 
         if 'fork' in data:
             if 'parent' in data:
@@ -242,7 +242,7 @@ class RepoInfoWorker(Worker):
         r = requests.get(url, headers=self.headers)
         self.update_gh_rate_limit(r)
 
-        data = self.get_repo_data(self, url, r)
+        data = self.get_repo_data(url, r)
 
         if 'archived' in data:
             if data['archived']:


### PR DESCRIPTION
This fixes a bug from #721 with wrong number of parameters for `get_repo_data`.

Resolves #737

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>