### PR TITLE
Fix Augur process control commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ default:
 #
 #  Installation
 #
-.PHONY: install install-dev 
-.PHONY: install-spdx install-spdx-sudo install-augur-sbom 
+.PHONY: install install-dev
+.PHONY: install-spdx install-spdx-sudo install-augur-sbom
 .PHONY: clean rebuild
 install:
 	@ ./scripts/install/install.sh prod
@@ -63,12 +63,12 @@ rebuild-dev:
 #
 .PHONY: dev-start dev-stop dev monitor-frontend monitor-backend monitor frontend backend-stop backend-start backend-restart backend clean rebuild
 
-dev-start: 
+dev-start:
 	@ scripts/control/start_augur.sh
 	@ scripts/control/start_frontend.sh
 
-dev-stop: 
-	@ augur util kill
+dev-stop:
+	@ augur util stop
 	@ scripts/control/kill_frontend.sh
 
 dev: dev-stop dev-start
@@ -100,7 +100,7 @@ test-python-versions:
 #
 # Documentation
 #
-.PHONY: docs docs-view 
+.PHONY: docs docs-view
 docs:
 	@ bash -c 'cd docs/ && rm -rf build/ && make html;'
 
@@ -112,7 +112,7 @@ docs-view: docs
 # Docker Shortcuts
 # Do not use these unless you know what they mean.
 .PHONY: compose-run compose-run-database
-.PHONY: build-backend run-backend build-frontend run-frontend build-database run-database 
+.PHONY: build-backend run-backend build-frontend run-frontend build-database run-database
 
 
 compose-run:

--- a/augur/cli/run.py
+++ b/augur/cli/run.py
@@ -11,7 +11,7 @@ from gunicorn.arbiter import Arbiter
 
 from augur.housekeeper import Housekeeper
 from augur.server import Server
-from augur.cli.util import kill_processes
+from augur.cli.util import stop_processes
 from augur.application import Application
 
 logger = logging.getLogger("augur")
@@ -27,7 +27,7 @@ def cli(disable_housekeeper, skip_cleanup):
     logger.info("Augur application initialized")
     if not skip_cleanup:
         logger.debug("Cleaning up old Augur processes...")
-        kill_processes()
+        stop_processes()
         time.sleep(2)
     else:
         logger.debug("Skipping process cleanup")

--- a/augur/cli/util.py
+++ b/augur/cli/util.py
@@ -42,39 +42,54 @@ def export_env(config):
     export_file.close()
     env_file.close()
 
-@cli.command('kill')
-@initialize_logging
-def cli_kill_processes():
-    """
-    Terminates all currently running backend Augur processes, including any workers. Will only work in a virtual environment.    
-    """
+def _stop_processes_handler(attach_handler=False):
+    if attach_handler is True:
+        _logger = logging.getLogger("augur")
+    else:
+        _logger = logger
     processes = get_augur_processes()
     if processes != []:
         for process in processes:
             if process.pid != os.getpid():
-                logger.info(f"Killing process {process.pid}")
+                logger.info(f"Stopping process {process.pid}")
                 try:
                     process.send_signal(signal.SIGTERM)
                 except psutil.NoSuchProcess as e:
                     pass
 
+@cli.command('stop')
+@initialize_logging
+def cli_stop_processes():
+    """
+    Terminates all currently running backend Augur processes, including any workers. Will only work in a virtual environment.
+    """
+    _stop_processes_handler()
+
+
+def stop_processes():
+    _stop_processes_handler(attach_handler=True)
+
+@cli.command('kill')
+@initialize_logging
 def kill_processes():
-    logger = logging.getLogger("augur")
+    """
+    Terminates all currently running backend Augur processes, including any workers. Will only work in a virtual environment.
+    """
     processes = get_augur_processes()
     if processes != []:
         for process in processes:
             if process.pid != os.getpid():
                 logger.info(f"Killing process {process.pid}")
                 try:
-                    process.send_signal(signal.SIGTERM)
+                    process.send_signal(signal.SIGKILL)
                 except psutil.NoSuchProcess as e:
-                    logger.warning(e)
+                    pass
 
 @cli.command('list',)
 @initialize_logging
 def list_processes():
     """
-    Outputs the name and process ID (PID) of all currently running backend Augur processes, including any workers. Will only work in a virtual environment.    
+    Outputs the name and process ID (PID) of all currently running backend Augur processes, including any workers. Will only work in a virtual environment.
     """
     processes = get_augur_processes()
     for process in processes:

--- a/augur/cli/util.py
+++ b/augur/cli/util.py
@@ -7,7 +7,6 @@ import os
 import signal
 import logging
 from subprocess import call, run
-import time
 
 import psutil
 import click
@@ -53,28 +52,9 @@ def cli_kill_processes():
     if processes != []:
         for process in processes:
             if process.pid != os.getpid():
-                logger.info(f"Terminating process {process.pid}")
-                try:
-                    process.send_signal(signal.SIGTERM)
-                    logger.info(f"sending SIGTERM Signal to {process.pid}")
-                except psutil.NoSuchProcess as e:
-                    pass
-
-            logger.info(f"Waiting to check if processes terminated.")
-
-    time.sleep(15)
-    logger.info(f"Checking on process termination.")
-
-    processes = get_augur_processes()
-
-    if processes != []:
-        for process in processes:
-
-            if process.pid != os.getpid():
                 logger.info(f"Killing process {process.pid}")
                 try:
