### PR TITLE
Update installation logging for clarity

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -23,14 +23,14 @@ Backend
 Required:
 
 -  `GitHub Access Token <https://github.com/settings/tokens>`__ (``repo`` and all ``read`` scopes except ``enterprise``)
--  `GitLab Access Token <https://gitlab.com/profile/personal_access_tokens>`__ 
+-  `GitLab Access Token <https://gitlab.com/profile/personal_access_tokens>`__
 -  `Python 3.6 or later <https://www.python.org/downloads/>`__
 
 Our REST API & data collection workers are written in Python 3.6. We query the GitHub & GitLab API to collect data about issues, pull requests, contributors, and other information about a repository, so GitLab and GitHub access tokens are **required** for data collection.
 
 Optional:
 
--  `Go 1.12 or later <https://golang.org/doc/install>`__ 
+-  `Go 1.12 or later <https://golang.org/doc/install>`__
 
 The ``value_worker`` uses a Go package called `scc <https://github.com/boyter/scc>`_ to run COCOMO calculations.
 Once you've installed Go, follow the appropriate steps for your system to install the ``scc`` package.
@@ -63,7 +63,7 @@ after which you'll move on to the next section to configure the workers.
    $ git clone https://github.com/chaoss/augur.git
    $ cd augur/
 
-1. Create a virtual environment in a directory of your choosing. Be sure to use the correct ``python`` command for 
+1. Create a virtual environment in a directory of your choosing. Be sure to use the correct ``python`` command for
 your installation of Python 3: on most systems, this is ``python3``, but yours may differ (you can use ``python -V`` or ``python3 -V`` to check).
 
 .. code-block:: bash
@@ -92,7 +92,7 @@ your installation of Python 3: on most systems, this is ``python3``, but yours m
 
    $ make install
 
-If you think something went wrong, check the log files under ``logs/install/``. If you want to try again, you can use ``make clean`` to delete any build files before running ``make install`` again.
+If you think something went wrong, check the log files in ``logs/``. If you want to try again, you can use ``make clean`` to delete any build files before running ``make install`` again.
 
 .. note::
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -12,7 +12,7 @@ If you're running Augur on macOS, we strongly suggest adding the following line 
 macOS takes "helpful" measures to prevent Python subprocesses (which Augur uses) from forking cleanly, and setting this environment variable disables these safety measures to restore normal Python functionality.
 
 .. warning::
-  If you skip this step, you'll likely see all housekeeer jobs randomly exiting for no reason, and the Gunicorn server will not behave nicely either. Don't say we didn't warn you!
+  If you skip this step, you'll likely see all housekeeer jobs randomly exiting for no reason, and the Gunicorn server will not behave nicely either. Skip this step at your peril!
 
 
 Dependencies
@@ -55,6 +55,9 @@ after which you'll move on to the next section to configure the workers.
 
 .. note::
   Lines that start with a ``$`` denote a command to be run in an interactive terminal.
+
+.. warning::
+  Do **NOT** install or run Augur using ``sudo``. It is not required, and using it will inevitably cause some permissions trouble. Don't say we didn't warn you!
 
 0. Clone the repository and change to the newly created directory.
 

--- a/scripts/install/api_key.sh
+++ b/scripts/install/api_key.sh
@@ -20,13 +20,11 @@ echo
 if [[ $existing_api_key != *"invalid_key"* ]]; then
   read -r -p "We noticed you have an Augur API key already. Would you like to overwrite it with a new one? [Y/n] " response
   case "$response" in
-      [yY][eE][sS]|[yY]) 
+      [yY][eE][sS]|[yY])
           echo
           get_api_key
           ;;
       *)
-          echo "Skipping API key generation process and resuming installation..."
-          echo
           ;;
   esac
 else

--- a/scripts/install/backend.sh
+++ b/scripts/install/backend.sh
@@ -12,4 +12,3 @@ if [[ $target == *"prod"* ]]; then
 else
     pip install -e .[dev]
 fi
