### PR TITLE
Added error handling for a type error caused when the Github Worker tries to bulk insert. 

### DIFF
--- a/workers/worker_persistance.py
+++ b/workers/worker_persistance.py
@@ -761,6 +761,7 @@ class Persistant():
 
                     sql = 'COPY {} ({}) FROM STDIN WITH CSV'.format(
                         table_name, columns)
+                    #This causes the github worker to throw an error with pandas
                     cur.copy_expert(sql=sql, file=s_buf)
 
             df = pd.DataFrame(insert)


### PR DESCRIPTION
This should get rid of the 'bigint' conversion errors thrown by psycopg2. I was not able to replicate the issue after these changes.