### PR TITLE
Added unit tests for worker methods

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,11 +1,15 @@
 import pytest
 import os
+import json
 import pandas as pd
+import tempfile
 from queue import Queue
 from workers.util import read_config
 from workers.worker_base import Worker
 from augur.config import AugurConfig, default_config
 from augur import ROOT_AUGUR_DIRECTORY
+
+temp_dir = tempfile.gettempdir()
 
 def test_dump_queues():
     sample_queue = Queue()
@@ -28,16 +32,24 @@ def test_read_config_exception():
 def test_config_get_section_no_exception():
     test_config = default_config
     test_config['Database']['user'] = "test_user"
-    config_object = AugurConfig(ROOT_AUGUR_DIRECTORY, test_config)
+    config_object = AugurConfig(temp_dir, test_config)
     assert type(config_object.get_section("Database")) == dict
 
 def test_config_get_section_exception():
     test_config = default_config
     test_config['Database']['user'] = "test_user"
-    config_object = AugurConfig(ROOT_AUGUR_DIRECTORY, test_config)
+    config_object = AugurConfig(temp_dir, test_config)
     with pytest.raises(KeyError):
         config_object.get_section("absent_section")
 
+def test_discover_config_file_env_exception():
+    original_env_value = os.environ.get('AUGUR_CONFIG_FILE')
+    os.environ['AUGUR_CONFIG_FILE'] = os.path.join(temp_dir, "augur.config.json")
+    test_config = default_config
+    config_object = AugurConfig(temp_dir, test_config)
+    assert config_object.discover_config_file() == os.path.join(temp_dir, "augur.config.json")
+    if original_env_value is not None:
+        os.environ['AUGUR_CONFIG_FILE'] = original_env_value
 
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,8 @@ import pandas as pd
 from queue import Queue
 from workers.util import read_config
 from workers.worker_base import Worker
+from augur.config import AugurConfig, default_config
+from augur import ROOT_AUGUR_DIRECTORY
 
 def test_dump_queues():
     sample_queue = Queue()
@@ -22,3 +24,21 @@ def test_read_config_no_exception():
 def test_read_config_exception():
     with pytest.raises(AttributeError):
         db_name = read_config('Server', 'username')
+
+def test_config_get_section_no_exception():
+    test_config = default_config
+    test_config['Database']['user'] = "test_user"
+    config_object = AugurConfig(ROOT_AUGUR_DIRECTORY, test_config)
+    assert type(config_object.get_section("Database")) == dict
+
+def test_config_get_section_exception():
+    test_config = default_config
+    test_config['Database']['user'] = "test_user"
+    config_object = AugurConfig(ROOT_AUGUR_DIRECTORY, test_config)
+    with pytest.raises(KeyError):
+        config_object.get_section("absent_section")
+
+
+
+
+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,21 @@
+import pytest
+import pandas as pd
+from queue import Queue
+from workers.util import read_config
+from workers.worker_base import Worker
+
+def test_dump_queues():
+    sample_queue = Queue()
+    list_sample = ["x@x.com", "y@y.com", "z@z.com"]
+    for list_item in list_sample:
+        sample_queue.put(list_item)
+    queue_to_list = Worker.dump_queue(sample_queue)
+    assert queue_to_list == ["x@x.com", "y@y.com", "z@z.com"]
+
+def test_read_config_no_exception():
+    db_name = read_config('Database', 'user', 'AUGUR_DB_USER', 'augur', config_file_path="augur.config.json")
+    assert db_name == "augur"
+
+def test_read_config_exception():
+    with pytest.raises(AttributeError):
+        db_name = read_config('Server', 'username')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 import pandas as pd
 from queue import Queue
 from workers.util import read_config
@@ -13,7 +14,9 @@ def test_dump_queues():
     assert queue_to_list == ["x@x.com", "y@y.com", "z@z.com"]
 
 def test_read_config_no_exception():
-    db_name = read_config('Database', 'user', 'AUGUR_DB_USER', 'augur', config_file_path="augur.config.json")
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    print(base_dir)
+    db_name = read_config('Database', 'user', 'AUGUR_DB_USER', 'augur', config_file_path=base_dir+"/augur.config.json")
     assert db_name == "augur"
 
 def test_read_config_exception():

--- a/workers/worker_base.py
+++ b/workers/worker_base.py
@@ -411,6 +411,7 @@ class Worker():
             "was reduced to {} tuples, and {} tuple updates are needed.\n".format(need_insertion_count, need_update_count))
         return new_data
 
+    @staticmethod
     def check_duplicates(self, new_data, table_values, key):
         """ Filters what items of the new_data json (list of dictionaries) that are not 
         present in the table_values df 
@@ -450,6 +451,7 @@ class Worker():
         if not connected:
             sys.exit('Could not connect to the broker after 5 attempts! Quitting...\n')
 
+    @staticmethod
     def dump_queue(queue):
         """
         Empties all pending items in a queue and returns them in a list.


### PR DESCRIPTION
Added a few unit tests for the base worker. Also added the `@staticmethod` decorators to `check_duplicates` &  `dump_queue` as they're more related to the Worker class rather than the object! [they do not utilize any variable from the __init__ method, therefore they are worker agnostic]

Signed-off-by: mrsaicharan1 <saicharan.reddy1@gmail.com>
