### PR TITLE
Fixed Go Breaking the Docker Build 

### DIFF
--- a/scripts/docker/install-go.sh
+++ b/scripts/docker/install-go.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# install Go
+installGo() (
+    cd "$(mktemp -d)"
+    wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+)
+installGo
+export PATH=$PATH:/usr/local/go/bin

--- a/scripts/install/workers.sh
+++ b/scripts/install/workers.sh
@@ -43,16 +43,3 @@ do
 
 done
 
-
-
-if [ -d "$HOME/scorecard" ]; then
-  echo " Scorecard already exists, skipping cloning ..."
-else
-  echo "Cloning OSSF Scorecard to generate scorecard data ..."
-  git clone https://github.com/ossf/scorecard $HOME/scorecard
-  CURRENT_DIR=$PWD;
-  cd $HOME/scorecard;
-  go build;
-  echo "scorecard build done"
-  cd $CURRENT_DIR
-fi

--- a/scripts/install/workers.sh
+++ b/scripts/install/workers.sh
@@ -43,7 +43,7 @@ do
 
 done
 
-go env -w GO111MODULE=auto
+export PATH=$PATH:/usr/local/go/bin
 
 if [ -d "$HOME/scorecard" ]; then
   echo " Scorecard already exists, skipping cloning ..."

--- a/scripts/install/workers.sh
+++ b/scripts/install/workers.sh
@@ -43,3 +43,16 @@ do
 
 done
 
+go env -w GO111MODULE=auto
+
+if [ -d "$HOME/scorecard" ]; then
+  echo " Scorecard already exists, skipping cloning ..."
+else
+  echo "Cloning OSSF Scorecard to generate scorecard data ..."
+  git clone https://github.com/ossf/scorecard $HOME/scorecard
+  CURRENT_DIR=$PWD;
+  cd $HOME/scorecard;
+  go build;
+  echo "scorecard build done"
+  cd $CURRENT_DIR
+fi

--- a/util/docker/backend/Dockerfile
+++ b/util/docker/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
         git \
         gcc \
         python3-pip \
-        golang \
+        wget \
         postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
@@ -29,13 +29,10 @@ COPY ./schema/ schema/
 
 COPY ./util/docker/backend/backend.docker.config.json .
 
-# TODO: fix install script because currently the go module reqs fail and in turn make the build fail?
-# Could be something else but I don't know what else? 
-
-#Might want to set these up in differant RUN statements.
 RUN set -x \
     && pip install .
 
+RUN ./scripts/docker/install-go.sh
 RUN ./scripts/install/workers.sh 
 RUN augur config init --rc-config-file /augur/backend.docker.config.json \
     && mkdir -p repos/ logs/

--- a/util/docker/backend/Dockerfile
+++ b/util/docker/backend/Dockerfile
@@ -12,7 +12,8 @@ RUN set -x \
         git \
         gcc \
         python3-pip \
-        postgresql-client 
+        golang \
+        postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 5000
@@ -27,6 +28,11 @@ COPY ./workers/ workers/
 COPY ./schema/ schema/
 
 COPY ./util/docker/backend/backend.docker.config.json .
+
+# TODO: fix install script because currently the go module reqs fail and in turn make the build fail?
+# Could be something else but I don't know what else? 
+
+#Might want to set these up in differant RUN statements.
 RUN set -x \
     && pip install . \
     && ./scripts/install/workers.sh \

--- a/util/docker/backend/Dockerfile
+++ b/util/docker/backend/Dockerfile
@@ -34,9 +34,10 @@ COPY ./util/docker/backend/backend.docker.config.json .
 
 #Might want to set these up in differant RUN statements.
 RUN set -x \
-    && pip install . \
-    && ./scripts/install/workers.sh \
-    && augur config init --rc-config-file /augur/backend.docker.config.json \
+    && pip install .
+
+RUN ./scripts/install/workers.sh 
+RUN augur config init --rc-config-file /augur/backend.docker.config.json \
     && mkdir -p repos/ logs/
 
 COPY ./util/docker/backend/entrypoint.sh /


### PR DESCRIPTION
The containers run Debian 10 which is great except Debian's go package is very out of date. I decided to install it with a bash script instead of apt and it works fine now. The issue had to do with it breaking the scorecard build. 