### PR TITLE
Fixed edge case causing ValueErrors

### DIFF
--- a/workers/github_worker/github_worker.py
+++ b/workers/github_worker/github_worker.py
@@ -95,6 +95,8 @@ class GitHubWorker(WorkerGitInterfaceable):
                         }
                     }, prefix='user.'
                 )
+            else:
+                self.logger.info("Contributor enrichment is not needed, no inserts in action map.")
             
             issues_insert = [
                 {

--- a/workers/github_worker/github_worker.py
+++ b/workers/github_worker/github_worker.py
@@ -84,7 +84,9 @@ class GitHubWorker(WorkerGitInterfaceable):
                     and isinstance(issue['pull_request'], dict) and 'url' in issue['pull_request']
                 )
             
-            try:
+            #This is sending empty data to enrich_cntrb_id, fix with check.
+            #The problem happens when ['insert'] is empty but ['all'] is not.
+            if len(inc_source_issues['insert']) > 0:  
                 inc_source_issues['insert'] = self.enrich_cntrb_id(
                     inc_source_issues['insert'], 'user.login', action_map_additions={
                         'insert': {
@@ -93,9 +95,7 @@ class GitHubWorker(WorkerGitInterfaceable):
                         }
                     }, prefix='user.'
                 )
-            except ValueError:
-                self.logger.info(f"Enrich contrib data is empty for {inc_source_issues['insert']}, the empty field is the user login.")
-
+            
             issues_insert = [
                 {
                     'repo_id': self.repo_id,
@@ -168,6 +168,7 @@ class GitHubWorker(WorkerGitInterfaceable):
 
         #Use the increment insert method in order to do the 
         #remaining pages of the paginated endpoint that weren't inserted inside the paginate_endpoint method
+        #empty data is checked for in the method so it's not needed outside of it. 
         pk_source_issues_increment_insert(source_issues,action_map)
 
         pk_source_issues = self.pk_source_issues

--- a/workers/pull_request_worker/pull_request_worker.py
+++ b/workers/pull_request_worker/pull_request_worker.py
@@ -409,15 +409,16 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
 
             #self.logger.info(f"inc_source_prs is: {inc_source_prs} and the action map is {action_map}...")
 
-            #This is sending empty data to enrich_cntrb_id
-            inc_source_prs['insert'] = self.enrich_cntrb_id(
-                inc_source_prs['insert'], 'user.login', action_map_additions={
-                    'insert': {
-                        'source': ['user.node_id'],
-                        'augur': ['gh_node_id']
-                    }
-                }, prefix='user.'
-            )            
+            #This is sending empty data to enrich_cntrb_id, fix with check 
+            if len(inc_source_prs['insert']) > 0:    
+                inc_source_prs['insert'] = self.enrich_cntrb_id(
+                    inc_source_prs['insert'], 'user.login', action_map_additions={
+                        'insert': {
+                            'source': ['user.node_id'],
+                            'augur': ['gh_node_id']
+                        }
+                    }, prefix='user.'
+                )            
             
             
 

--- a/workers/pull_request_worker/pull_request_worker.py
+++ b/workers/pull_request_worker/pull_request_worker.py
@@ -418,7 +418,9 @@ class GitHubPullRequestWorker(WorkerGitInterfaceable):
                             'augur': ['gh_node_id']
                         }
                     }, prefix='user.'
-                )            
+                )
+            else:
+                self.logger.info("Contributor enrichment is not needed, no inserts in action map.")            
             
             
 


### PR DESCRIPTION
Fixed edge case with bulk insertions. I didn't make the bug happen but my changes in the bulk insert made it happen way more often. The insertion method checks to see if source_issues['all'] isn't empty but not if source_issues['insert'] is empty. So when it tried to enrich_cntrb_id source_issues['insert'] was empty causing a ValueError.