### PR TITLE
Added support for alternate identifiers for source data when enriching contributor.

### DIFF
--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -286,10 +286,11 @@ class WorkerGitInterfaceable(Worker):
 
             self.logger.info(f"Enriching {index} of {len(source_data)}")
 
-            gh_user_ids = []
+
+            user_unique_ids = []
             for row in table_values_cntrb:
               try:
-                gh_user_ids.append(row['gh_user_id'])
+                user_unique_ids.append(row['gh_user_id'])
               except Exception as e:
                 self.logger.info(f"Error adding gh_user_id: {e}. Row: {row}")
 
@@ -307,7 +308,7 @@ class WorkerGitInterfaceable(Worker):
 
             #self.logger.info(f"cntrb logins length: {len(cntrb_logins)}")
             #if user.id is in the database then there is no need to add the contributor
-            if data[f'{prefix}id'] in gh_user_ids:
+            if data[f'{prefix}id'] in user_unique_ids:
 
                 self.logger.info("{} found in database".format(data[f'{prefix}id']))
 

--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -270,12 +270,9 @@ class WorkerGitInterfaceable(Worker):
             s.sql.select(self.get_relevant_columns(self.contributors_table,cntrb_action_map))
         ).fetchall()
 
-        self.logger.info(f"table_values_cntrb type: {type(table_values_cntrb)}")
-        self.logger.info(f"table_values_cntrb keys: {table_values_cntrb[0].keys()}")
-
         source_data = expanded_source_df.to_dict(orient='records')
 
-        self.logger.info(f"source_data type: {type(source_data)}")
+        self.logger.info(f"table_values_cntrb keys: {table_values_cntrb[0].keys()}")
         self.logger.info(f"source_data keys: {source_data[0].keys()}")
 
         #We can't use this because of worker collisions
@@ -306,10 +303,10 @@ class WorkerGitInterfaceable(Worker):
                     user_unique_ids.append(row['gh_node_id'])
                   except Exception as e:
                     self.logger.info(f"Error adding gh_node_id: {e}. Row: {row}")
-                
+
 
             #self.logger.info(f"gh_user_ids: {gh_user_ids}")
-            
+
             # self.logger.info(f"Users gh_user_id: {data['user.id']}")
             # in_user_ids = False
             # if data['user.id'] in gh_user_ids:
@@ -318,7 +315,7 @@ class WorkerGitInterfaceable(Worker):
 
             # self.logger.info(f"table_values_cntrb len: {len(table_values_cntrb)}")
 
-            #Deal with if data 
+            #Deal with if data
 
             #See if we can check using the user.id
             source_data_id = None
@@ -326,7 +323,7 @@ class WorkerGitInterfaceable(Worker):
                 source_data_id = data[f'{prefix}id']
             except KeyError:
                 source_data_id = data[f'{prefix}node_id']
-            
+
 
 
             #if user.id is in the database then there is no need to add the contributor
@@ -350,7 +347,7 @@ class WorkerGitInterfaceable(Worker):
             #contributor is not in the database
             else:
 
-              
+
               self.logger.info("{} not in database, making api call".format(source_data_id))
               self.logger.info("login: {}".format(data[f'{prefix}login']))
 
@@ -422,8 +419,8 @@ class WorkerGitInterfaceable(Worker):
               except Exception as e:
                 self.logger.info(f"Contributor was unable to be added to table! Attempting to get cntrb_id from table anyway because of possible collision. Error: {e}")
 
-              
-              #Get the contributor id from the newly inserted contributor.  
+
+              #Get the contributor id from the newly inserted contributor.
               cntrb_id_row = self.db.execute(
                   s.sql.select(self.get_relevant_columns(self.contributors_table,cntrb_action_map)).where(
                     self.contributors_table.c.gh_user_id==cntrb["gh_user_id"]


### PR DESCRIPTION
Different types of data have different identifiers so now if the source data doesn't have a user.id the method will instead use the user.node_id to determine whether or not the user is in the contributors table. We can't just check one key for all of them either since some data doesn't have a user.node_id and some data doesn't have a user.id.