### PR TITLE
git.sh script is needed for large collections (500+ repos) to accomod…

### DIFF
--- a/scripts/install/git.sh
+++ b/scripts/install/git.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 git config --global diff.renameLimit 200000
-git config --global credential.helper cache
-git config --global credential.helper 'cache --timeout=9999999999999'
+git config --global credential.helper store

--- a/scripts/install/git.sh
+++ b/scripts/install/git.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+git config --global diff.renameLimit 200000
+git config --global credential.helper cache
+git config --global credential.helper 'cache --timeout=9999999999999'


### PR DESCRIPTION
git.sh script is needed for large collections (500+ repos) to accomodate large scale refactoring and repos that are removed, due to platform behavior when we attempt to clone a repo that no longer exists. Long term, error handling in Facade, and addressing 2 open issues related to repository org changes, repository additions in orgs, and repository deletion will fix this issue