-                    process.send_signal(signal.SIGKILL)
-                    logger.info(f"sending SIGKILL Signal to {process.pid}")
+                    process.send_signal(signal.SIGTERM)
                 except psutil.NoSuchProcess as e:
                     pass
 
@@ -84,29 +64,11 @@ def kill_processes():
     if processes != []:
         for process in processes:
             if process.pid != os.getpid():
-                logger.info(f"Terminating process {process.pid}")
+                logger.info(f"Killing process {process.pid}")
                 try:
                     process.send_signal(signal.SIGTERM)
-                    logger.info(f"sending SIGTERM Signal to {process.pid}")
                 except psutil.NoSuchProcess as e:
                     logger.warning(e)
-            logger.info(f"Waiting to check if processes terminated.")
-
-    time.sleep(15)
-    logger.info(f"Checking on process termination.")
-
-    processes = get_augur_processes()
-
-    if processes != []:
-        for process in processes:
-            if process.pid != os.getpid():
-                logger.info(f"Killing process {process.pid}")
-                logger.info(f"Killing process {process.pid}")
-                try:
-                    process.send_signal(signal.SIGKILL)
-                    logger.info(f"sending SIGKILL Signal to {process.pid}")
-                except psutil.NoSuchProcess as e:
-                    pass
 
 @cli.command('list',)
 @initialize_logging

--- a/docs/source/getting-started/command-line-interface/util.rst
+++ b/docs/source/getting-started/command-line-interface/util.rst
@@ -58,28 +58,28 @@ Example usage::
   $ augur util kill
 
   # successful output looks like:
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33607
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33775
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33776
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33777
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33778
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33780
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33781
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33782
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33783
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33784
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33785
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33786
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33787
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33788
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33789
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33790
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33792
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33793
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33794
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33795
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33798
-  > CLI: [util.cli_kill_processes] [INFO] Killing process 33962
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33607
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33775
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33776
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33777
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33778
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33780
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33781
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33782
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33783
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33784
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33785
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33786
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33787
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33788
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33789
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33790
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33792
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33793
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33794
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33795
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33798
+  > CLI: [util.cli_stop_processes] [INFO] Killing process 33962
 
 ``list``
 ---------

--- a/docs/source/getting-started/command-line-interface/util.rst
+++ b/docs/source/getting-started/command-line-interface/util.rst
@@ -48,14 +48,14 @@ Example usage::
   AUGUR_DB_USER="your_db_user"
   AUGUR_DB_PASSWORD="your_db_password"
 
-``kill``
+``stop``
 ---------
-Terminates all currently running backend Augur processes, including any workers. Will only work in a virtual environment.
+Gracefully terminates all currently running backend Augur processes, including any workers. Will only work in a virtual environment.
 
 Example usage::
 
   # to stop the server and workers
-  $ augur util kill
+  $ augur util stop
 
   # successful output looks like:
   > CLI: [util.cli_stop_processes] [INFO] Killing process 33607
@@ -80,6 +80,23 @@ Example usage::
   > CLI: [util.cli_stop_processes] [INFO] Killing process 33795
   > CLI: [util.cli_stop_processes] [INFO] Killing process 33798
   > CLI: [util.cli_stop_processes] [INFO] Killing process 33962
+
+``kill``
+---------
+Forcefully terminates all currently running backend Augur processes, including any workers, by using ``SIGKILL``. Will only work in a virtual environment.
+
+Example usage::
+
+  # to stop the server and workers
+  $ augur util kill
+
+  # successful output looks like:
+  > CLI: [util.kill_processes] [INFO] Killing process 87340
+  > CLI: [util.kill_processes] [INFO] Killing process 87573
+  > CLI: [util.kill_processes] [INFO] Killing process 87574
+  > CLI: [util.kill_processes] [INFO] Killing process 87575
+  > CLI: [util.kill_processes] [INFO] Killing process 87576
+
 
 ``list``
 ---------


### PR DESCRIPTION
At somepoint in the summer, a patch was introduced that introduced a 15 second wait time to the `augur util kill` command that occured after the first attempt to gracefully stop the process with `SIGTERM`, after which it would attempt to kill all the process with `SIGKILL`. While this fallback makes sense, it in inadvertently introduced this artifical 15 second wait time to the startup of the main server. This was due to poor design during the initial implementation, which copied code blocks that should have been refactored. The 15 second delay was added to both of these code blocks, one of which was used in `augur run`, thus causing the slowdown.

This was fixed by refactoring out the copied code blocks to a singular underlying method call, removing the 15 second wait altogether, and exposing a new command as well changing the meaning of an existing one.

The `augur util stop` command was added, which will attempt to gracefully terminate any existing Augur process. This was how `augur util kill` previously behaved; `augur util kill` will now send a `SIGKILL` signal instead of a `SIGTERM`, in order to forcefully halt the execution of the process. This should only be used when Augur has crashed hard, and is not responding to attempts to use `augur util stop`.

There is further refactoring to be done, but this is better than where it was before!