### PR TITLE
Added more specificity and detail to the documentation

### DIFF
--- a/docs/source/deployment/nginx-configuration.rst
+++ b/docs/source/deployment/nginx-configuration.rst
@@ -24,7 +24,7 @@ Your Augur instance must be compiled with publicly accessible domain that the fr
 	{
 	    "Server": {
 	        "cache_expire": 3600,
-	        "host": "you.domain.tld",
+	        "host": "subdomain.domain.tld",
 	        "port": "5000",
 	        "workers": 8
 	    }
@@ -123,11 +123,11 @@ This file will be located in your `/etc/nginx/sites-enabled` directory on most l
 		        listen 80;
 		        server_name  <<your server subdomain.domain.tld>>;
 
-		        root /home/sean/github/<<augur-instance-home>>/frontend/dist;
+		        root /home/user/.../<<augur-instance-home>>/frontend/dist;
 		        index index.html index.htm;
 
 		        location / {
-		        root /home/sean/github/augur-census/frontend/dist;
+		        root /home/user/.../<<augur-instance-home>>/frontend/dist;
 		        try_files $uri $uri/ /index.html;
 		        }
 
@@ -137,7 +137,7 @@ This file will be located in your `/etc/nginx/sites-enabled` directory on most l
 		#        }
 
 		        location /api_docs/ {
-		        root /home/sean/github/augur-census/frontend/public;
+		        root /home/user/.../<<augur-instance-home>>/frontend/dist;
 		        index index.html;
 		        }
 

--- a/docs/source/getting-started/frontend.rst
+++ b/docs/source/getting-started/frontend.rst
@@ -1,7 +1,7 @@
 Augur's Frontend
 =================
 
-To compile Augur's frontend for deployment in a production environment (i.e., behind an nginx server), you must first run `augur config init-frontend` from within your python virtual environment. You must then enter Augur's home directory and run `npm install`, and then `npm run build`. After that, follow the instructions for configuring Augur behind Nginx. 
+To compile Augur's frontend for deployment in a production environment (i.e., behind an nginx server), you must first run `augur config init-frontend` from within your python virtual environment. You must then enter Augur's home directory and run `npm install`, and then `npm run build` in the frontend directory. After that, follow the instructions for configuring Augur behind Nginx. 
 
 Augur's frontend source code can be found at ``<root_augur_directory>/frontend/src/``. It uses Vue.js as its primary architecture framework, and Vega/Vega Lite for its visualizations. It's configured via the ``frontend.config.json`` file in ``<root_augur_directory>/frontend/``.
 


### PR DESCRIPTION
Added more details in the documentation. First, more detail in the "Augur's Frontend" section so new users don't get confused which directory to run npm commands in. Second, in the "Web Server Configuration" section making the directories more general. Additionally, lines 130 & 140 were a bit obscure on whether they needed to be replaced as well.

Signed-off-by: Sean Brennan <brennansean6@gmail.com>