### PR TITLE
Paginate endpoint can now stagger insertions to insert a certain amount at a time to the database.

### DIFF
--- a/workers/pull_request_worker/pull_request_worker.py
+++ b/workers/pull_request_worker/pull_request_worker.py
@@ -394,8 +394,6 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
         }
 
         #Use a parent method in order to iterate through pull request pages
-        #TODO: Make it do a db insert every ~500 records or so.
-
         #Define a method to pass paginate_endpoint so that prs can be inserted incrementally
 
         def pk_source_increment_insert(inc_source_prs, action_map):

--- a/workers/pull_request_worker/pull_request_worker.py
+++ b/workers/pull_request_worker/pull_request_worker.py
@@ -480,7 +480,7 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
                 return
 
             if self.deep_collection:
-                source_data = source_prs['all']
+                source_data = inc_source_prs['all']
 
             # Merge source data to inserted data to have access to inserted primary keys
 
@@ -586,6 +586,10 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
 
         pk_source_prs = self.enrich_data_primary_keys(source_data, self.pull_requests_table,
             gh_merge_fields, augur_merge_fields)
+        
+        pk_source_prs += self.pk_source_prs
+
+        self.pk_source_prs = []
 
         return pk_source_prs
 

--- a/workers/pull_request_worker/pull_request_worker.py
+++ b/workers/pull_request_worker/pull_request_worker.py
@@ -54,6 +54,9 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
         self.tool_version = '1.0.0'
         self.data_source = 'GitHub API'
 