-

--- a/scripts/install/checks.sh
+++ b/scripts/install/checks.sh
@@ -4,7 +4,7 @@ if [[ -z "$VIRTUAL_ENV" ]]; then
   echo "*** We noticed you're not currently inside a virtual environment. Augur MUST be run inside a virtual environment. ***"
   read -r -p "*** Would you like us to generate a environment for you automatically? If you select no, you must create it yourself. [Y/n] " response
   case "$response" in
-      [yY][eE][sS]|[yY]) 
+      [yY][eE][sS]|[yY])
           echo
           $augur_python_command -m venv $HOME/.virtualenvs/augur_env
           echo "*** Your environment was installed to $HOME/.virtualenvs/augur_env/. Please activate your environment using your shell's appropriate command. ***"
@@ -57,9 +57,4 @@ fi
 
 if [[ ! -d logs ]]; then
     mkdir logs
-    mkdir logs/install
-fi
-
-if [[ ! -d logs/install ]]; then
-    mkdir logs/install
 fi

--- a/scripts/install/config.sh
+++ b/scripts/install/config.sh
@@ -72,7 +72,8 @@ function set_db_credentials() {
 
   read -p "Database: " db_name
   read -p "User: " db_user
-  read -p "Password: " password
+  read -s -p "Password: " password
+  echo
 
   if [[ $install_locally == 'false' ]]; then
     read -p "Host: " host

--- a/scripts/install/frontend.sh
+++ b/scripts/install/frontend.sh
@@ -22,14 +22,9 @@ function install_deps() {
 
 read -r -p "Would you like to install Augur's frontend dependencies? [Y/n] " response
 case "$response" in
-  [yY][eE][sS]|[yY]) 
+  [yY][eE][sS]|[yY])
     echo "Installing..."
-
-    if [[ ! -d logs/install ]]; then
-    mkdir logs/install
-    fi
-
-    install_deps > logs/install/frontend.log 2>&1
+    install_deps > logs/frontend-install.log
     echo "Done!"
     ;;
   *)

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -18,29 +18,24 @@ else
   echo
 fi
 
-echo "Installing the backend and its dependencies..."
-scripts/install/backend.sh $target > logs/install/backend.log 2>&1
+scripts/install/backend.sh $target 2>&1 | tee logs/backend-install.log
 echo "Done!"
 
-echo "Installing workers and their dependencies..."
-scripts/install/workers.sh $target > logs/install/workers.log 2>&1
+scripts/install/workers.sh $target 2>&1 | tee logs/workers-install.log
 echo "Done!"
 
-if [[ ! -e augur.config.json ]]; then
+if [[ ! -e augur.config.json && ! -e $HOME/.augur/augur.config.json ]]; then
   echo "No config file found. Generating..."
-  scripts/install/config.sh
-  echo
+  scripts/install/config.sh $target
 else
+  echo "file found"
   read -r -p "We noticed you have a config file already. Would you like to overwrite it with a new one? [Y/n] " response
   case "$response" in
       [yY][eE][sS]|[yY])
           echo "Generating a config file..."
           scripts/install/config.sh $target
-          echo
           ;;
       *)
-          echo "Skipping config generation process and resuming installation..."
-          echo
           ;;
   esac
 fi

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -28,7 +28,6 @@ if [[ ! -e augur.config.json && ! -e $HOME/.augur/augur.config.json ]]; then
   echo "No config file found. Generating..."
   scripts/install/config.sh $target
 else
-  echo "file found"
   read -r -p "We noticed you have a config file already. Would you like to overwrite it with a new one? [Y/n] " response
   case "$response" in
       [yY][eE][sS]|[yY])


### PR DESCRIPTION
## Changelog

This patch:

- updates the installation process to write the all logs (including errors) to both `stdout` and to the `logs/` directory
- hides user input when entering their database password during the installation process
- adds a warning in the documentation to not use `sudo` when running or installing Augur