### PR TITLE
Issue_worker ' quote ' issue 

### DIFF
--- a/workers/gitlab_issues_worker/gitlab_issues_worker.py
+++ b/workers/gitlab_issues_worker/gitlab_issues_worker.py
@@ -5,6 +5,7 @@ from multiprocessing import Process, Queue
 import pandas as pd
 import sqlalchemy as s
 from workers.worker_base import Worker
+from urllib.parse import urlparse, quote
 
 
 class GitLabIssuesWorker(Worker):


### PR DESCRIPTION
For the Issue _worker problem 
```
File "/Users/gogginsS/github/chaoss/augur-dev/workers/gitlab_issues_worker/gitlab_issues_worker.py", line 51, in gitlab_issues_model
 url_encoded_format_project_address = quote(owner + '/' + repo, safe='')
 NameError: name 'quote' is not defined
```
I found out that we did not import ` quote ` from ` urllib.parse `   
So I just added the import Statement and I believe it should work.