+        #Needs to be an attribute of the class for incremental database insert using paginate_endpoint
+        self.pk_source_prs = None
+
     def graphql_paginate(self, query, data_subjects, before_parameters=None):
         """ Paginate a GitHub GraphQL query backwards
 
@@ -392,6 +395,87 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
 
         #Use a parent method in order to iterate through pull request pages
         #TODO: Make it do a db insert every ~500 records or so.
+
+        #Define a method to pass paginate_endpoint so that prs can be inserted incrementally
+
+        def pk_source_increment_insert(inc_source_prs, action_map):
+
+
+            prs_insert = [
+            {
+                'repo_id': self.repo_id,
+                'pr_url': pr['url'],
+                'pr_src_id': pr['id'],
+                'pr_src_node_id': None,
+                'pr_html_url': pr['html_url'],
+                'pr_diff_url': pr['diff_url'],
+                'pr_patch_url': pr['patch_url'],
+                'pr_issue_url': pr['issue_url'],
+                'pr_augur_issue_id': None,
+                'pr_src_number': pr['number'],
+                'pr_src_state': pr['state'],
+                'pr_src_locked': pr['locked'],
+                'pr_src_title': pr['title'],
+                'pr_augur_contributor_id': pr['cntrb_id'],
+                'pr_body': pr['body'],
+                'pr_created_at': pr['created_at'],
+                'pr_updated_at': pr['updated_at'],
+                'pr_closed_at': pr['closed_at'],
+                'pr_merged_at': pr['merged_at'],
+                'pr_merge_commit_sha': pr['merge_commit_sha'],
+                'pr_teams': None,
+                'pr_milestone': None if not (
+                    pr['milestone'] and 'title' in pr['milestone']
+                ) else pr['milestone']['title'],
+                'pr_commits_url': pr['commits_url'],
+                'pr_review_comments_url': pr['review_comments_url'],
+                'pr_review_comment_url': pr['review_comment_url'],
+                'pr_comments_url': pr['comments_url'],
+                'pr_statuses_url': pr['statuses_url'],
+                'pr_meta_head_id': None,
+                'pr_meta_base_id': None,
+                'pr_src_issue_url': pr['issue_url'],
+                'pr_src_comments_url': pr['comments_url'], # NOTE: this seems redundant
+                'pr_src_review_comments_url': pr['review_comments_url'], # this too
+                'pr_src_commits_url': pr['commits_url'], # this one also seems redundant
+                'pr_src_statuses_url': pr['statuses_url'],
+                'pr_src_author_association': pr['author_association'],
+                'tool_source': self.tool_source,
+                'tool_version': self.tool_version,
+                'data_source': 'GitHub API'
+            } for pr in inc_source_prs['insert']
+            ]
+
+            #The b_pr_src_id bug comes from here
+            if len(inc_source_prs['insert']) > 0 or len(inc_source_prs['update']) > 0:
+                self.bulk_insert(
+                    self.pull_requests_table,
+                    update=inc_source_prs['update'], unique_columns=action_map['insert']['augur'],
+                    insert=prs_insert, update_columns=action_map['update']['augur']
+                )   
+
+                source_data = inc_source_prs['insert'] + inc_source_prs['update']
+
+            elif not self.deep_collection:
+                self.logger.info(
+                    "There are no prs to update, insert, or collect nested information for.\n"
+                )
+                self.register_task_completion(self.task_info, self.repo_id, 'pull_requests')
+                return
+
+            if self.deep_collection:
+                source_data = source_prs['all']
+
+            # Merge source data to inserted data to have access to inserted primary keys
+
+            gh_merge_fields = ['id']
+            augur_merge_fields = ['pr_src_id']
+
+            pk_source_prs = self.enrich_data_primary_keys(source_data, self.pull_requests_table,
+                gh_merge_fields, augur_merge_fields)
+            
+
+        
         source_prs = self.paginate_endpoint(
             pr_url, action_map=pr_action_map, table=self.pull_requests_table,
             where_clause=self.pull_requests_table.c.repo_id == self.repo_id
@@ -465,7 +549,7 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
                 update=source_prs['update'], unique_columns=pr_action_map['insert']['augur'],
                 insert=prs_insert, update_columns=pr_action_map['update']['augur']
             )
-
+            #TODO: figure out what source_data is
             source_data = source_prs['insert'] + source_prs['update']
 
         elif not self.deep_collection:

--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -1172,6 +1172,7 @@ class WorkerGitInterfaceable(Worker):
         self, url, action_map={}, table=None, where_clause=True, platform='github', in_memory=True
     ):
 
+        #Get augur columns using the action map along with the primary key
         table_values = self.db.execute(
             s.sql.select(self.get_relevant_columns(table, action_map)).where(where_clause)
         ).fetchall()
@@ -1180,10 +1181,14 @@ class WorkerGitInterfaceable(Worker):
         multiple_pages = False
         need_insertion = []
         need_update = []
+
+        #Stores sum of page data
         all_data = []
         forward_pagination = True
         backwards_activation = False
         last_page_number = -1
+
+        #Block to handle page queries and retry at least 10 times
         while True:
 
             # Multiple attempts to hit endpoint
@@ -1285,7 +1290,8 @@ class WorkerGitInterfaceable(Worker):
                     (page_number >= last_page_number and forward_pagination):
                 self.logger.info("No more pages to check, breaking from pagination.\n")
                 break
-
+            
+            #This is probably where we should insert at around ~500 at a time
             page_number = page_number + 1 if forward_pagination else page_number - 1
 
         if forward_pagination:

--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -1296,7 +1296,6 @@ class WorkerGitInterfaceable(Worker):
             #makes sure that stagger is enabled, we have an insertion method, and the insertion happens every 500 pages or so.
             if stagger and insertion_method != None and page_number % insertion_threshold == 0:
                 #call insertion method passed as argument.
-                #clear the data from memory and avoid duplicate insertions.
                 staggered_source_prs = {
                     'insert' : need_insertion,
                     'update' : need_update,
@@ -1306,6 +1305,7 @@ class WorkerGitInterfaceable(Worker):
                 #Use the method the subclass needs in order to insert the data.
                 insertion_method(staggered_source_prs,action_map)
 
+                #clear the data from memory and avoid duplicate insertions.
                 need_insertion = []
                 need_update = []
                 all_data = []

--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -1168,8 +1168,9 @@ class WorkerGitInterfaceable(Worker):
         return all_data
 
 
+    #insertion_method and stagger are arguments that allow paginate_endpoint to insert at around ~500 pages at a time.
     def paginate_endpoint(
-        self, url, action_map={}, table=None, where_clause=True, platform='github', in_memory=True
+        self, url, action_map={}, table=None, where_clause=True, platform='github', in_memory=True, stagger=False, insertion_method=None 
     ):
 
         #Get augur columns using the action map along with the primary key
@@ -1292,6 +1293,14 @@ class WorkerGitInterfaceable(Worker):
                 break
             
             #This is probably where we should insert at around ~500 at a time
+            #makes sure that stagger is enabled, we have an insertion method, and the insertion happens every 500 pages or so.
+            if stagger and insertion_method != None and page_number % 500 == 0:
+                #call insertion method passed as argument.
+                #clear the data from memory and avoid duplicate insertions.
+                need_insertion = []
+                need_update = []
+                all_data = []
+
             page_number = page_number + 1 if forward_pagination else page_number - 1
 
         if forward_pagination:


### PR DESCRIPTION
 I made it so that the pull request worker can stagger its insertion into the database when paginating through pull requests.