### PR TITLE
Revert pandas version to v1.0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "sqlalchemy",
         "flask_login",
         "flask",
-        "pandas",
+        "pandas==1.0.5",
         "requests",
         "flask_cors",
         "flask_wtf",


### PR DESCRIPTION
Fixes a bug that causes the `test_issue_duration` unit test to fail on 3.6 due to new behavior in Pandas.