### PR TITLE
Change source of where docker pulls images back to expected hosting site

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   backend:
-    image: augurlabs/augur_backend
+    image: augurlabs/augur:backend
     build: 
       context: .
       dockerfile: ./util/docker/backend/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   backend:
-    image: isaacmilarky/augur_backend
+    image: augurlabs/augur_backend
     build: 
       context: .
       dockerfile: ./util/docker/backend/Dockerfile


### PR DESCRIPTION
Current docker image is now hosted on augurlabs' dockerhub page.