### PR TITLE
Dev release schema patch

### DIFF
--- a/schema/create_schema.sql
+++ b/schema/create_schema.sql
@@ -25,4 +25,5 @@
 \i schema/generate/21-schema_update_23.sql
 \i schema/generate/22-schema_update_24.sql
 \i schema/generate/23-schema_update_25.sql
+\i schema/generate/24-schema_update_26.sql 
 

--- a/schema/generate/24-schema_update_26.sql
+++ b/schema/generate/24-schema_update_26.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "augur_data"."releases" ALTER COLUMN "release_id" TYPE char(64) COLLATE "pg_catalog"."default" USING "release_id"::char(64);
+
+ALTER TABLE "augur_data"."releases" ALTER COLUMN "release_description" TYPE varchar COLLATE "pg_catalog"."default";
+
+ALTER TABLE "augur_data"."releases" ADD COLUMN "tag_only" bool;

--- a/schema/generate/24-schema_update_26.sql
+++ b/schema/generate/24-schema_update_26.sql
@@ -3,3 +3,5 @@ ALTER TABLE "augur_data"."releases" ALTER COLUMN "release_id" TYPE char(64) COLL
 ALTER TABLE "augur_data"."releases" ALTER COLUMN "release_description" TYPE varchar COLLATE "pg_catalog"."default";
 
 ALTER TABLE "augur_data"."releases" ADD COLUMN "tag_only" bool;
+
+update "augur_operations"."augur_settings" set value = 26 where setting = 'augur_data_version'; 


### PR DESCRIPTION
Adds the tags to the schema creation, which was missed during testing because a new contributor didn't know to include that in the patch. 