### PR TITLE
Fix repo_info_worker for forked data

### DIFF
--- a/workers/repo_info_worker/repo_info_worker.py
+++ b/workers/repo_info_worker/repo_info_worker.py
@@ -23,7 +23,7 @@ class RepoInfoWorker(Worker):
         models = ['repo_info']
 
         # Define the tables needed to insert, update, or delete on
-        data_tables = ['repo_info']
+        data_tables = ['repo_info', 'repo']
         operations_tables = ['worker_history', 'worker_job']
 
         # Run the general worker initialization
@@ -144,14 +144,6 @@ class RepoInfoWorker(Worker):
 
         # Get committers count info that requires seperate endpoint
         committers_count = self.query_committers_count(owner, repo)
-        # Note that the addition of information about where a repository may be forked from, and whether a repository is archived, updates the `repo` table, not the `repo_info` table.
-        forked = self.is_forked(owner, repo)
-        archived = self.is_archived(owner, repo)
-        if archived is not False:
-            archived_date_collected = archived
-            archived = True
-        else:
-            archived_date_collected = None
 
         # Put all data together in format of the table
         self.logger.info(f'Inserting repo info for repo with id:{repo_id}, owner:{owner}, name:{repo}\n')
@@ -189,14 +181,29 @@ class RepoInfoWorker(Worker):
             'tool_source': self.tool_source,
             'tool_version': self.tool_version,
             'data_source': self.data_source
-            # 'forked_from': forked,
-            # 'repo_archived': archived,
-            # 'repo_archived_date_collected': archived_date_collected
         }
 
         result = self.db.execute(self.repo_info_table.insert().values(rep_inf))
         self.logger.info(f"Primary Key inserted into repo_info table: {result.inserted_primary_key}\n")
         self.results_counter += 1
+
+        # Note that the addition of information about where a repository may be forked from, and whether a repository is archived, updates the `repo` table, not the `repo_info` table.
+        forked = self.is_forked(owner, repo)
+        archived = self.is_archived(owner, repo)
+        archived_date_collected = None
+        if archived is not False:
+            archived_date_collected = archived
+            archived = 1
+        else:
+            archived = 0
+
+        rep_additional_data = {
+            'forked_from': forked,
+            'repo_archived': archived,
+            'repo_archived_date_collected': archived_date_collected
+        }
+        result = self.db.execute(self.repo_table.update().where(repo_table.c.repo_id==repo_id).values(rep_additional_data))
+        self.logger.info(f"Primary Key inserted into repo table: {result.inserted_primary_key}\n")
 
         self.logger.info(f"Inserted info for {owner}/{repo}\n")
 
@@ -219,12 +226,12 @@ class RepoInfoWorker(Worker):
                 else:
                     url = r.links['next']['url']
         except Exception:
-            logging.exception('An error occured while querying contributor count\n')
+            self.logger.exception('An error occured while querying contributor count\n')
 
         return committers
 
     def is_forked(self, owner, repo): #/repos/:owner/:repo parent
-        logging.info('Querying parent info to verify if the repo is forked\n')
+        self.logger.info('Querying parent info to verify if the repo is forked\n')
         url = f'https://api.github.com/repos/{owner}/{repo}'
 
         r = requests.get(url, headers=self.headers)
@@ -240,7 +247,7 @@ class RepoInfoWorker(Worker):
         return False
 
     def is_archived(self, owner, repo):
-        logging.info('Querying committers count\n')
+        self.logger.info('Querying committers count\n')
         url = f'https://api.github.com/repos/{owner}/{repo}'
 
         r = requests.get(url, headers=self.headers)
@@ -265,16 +272,16 @@ class RepoInfoWorker(Worker):
             data = json.loads(json.dumps(response.text))
 
         if 'errors' in data:
-            logging.info("Error!: {}".format(data['errors']))
+            self.logger.info("Error!: {}".format(data['errors']))
             if data['errors'][0]['message'] == 'API rate limit exceeded':
                 self.update_gh_rate_limit(response)
 
         if 'id' in data:
             success = True
         else:
-            logging.info("Request returned a non-data dict: {}\n".format(data))
+            self.logger.info("Request returned a non-data dict: {}\n".format(data))
             if data['message'] == 'Not Found':
-                logging.info("Github repo was not found or does not exist for endpoint: {}\n".format(url))
+                self.logger.info("Github repo was not found or does not exist for endpoint: {}\n".format(url))
             if data['message'] == 'You have triggered an abuse detection mechanism. Please wait a few minutes before you try again.':
                 self.update_gh_rate_limit(r, temporarily_disable=True)
             if data['message'] == 'Bad credentials':


### PR DESCRIPTION
This fixes a bug from #721 with the wrong number of parameters for
`get_repo_data` and moves forked data from `repo_info` into the `repo` table.

Resolves #737

Could not check logs for errors

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>