### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -74,7 +74,7 @@ paths:
             type: array
       tags:
       - utility
-  /repo-groups/:repo_group_id/Committers:
+  /repo-groups/:repo_group_id/committers:
     get:
       description: 'Number of persons opening an issue for the first time. '
       externalDocs:


### PR DESCRIPTION
The documentation for the committers indicated that the endpoint should be called with http://localhost:5000/api/unstable/repo-groups/1/Committers but the correct url is http://localhost:5000/api/unstable/repo-groups/1/committers. The only difference being the c in committers