### PR TITLE
Update default config file location

### DIFF
--- a/augur/cli/run.py
+++ b/augur/cli/run.py
@@ -25,6 +25,7 @@ def cli(disable_housekeeper, skip_cleanup):
     """
     augur_app = Application()
     logger.info("Augur application initialized")
+    logger.info(f"Using config file: {augur_app.config.config_file_location}")
     if not skip_cleanup:
         logger.debug("Cleaning up old Augur processes...")
         stop_processes()
@@ -98,7 +99,6 @@ def exit(augur_app, worker_processes, master):
         if master is not None:
             logger.debug("Shutting down Gunicorn server")
             master.halt()
-            master = None
 
         logger.info("Shutdown complete")
         sys.exit(0)

--- a/augur/logging.py
+++ b/augur/logging.py
@@ -3,7 +3,7 @@ import logging.config
 import logging.handlers
 from logging import FileHandler, StreamHandler, Formatter
 from multiprocessing import Process, Queue, Event, current_process
-from time import sleep 
+from time import sleep
 import os
 from pathlib import Path
 import atexit
@@ -98,7 +98,6 @@ class AugurLogging():
         if disable_logs:
             self._disable_all_logging()
 
-
     def _disable_all_logging(self):
         for logger in ["augur", "augur.application", "augur.housekeeper", "augur.config", "augur.cli", "root"]:
             lg = logging.getLogger(logger)
@@ -142,7 +141,6 @@ class AugurLogging():
         self._configure_logfiles()
         self._configure_cli_logger()
         self._configure_gunicorn_logging()
-        logger.debug("Loggers are fully configured")
 
     def _configure_logfiles(self):
         self.logfile_config = {

--- a/docs/source/development-guide/installation.rst
+++ b/docs/source/development-guide/installation.rst
@@ -14,10 +14,10 @@ However, during the course of development, you might find that you need to reset
 
 More information about Augur's Docker images can be found `here <../docker/docker.html>`_. If you're new to our Docker process, we recommend following the `introduction section <../docker/toc.html>`_ first.
 
-Installing the source code
+Installing from source
 ----------------------------
 
-The process for installing Augur's source code for development is essentially the same as detailed in the `installation <../getting-started/installation.html>`_ section of the Getting Started guide. 
+The process for installing Augur's source code for development is essentially the same as detailed in the `installation <../getting-started/installation.html>`_ section of the Getting Started guide.
 
 **However**, when running the installation script, use the following command instead:
 
@@ -25,15 +25,16 @@ The process for installing Augur's source code for development is essentially th
 
    $ make install-dev
 
-This will install a few extra dependencies for testing and documentation, as well as install all the Python packages in `edit mode <https://pip-python3.readthedocs.io/en/latest/reference/pip_install.html#editable-installs>`_. 
-This essentially means you will not have to run ``pip install .`` everytime you make a change to the backend.
+This will install a few extra dependencies for testing and documentation, as well as install all the Python packages in `editable mode <https://pip-python3.readthedocs.io/en/latest/reference/pip_install.html#editable-installs>`_. This means you will not have to reinstall the package everytime you make a change to the Python source code.
+
+This command will also create your ``augur.config.json`` file in the root of your cloned source code directory **instead of** the default location in ``$HOME/.augur/``. This is purely for convenience sake, as it will allow you to open this file in your text editor with all the other source code files, and also allows you to have multiple developer installations of Augur on the same machine if needed. If Augur finds a config file in both the root of the cloned directory AND in the default location, it will always use the one in the root of the cloned directory.
 
 .. note::
-    You can still use ``make clean`` to get rid of the installed binaries if something we wrong and you want to try again.
+    You can still use ``make clean`` to get rid of the installed binaries if something went wrong and you want to try again.
 
 Conclusion
 -----------
 
-Like I said, it's pretty similar. For (optional) further reading, the `Makefile <make/toc.html>`_ documentation and the `Creating a Metric guide <create-a-metric/toc.html>`_ are good places to start.
+All in all, it's pretty similar. For further reading, the `Makefile <make/toc.html>`_ documentation and the `Creating a Metric guide <create-a-metric/toc.html>`_ are good places to start.
 
 Happy hacking!

--- a/docs/source/getting-started/collecting-data.rst
+++ b/docs/source/getting-started/collecting-data.rst
@@ -21,7 +21,7 @@ There are a few workers that ship ready to collect out of the box:
 - ``linux_badge_worker`` (collects `CII badging <https://bestpractices.coreinfrastructure.org/en>`_ data from the CII API)
 - ``insight_worker`` (queries Augur's metrics API to find interesting anomalies in the collected data)
 
-All worker configuration options are found in the ``Workers`` block of the ``augur.config.json`` file (which you generated at the end of the previous section) with each worker having its own subsection with same title as the the worker's name.
+All worker configuration options are found in the ``Workers`` block of the ``augur.config.json`` file (which was generated for you at the end of the previous section). This file is located at ``$HOME/.augur/augur.config.json``. Each worker has its own subsection with same title as the the worker's name.
 
 A full configuration file reference can be found on the next page, but we recommend leaving the defaults and only changing them when necessary; read on for more on how to make sure your workers are properly configured.
 
@@ -51,7 +51,7 @@ Next up are the configuration options specific to each worker (but some workers 
 ``insight_worker``
 ::::::::::::::::::
 
-We recommend leaving the defaults in place for the insight worker unless you interested in other metrics, or anomalies for a different time period. 
+We recommend leaving the defaults in place for the insight worker unless you interested in other metrics, or anomalies for a different time period.
 
 - ``training_days``, which specifies the date range that the ``insight_worker`` should use as its baseline for the statistical comparison. Defaults to ``365``, meaning that the worker will identify metrics that have had anomalies compared to their values over the course of the past year, starting at the current date.
 
@@ -66,15 +66,15 @@ We recommend leaving the defaults in place for the insight worker unless you int
         'endpoint_name_1': 'field_2_of_endpoint',
         'endpoint_name_2': 'field_1_of_endpoint',
         ...
-    } 
+    }
 
     # defaults to the following
 
     {
-        "issues-new": "issues", 
-        "code-changes": "commit_count", 
-        "code-changes-lines": "added", 
-        "reviews": "pull_requests", 
+        "issues-new": "issues",
+        "code-changes": "commit_count",
+        "code-changes-lines": "added",
+        "reviews": "pull_requests",
         "contributors-new": "new_contributors"
     }
 
@@ -114,7 +114,7 @@ If you're using the Docker container, you can use the `provided UI <../docker/us
 Running collections
 --------------------
 
-Congratuations! At this point you (hopefully) have a fully functioning and configured Augur instance. 
+Congratuations! At this point you (hopefully) have a fully functioning and configured Augur instance.
 
 After you've loaded your repos, you're ready for your first collection run. We recommend running only the default workers first to gather the initial data. If you're collecting data for a lot of repositories, or repositories with a lot of data, we recommend increasing the number of ``github_workers`` and ``pull_request_workers``.
 

--- a/metadata.py
+++ b/metadata.py
@@ -4,8 +4,8 @@ __url__ = "https://github.com/chaoss/augur"
 
 __short_description__ = "Python 3 package for free/libre and open-source software community metrics & data collection"
 
-__version__ = "0.13.0"
-__release__ = "v0.13.0"
+__version__ = "0.13.1"
+__release__ = "v0.13.1"
 
 __license__ = "MIT"
 __copyright__ = "CHAOSS & Augurlabs 2020"

--- a/scripts/install/config.sh
+++ b/scripts/install/config.sh
@@ -4,6 +4,8 @@ PS3="
 Please type the number corresponding to your selection and then press the Enter/Return key.
 Your choice: "
 
+target=$1
+
 function get_api_key_and_repo_path() {
   echo
   echo "Please provide a valid GitHub API key."
@@ -91,7 +93,14 @@ function save_credentials() {
   echo "**********************************"
   echo
 
-  augur configure generate --db_name $db_name --db_host $host --db_port $port --db_user $db_user --db_password $password --github_api_key $github_api_key --gitlab_api_key $gitlab_api_key --facade_repo_directory $facade_repo_directory
+  cmd=( augur configure generate --db_name $db_name --db_host $host --db_port $port --db_user $db_user --db_password $password --github_api_key $github_api_key --gitlab_api_key $gitlab_api_key --facade_repo_directory $facade_repo_directory )
+
+  if [[ $target == *"dev"* ]]; then
+    cmd+=( --write-to-src )
+  fi
+
+  "${cmd[@]}"
+
   augur db check-pgpass
 
 }
@@ -105,6 +114,7 @@ function create_db_schema() {
     echo "**********************************"
     echo
 }
+
 
 echo
 echo "**********************************"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -33,9 +33,9 @@ if [[ ! -e augur.config.json ]]; then
 else
   read -r -p "We noticed you have a config file already. Would you like to overwrite it with a new one? [Y/n] " response
   case "$response" in
-      [yY][eE][sS]|[yY]) 
+      [yY][eE][sS]|[yY])
           echo "Generating a config file..."
-          scripts/install/config.sh
+          scripts/install/config.sh $target
           echo
           ;;
       *)


### PR DESCRIPTION
Currently, on all branches, using `augur configure generate` (the augur lib command to create a config file) behaves in an undesirable way if installed using `make install`. The issue is that after running `augur configure generate`, if you used `make install` to install Augur, your config file is not written to root of your cloned source code directory. It is instead written to the `site-packages/augur/` folder that lives with your Python binary inside your virtualenv folder. The reason that it writes to this location is due to how I implemented the config generation script. The script uses a package-level variable called `ROOT_AUGUR_DIRECTORY` to determine the location of the root of the file currently that is currently running; when installed in non-editable mode (without using the `-e` flag, like in `make install`), `pip` will copy ONLY the files defined in your `MANIFEST.in` from your cloned source code directory (if that's what you're installing) into that `site-packages` folder; **these are the files that are "running" when using augur installed in non-editable mode** - that is, without `-e`.

However, when installing the package in editable mode with `-e` (like `pip install -e .` in `make install-dev`), the files are **not** copied into that folder. Instead, some stuff happens behind the scenes, and `pip` links the contents of your local cloned directory to the `site-packages` folder; this is what allows you to make changes, save, and then run the commands again. That means when we use `install-dev`, **these are the files that are running when we execute augur commands. This is why the augur.config.json file is always installed to your cloned source code directory; that's the "root" of the currently running Augur binary.

There's a very important caveat to using `make install`, however; _it has no way of knowing where you installed the binary from_. This means it has _no way of installing the config file to your cloned source code directory_. In fact, it's not even guranteed that the source is on your machine; all the other packages you install with `pip` like `pandas` only have the files in their `MANIFEST.in` copied as well. If we want the config file to only ever be in one location, then this is problem; it can't be in the source code directory like it has been. We need to pick a standard location on the file system to store the config file outside the cloned source code tree.

To this end, this patch changes the default config file location `$HOME/.augur/augur.config.json` for all production installations. However, if it detects a config file in the root Augur directory, then it will use that instead, for backwards compatibility.