### PR TITLE
Add tag_only releases to the release worker

### DIFF
--- a/augur/metrics/release.py
+++ b/augur/metrics/release.py
@@ -9,7 +9,7 @@ from augur.util import register_metric
 
 @register_metric()
 def releases(self, repo_group_id, repo_id=None, period='day', begin_date=None, end_date=None):
-    """ Returns a timeseris of new reviews or pull requests opened
+    """ Returns a timeseris of new releases created
 
     :param repo_group_id: The repository's repo_group_id
     :param repo_id: The repository's repo_id, defaults to None
@@ -24,7 +24,7 @@ def releases(self, repo_group_id, repo_id=None, period='day', begin_date=None, e
         end_date = datetime.datetime.now().strftime('%Y-%m-%d')
 
     if not repo_id:
-        reviews_SQL = s.sql.text("""
+        releases_SQL = s.sql.text("""
             SELECT
                 res.repo_name,
                 res.release_id,
@@ -47,18 +47,19 @@ def releases(self, repo_group_id, repo_id=None, period='day', begin_date=None, e
                     releases LEFT JOIN repo ON releases.repo_id = repo.repo_id
                 WHERE
                     repo.repo_id in (SELECT repo_id FROM repo WHERE repo_group_id=:repo_group_id )
+                    AND releases.tag_only = False
             ) as res
             GROUP BY releases.repo_id, releases.release_id
             ORDER BY releases.release_published_at DESC
         """)
 
-        results = pd.read_sql(reviews_SQL, self.database,
+        results = pd.read_sql(releases_SQL, self.database,
                               params={'period': period, 'repo_group_id': repo_group_id,
                                       'begin_date': begin_date, 'end_date': end_date })
         return results
 
     else:
-        reviews_SQL = s.sql.text("""
+        releases_SQL = s.sql.text("""
             SELECT
                 repo.repo_name,
                 releases.release_id,
@@ -75,11 +76,80 @@ def releases(self, repo_group_id, repo_id=None, period='day', begin_date=None, e
                 COUNT(releases)
             FROM
                 releases LEFT JOIN repo ON releases.repo_id = repo.repo_id
+            WHERE releases.tag_only = False
             GROUP BY repo.repo_id, releases.release_id
             ORDER BY releases.release_published_at DESC
         """)
 
-        results = pd.read_sql(reviews_SQL, self.database,
+        results = pd.read_sql(releases_SQL, self.database,
+                              params={'period': period, 'repo_id': repo_id,
+                                      'begin_date': begin_date, 'end_date': end_date})
+        return results
+
+@register_metric()
+def tag_only_releases(self, repo_group_id, repo_id=None, period='day', begin_date=None, end_date=None):
+    """ Returns a timeseris of new tags that are considered releases
+    without an official release being published
+
+    :param repo_group_id: The repository's repo_group_id
+    :param repo_id: The repository's repo_id, defaults to None
+    :param period: To set the periodicity to 'day', 'week', 'month' or 'year', defaults to 'day'
+    :param begin_date: Specifies the begin date, defaults to '1970-1-1 00:00:00'
+    :param end_date: Specifies the end date, defaults to datetime.now()
+    :return: DataFrame of new releases/period
+    """
+    if not begin_date:
+        begin_date = '1970-1-1'
+    if not end_date:
+        end_date = datetime.datetime.now().strftime('%Y-%m-%d')
+
+    if not repo_id:
+        releases_SQL = s.sql.text("""
+            SELECT
+                res.repo_name,
+                res.release_id,
+                res.release_name,
+                res.release_author,
+                res.release_created_at,
+                res.release_tag_name,
+                COUNT(res)
+            FROM (
+                SELECT
+                    releases.*
+                    repo.repo_name
+                FROM
+                    releases LEFT JOIN repo ON releases.repo_id = repo.repo_id
+                WHERE
+                    repo.repo_id in (SELECT repo_id FROM repo WHERE repo_group_id=:repo_group_id )
+                    AND releases.tag_only = True
+            ) as res
+            GROUP BY releases.repo_id, releases.release_id
+            ORDER BY releases.release_published_at DESC
+        """)
+
+        results = pd.read_sql(releases_SQL, self.database,
+                              params={'period': period, 'repo_group_id': repo_group_id,
+                                      'begin_date': begin_date, 'end_date': end_date })
+        return results
+
+    else:
+        releases_SQL = s.sql.text("""
+            SELECT
+                repo.repo_name,
+                releases.release_id,
+                releases.release_name,
+                releases.release_author,
+                releases.release_created_at,
+                releases.release_tag_name,
+                COUNT(releases)
+            FROM
+                releases LEFT JOIN repo ON releases.repo_id = repo.repo_id
+            WHERE releases.tag_only = True
+            GROUP BY repo.repo_id, releases.release_id
+            ORDER BY releases.release_published_at DESC
+        """)
+
+        results = pd.read_sql(releases_SQL, self.database,
                               params={'period': period, 'repo_id': repo_id,
                                       'begin_date': begin_date, 'end_date': end_date})
         return results

--- a/workers/release_worker/release_worker.py
+++ b/workers/release_worker/release_worker.py
@@ -37,7 +37,65 @@ class ReleaseWorker(Worker):
         self.tool_version = '1.0.0'
         self.data_source = 'GitHub API'
 
-    def insert_release(self, task, repo_id, owner, release):
+    def get_release_inf(self, repo_id, release, tag_only):
+        if not tag_only:
+            name = "" if release['author']['name'] is None else release['author']['name']
+            company = "" if release['author']['company'] is None else release['author']['company']
+            author = name + '_' + company
+            release_inf = {
+                'release_id': release['id'],
+                'repo_id': repo_id,
+                'release_name': release['name'],
+                'release_description': release['description'],
+                'release_author': author,
+                'release_created_at': release['createdAt'],
+                'release_published_at': release['publishedAt'],
+                'release_updated_at': release['updatedAt'],
+                'release_is_draft': release['isDraft'],
+                'release_is_prerelease': release['isPrerelease'],
+                'release_tag_name': release['tagName'],
+                'release_url': release['url'],
+                'tag_only': tag_only,
+                'tool_source': self.tool_source,
+                'tool_version': self.tool_version,
+                'data_source': self.data_source
+            }
+        else:
+            if 'tagger' in release['target']:
+                if 'name' in release['target']['tagger']:
+                    name = release['target']['tagger']['name']
+                else:
+                    name = ""
+                if 'email' in release['target']['tagger']:
+                    email = '_' + release['target']['tagger']['email']
+                else:
+                    email = ""
+                author = name + email
+                if 'date' in release['target']['tagger']:
+                    date = release['target']['tagger']['date']
+                else:
+                    date = ""
+            else:
+                author = ""
+                date = ""
+            release_inf = {
+                'release_id': release['id'],
+                'repo_id': repo_id,
+                'release_name': release['name'],
+                'release_author': author,
+                'release_tag_name': release['name'],
+                'tag_only': tag_only,
+                'tool_source': self.tool_source,
+                'tool_version': self.tool_version,
+                'data_source': self.data_source
+            }
+            if date:
+                release_inf['release_created_at'] = date
+
+        return release_inf
+
+
+    def insert_release(self, task, repo_id, owner, release, tag_only = False):
 
         # Get current table values
         release_id_data_sql = s.sql.text("""
@@ -49,28 +107,9 @@ class ReleaseWorker(Worker):
         release_id_data = pd.read_sql(release_id_data_sql, self.db, params={'repo_id': repo_id})
         release_id_data = release_id_data.apply(lambda x: x.str.strip())
 
-        name = "" if release['author']['name'] is None else release['author']['name']
-        company = "" if release['author']['company'] is None else release['author']['company']
-        author = name+'_'+company
         # Put all data together in format of the table
         self.logger.info(f'Inserting release for repo with id:{repo_id}, owner:{owner}, release name:{release["name"]}\n')
-        release_inf = {
-            'release_id': release['id'],
-            'repo_id': repo_id,
-            'release_name': release['name'],
-            'release_description': release['description'],
-            'release_author': author,
-            'release_created_at': release['createdAt'],
-            'release_published_at': release['publishedAt'],
-            'release_updated_at': release['updatedAt'],
-            'release_is_draft': release['isDraft'],
-            'release_is_prerelease': release['isPrerelease'],
-            'release_tag_name': release['tagName'],
-            'release_url': release['url'],
-            'tool_source': self.tool_source,
-            'tool_version': self.tool_version,
-            'data_source': self.data_source
-        }
+        release_inf = self.get_release_inf(repo_id, release, tag_only)
 
         if release_id_data.size > 0 and release['id'] in release_id_data.values:
             result = self.db.execute(self.releases_table.update().where(
@@ -88,7 +127,64 @@ class ReleaseWorker(Worker):
         self.register_task_completion(task, repo_id, "releases")
         return
 
-    def releases_model(self, task, repo_id):
+    def get_query(self, owner, repo, tag_only):
+        if not tag_only:
+            query = """
+                {
+                    repository(owner:"%s", name:"%s"){
+                        id
+                        releases(orderBy: {field: CREATED_AT, direction: ASC}, last: %d) {
+                            edges {
+                                node {
+                                    name
+                                    publishedAt
+                                    createdAt
+                                    description
+                                    id
+                                    isDraft
+                                    isPrerelease
+                                    tagName
+                                    url
+                                    updatedAt
+                                    author {
+                                        name
+                                        company
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            """ % (owner, repo, 10)
+        else:
+            query = """
+                {
+                    repository(owner:"%s", name:"%s"){
+                        id
+                        refs(refPrefix: "refs/tags/", last: %d){
+                            edges {
+                                node {
+                                    name
+                                    id
+                                    target {
+                                        ... on Tag {
+                                            tagger {
+                                                name
+                                                email
+                                                date
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            """ % (owner, repo, 10)
+
+        return query
+
+    def fetch_data(self, task, repo_id, tag_only = False):
 
         github_url = task['given']['github_url']
 
@@ -98,33 +194,7 @@ class ReleaseWorker(Worker):
 
         url = 'https://api.github.com/graphql'
 
-        query = """
-            {
-                repository(owner:"%s", name:"%s"){
-                    id
-                    releases(orderBy: {field: CREATED_AT, direction: ASC}, last: %d) {
-                        edges {
-                            node {
-                                name
-                                publishedAt
-                                createdAt
-                                description
-                                id
-                                isDraft
-                                isPrerelease
-                                tagName
-                                url
-                                updatedAt
-                                author {
-                                    name
-                                    company
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        """ % (owner, repo, 10)
+        query = self.get_query(owner, repo, tag_only)
 
         # Hit the graphql endpoint and retry 3 times in case of failure
         num_attempts = 0
@@ -165,19 +235,41 @@ class ReleaseWorker(Worker):
             self.register_task_failure(task, repo_id, "Failed to hit endpoint: {}".format(url))
             return
 
-        self.logger.info("repository value is: {}\n".format(data))
+        data['owner'] = owner
 
+        return data
+
+
+    def releases_model(self, task, repo_id):
+
+        data = self.fetch_data(task, repo_id)
+
+        self.logger.info("repository value is: {}\n".format(data))
         if 'releases' in data:
-            if 'edges' in data['releases']:
+            if 'edges' in data['releases'] and data['releases']['edges']:
                 for n in data['releases']['edges']:
                     if 'node' in n:
                         release = n['node']
-                        self.insert_release(task, repo_id, owner, release)
+                        self.insert_release(task, repo_id, data['owner'], release)
                     else:
                         self.logger.info("There's no release to insert. Current node is not available in releases: {}\n".format(n))
+            elif 'edges' in data['releases'] and not data['releases']['edges']:
+                self.logger.info("Searching for tags instead of releases...")
+                data = self.fetch_data(task, repo_id, True)
+                self.logger.info("refs value is: {}\n".format(data))
+                if 'refs' in data:
+                    if 'edges' in data['refs']:
+                        for n in data['refs']['edges']:
+                            if 'node' in n:
+                                release = n['node']
+                                self.insert_release(task, repo_id, data['owner'], release, True)
+                            else:
+                                self.logger.info("There's no release to insert. Current node is not available in releases: {}\n".format(n))
+                    else:
+                        self.logger.info("There are no releases to insert for current repository: {}\n".format(data))
+                else:
+                    self.logger.info("There are no refs in data: {}\n".format(data))
             else:
                 self.logger.info("There are no releases to insert for current repository: {}\n".format(data))
         else:
             self.logger.info("Graphql response does not contain repository: {}\n".format(data))
-
-


### PR DESCRIPTION
This change checks for and adds tags to the `releases` table when they
are used instead of actual GitHub releases. It also adds metrics for
tag_only releases

Requires #893 to be merged first.

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>