### PR TITLE
docker patch

### DIFF
--- a/util/docker/backend/Dockerfile
+++ b/util/docker/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
         git \
         gcc \
         python3-pip \
-        postgresql-client 
+        postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 5000


### PR DESCRIPTION
Needed a backslash after installing postgresql client. Added. 