### PR TITLE
Api Docs Fixes

### DIFF
--- a/augur/routes/util.py
+++ b/augur/routes/util.py
@@ -94,7 +94,7 @@ def create_routes(server):
                         status=200,
                         mimetype="application/json")
 
-    @server.app.route('/{}/owner/<owner>/name/<repo>'.format(server.api_version))
+    @server.app.route('/{}/owner/<owner>/repo/<repo>'.format(server.api_version))
     def get_repo_by_git_name(owner, repo):
 
         get_repo_by_git_name_sql = s.sql.text("""
@@ -191,7 +191,7 @@ def create_routes(server):
                     repo_name
                 FROM issues JOIN repo ON issues.repo_id = repo.repo_id, issue_events
                 WHERE issues.repo_id = :repo_id
-                AND issues.pull_request IS NULL 
+                AND issues.pull_request IS NULL
                 AND issues.issue_id = issue_events.issue_id
                 GROUP BY issues.issue_id, repo_name
                 ORDER by OPEN_DAY DESC

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -99,7 +99,7 @@ paths:
   /owner/:owner/repo/:repo:
     get:
       description: Get the repo_group_id and repo_id of a particular repo.
-      operationId: Get Repo by Owner and Repo
+      operationId: Get Repo by Owner and Repo Name
       responses:
         '200':
           description: OK
@@ -813,6 +813,45 @@ paths:
       - description: Repository Group ID
         in: path
         name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                file_without_licenses:
+                  description: 'Example: True'
+                  type: string
+                name:
+                  description: 'Example: ActorServiceRegistry'
+                  type: string
+                number_of_license:
+                  description: 'Example: 2'
+                  type: integer
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_id/license-count:
+    get:
+      description: 'The declared software package license (fetched from CII Best Practices
+        badging data). '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md
+      operationId: License Count (Repo)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
         schema:
           type: string
         type: string
@@ -4240,7 +4279,7 @@ paths:
       - value
 
 
-      
+
   #visualization endpoints
   /contributor_reports/new_contributors_bar/:
     get:

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -1600,6 +1600,35 @@ paths:
   /repo-groups/:repo_group_id/abandoned-issues:
     get:
       description: List of abandoned issues (last updated &gt;= 1 year ago)
+      operationId: Abandoned Issues (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                issue_id:
+                  description: 'Example: 125071'
+                  type: integer
+                repo_id:
+                  description: 'Example: 22004'
+                  type: integer
+                updated_at:
+                  description: 'Example: 2017-10-30T06:52:19.000Z'
+                  type: string
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_id/abandoned-issues:
+    get:
+      description: List of abandoned issues (last updated &gt;= 1 year ago)
       operationId: Abandoned Issues (Repo)
       parameters:
       - description: Repository Group ID
@@ -1633,6 +1662,47 @@ paths:
       tags:
       - experimental
   /repo-groups/:repo_group_id/lines-changed-by-author:
+    get:
+      description: 'Count of closed issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
+      operationId: Lines Changed by Author (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                additions:
+                  description: 'Example: 25611'
+                  type: integer
+                affiliation:
+                  description: 'Example: NULL'
+                  type: string
+                cmt_author_date:
+                  description: 'Example: 2004-11-24'
+                  type: string
+                cmt_author_email:
+                  description: 'Example: david@loudthinking.com'
+                  type: string
+                deletions:
+                  description: 'Example: 296'
+                  type: integer
+                whitespace:
+                  description: 'Example: 5279'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_id/lines-changed-by-author:
     get:
       description: 'Count of closed issues. '
       externalDocs:

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -285,6 +285,550 @@ paths:
             type: array
       tags:
       - risk
+  /repo-groups/:repo_group_id/average-issue-resolution-time:
+    get:
+      description: 'The average issue resolution time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Average Issue Resolution Time (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                avg_issue_resolution_time:
+                  description: 'Example: 1413 days 15:39:48'
+                  type: string
+                repo_id:
+                  description: 'Example: 21353'
+                  type: integer
+                repo_name:
+                  description: 'Example: open_id_authentication'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/cii-best-practices-badge:
+    get:
+      description: 'The CII Best Practices Badge level. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
+      operationId: CII Best Practices Badge (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                badge_level:
+                  description: 'Example: in_progress'
+                  type: string
+                repo_id:
+                  description: 'Example: 21252'
+                  type: integer
+                repo_name:
+                  description: 'Example: php-legal-licenses'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/fork-count:
+    get:
+      description: 'Fork count. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Fork Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                forks:
+                  description: 'Example: 4'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21364'
+                  type: integer
+                repo_name:
+                  description: 'Example: irs_process_scripts'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/forks:
+    get:
+      description: 'A time series of fork count. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Forks (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-07-03T23:26:42.000Z'
+                  type: string
+                forks:
+                  description: 'Example: 519'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21036'
+                  type: integer
+                repo_name:
+                  description: 'Example: jquery-ujs'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/languages:
+    get:
+      description: 'The primary language of the repository. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
+      operationId: Languages (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                primary_language:
+                  description: 'Example: Go'
+                  type: string
+                repo_id:
+                  description: 'Example: 21277'
+                  type: integer
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/license-count:
+    get:
+      description: 'The declared software package license (fetched from CII Best Practices
+        badging data). '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md
+      operationId: License Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                file_without_licenses:
+                  description: 'Example: True'
+                  type: string
+                name:
+                  description: 'Example: ActorServiceRegistry'
+                  type: string
+                number_of_license:
+                  description: 'Example: 2'
+                  type: integer
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/license-coverage:
+    get:
+      description: 'Number of persons opening an issue for the first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
+      operationId: License Coverage (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                coverage:
+                  description: 'Example: 0.373'
+                  type: string
+                license_declared_files:
+                  description: 'Example: 19'
+                  type: integer
+                name:
+                  description: 'Example: ActorServiceRegistry'
+                  type: string
+                total_files:
+                  description: 'Example: 51'
+                  type: integer
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/license-declared:
+    get:
+      description: 'Number of persons opening an issue for the first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
+      operationId: License Declared (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                name:
+                  description: 'Example: trickster'
+                  type: string
+                note:
+                  description: 'Example: '
+                  type: string
+                short_name:
+                  description: 'Example: Apache-2.0'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/average-issue-resolution-time:
+    get:
+      description: 'The average issue resolution time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Average Issue Resolution Time (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                avg_issue_resolution_time:
+                  description: 'Example: 276 days 13:54:13.2'
+                  type: string
+                repo_name:
+                  description: 'Example: maven-release'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/cii-best-practices-badge:
+    get:
+      description: 'The CII Best Practices Badge level. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
+      operationId: CII Best Practices Badge (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                badge_level:
+                  description: 'Example: passing'
+                  type: string
+                repo_name:
+                  description: 'Example: trickster'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/committers:
+    get:
+      description: 'Number of persons contributing with an accepted commit for the
+        first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/metrics/Committers.md
+      operationId: Committers (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                count:
+                  description: 'Example: 1'
+                  type: integer
+                date:
+                  description: 'Example: 2018-10-25T00:00:00.000Z'
+                  type: string
+                repo_name:
+                  description: 'Example: weasel'
+                  type: string
+                rg_name:
+                  description: 'Example: Comcast'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/fork-count:
+    get:
+      description: 'Fork count. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Fork Count (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                forks:
+                  description: 'Example: 844'
+                  type: integer
+                repo_name:
+                  description: 'Example: graphiql'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/forks:
+    get:
+      description: 'A time series of fork count. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Forks (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-07-03T23:27:42.000Z'
+                  type: string
+                forks:
+                  description: 'Example: 843'
+                  type: integer
+                repo_name:
+                  description: 'Example: graphiql'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/license-coverage:
+    get:
+      description: 'Number of persons contributing with an accepted commit for the
+        first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
+      operationId: License Coverage (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                coverage:
+                  description: 'Example: 0.347'
+                  type: string
+                license_declared_file:
+                  description: 'Example: 33'
+                  type: integer
+                repo_name:
+                  description: 'Example: zucchini'
+                  type: string
+                total_files:
+                  description: 'Example: 95'
+                  type: integer
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/license-declared:
+    get:
+      description: 'Number of persons contributing with an accepted commit for the
+        first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
+      operationId: License Declared (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                name:
+                  description: 'Example: trickster'
+                  type: string
+                note:
+                  description: 'Example: '
+                  type: string
+                short_name:
+                  description: 'Example: Apache-2.0'
+                  type: string
+            type: array
+      tags:
+      - risk
   /repo-groups/:repo_group_id/abandoned-issues:
     get:
       description: List of abandoned issues (last updated &gt;= 1 year ago)
@@ -534,70 +1078,6 @@ paths:
             type: array
       tags:
       - experimental
-  /repo-groups/:repo_group_id/average-issue-resolution-time:
-    get:
-      description: 'The average issue resolution time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Average Issue Resolution Time (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                avg_issue_resolution_time:
-                  description: 'Example: 1413 days 15:39:48'
-                  type: string
-                repo_id:
-                  description: 'Example: 21353'
-                  type: integer
-                repo_name:
-                  description: 'Example: open_id_authentication'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/cii-best-practices-badge:
-    get:
-      description: 'The CII Best Practices Badge level. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
-      operationId: CII Best Practices Badge (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                badge_level:
-                  description: 'Example: in_progress'
-                  type: string
-                repo_id:
-                  description: 'Example: 21252'
-                  type: integer
-                repo_name:
-                  description: 'Example: php-legal-licenses'
-                  type: string
-            type: array
-      tags:
-      - risk
   /repo-groups/:repo_group_id/closed-issues-count:
     get:
       description: 'Count of closed issues. '
@@ -863,73 +1343,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/fork-count:
-    get:
-      description: 'Fork count. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Fork Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                forks:
-                  description: 'Example: 4'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21364'
-                  type: integer
-                repo_name:
-                  description: 'Example: irs_process_scripts'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/forks:
-    get:
-      description: 'A time series of fork count. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Forks (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-07-03T23:26:42.000Z'
-                  type: string
-                forks:
-                  description: 'Example: 519'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21036'
-                  type: integer
-                repo_name:
-                  description: 'Example: jquery-ujs'
-                  type: string
-            type: array
-      tags:
-      - risk
   /repo-groups/:repo_group_id/issue-backlog:
     get:
       description: 'Number of issues currently open. '
@@ -1558,135 +1971,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/languages:
-    get:
-      description: 'The primary language of the repository. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
-      operationId: Languages (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                primary_language:
-                  description: 'Example: Go'
-                  type: string
-                repo_id:
-                  description: 'Example: 21277'
-                  type: integer
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/license-count:
-    get:
-      description: 'The declared software package license (fetched from CII Best Practices
-        badging data). '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md
-      operationId: License Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                file_without_licenses:
-                  description: 'Example: True'
-                  type: string
-                name:
-                  description: 'Example: ActorServiceRegistry'
-                  type: string
-                number_of_license:
-                  description: 'Example: 2'
-                  type: integer
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/license-coverage:
-    get:
-      description: 'Number of persons opening an issue for the first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Coverage (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                coverage:
-                  description: 'Example: 0.373'
-                  type: string
-                license_declared_files:
-                  description: 'Example: 19'
-                  type: integer
-                name:
-                  description: 'Example: ActorServiceRegistry'
-                  type: string
-                total_files:
-                  description: 'Example: 51'
-                  type: integer
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/license-declared:
-    get:
-      description: 'Number of persons opening an issue for the first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Declared (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                name:
-                  description: 'Example: trickster'
-                  type: string
-                note:
-                  description: 'Example: '
-                  type: string
-                short_name:
-                  description: 'Example: Apache-2.0'
-                  type: string
-            type: array
-      tags:
-      - risk
   /repo-groups/:repo_group_id/lines-changed-by-author:
     get:
       description: 'Count of closed issues. '
@@ -2384,76 +2668,6 @@ paths:
             type: array
       tags:
       - experimental
-  /repos/:repo_id/average-issue-resolution-time:
-    get:
-      description: 'The average issue resolution time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Average Issue Resolution Time (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                avg_issue_resolution_time:
-                  description: 'Example: 276 days 13:54:13.2'
-                  type: string
-                repo_name:
-                  description: 'Example: maven-release'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repos/:repo_id/cii-best-practices-badge:
-    get:
-      description: 'The CII Best Practices Badge level. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
-      operationId: CII Best Practices Badge (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                badge_level:
-                  description: 'Example: passing'
-                  type: string
-                repo_name:
-                  description: 'Example: trickster'
-                  type: string
-            type: array
-      tags:
-      - risk
   /repos/:repo_id/closed-issues-count:
     get:
       description: 'Count of closed issues. '
@@ -2601,66 +2815,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repos/:repo_id/committers:
-    get:
-      description: 'Number of persons contributing with an accepted commit for the
-        first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/metrics/Committers.md
-      operationId: Committers (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                count:
-                  description: 'Example: 1'
-                  type: integer
-                date:
-                  description: 'Example: 2018-10-25T00:00:00.000Z'
-                  type: string
-                repo_name:
-                  description: 'Example: weasel'
-                  type: string
-                rg_name:
-                  description: 'Example: Comcast'
-                  type: string
-            type: array
-      tags:
-      - risk
   /repos/:repo_id/contributors:
     get:
       description: 'List of contributors and their contributions. '
@@ -2785,79 +2939,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repos/:repo_id/fork-count:
-    get:
-      description: 'Fork count. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Fork Count (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                forks:
-                  description: 'Example: 844'
-                  type: integer
-                repo_name:
-                  description: 'Example: graphiql'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repos/:repo_id/forks:
-    get:
-      description: 'A time series of fork count. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Forks (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-07-03T23:27:42.000Z'
-                  type: string
-                forks:
-                  description: 'Example: 843'
-                  type: integer
-                repo_name:
-                  description: 'Example: graphiql'
-                  type: string
-            type: array
-      tags:
-      - risk
   /repos/:repo_id/issue-backlog:
     get:
       description: 'Time since an issue is proposed until it is closed. '
@@ -3500,87 +3581,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repos/:repo_id/license-coverage:
-    get:
-      description: 'Number of persons contributing with an accepted commit for the
-        first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Coverage (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                coverage:
-                  description: 'Example: 0.347'
-                  type: string
-                license_declared_file:
-                  description: 'Example: 33'
-                  type: integer
-                repo_name:
-                  description: 'Example: zucchini'
-                  type: string
-                total_files:
-                  description: 'Example: 95'
-                  type: integer
-            type: array
-      tags:
-      - risk
-  /repos/:repo_id/license-declared:
-    get:
-      description: 'Number of persons contributing with an accepted commit for the
-        first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Declared (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                name:
-                  description: 'Example: trickster'
-                  type: string
-                note:
-                  description: 'Example: '
-                  type: string
-                short_name:
-                  description: 'Example: Apache-2.0'
-                  type: string
-            type: array
-      tags:
-      - risk
   /repos/:repo_id/pull-request-acceptance-rate:
     get:
       description: Timeseries of pull request acceptance rate (expressed as the ratio

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -235,6 +235,140 @@ paths:
             type: array
       tags:
       - utility
+  /repo-groups/:repo_group_id/average-issue-resolution-time:
+    get:
+      description: 'The average issue resolution time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Average Issue Resolution Time (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                avg_issue_resolution_time:
+                  description: 'Example: 1413 days 15:39:48'
+                  type: string
+                repo_id:
+                  description: 'Example: 21353'
+                  type: integer
+                repo_name:
+                  description: 'Example: open_id_authentication'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/average-issue-resolution-time:
+    get:
+      description: 'The average issue resolution time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Average Issue Resolution Time (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                avg_issue_resolution_time:
+                  description: 'Example: 276 days 13:54:13.2'
+                  type: string
+                repo_name:
+                  description: 'Example: maven-release'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/cii-best-practices-badge:
+    get:
+      description: 'The CII Best Practices Badge level. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
+      operationId: CII Best Practices Badge (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                badge_level:
+                  description: 'Example: in_progress'
+                  type: string
+                repo_id:
+                  description: 'Example: 21252'
+                  type: integer
+                repo_name:
+                  description: 'Example: php-legal-licenses'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repos/:repo_id/cii-best-practices-badge:
+    get:
+      description: 'The CII Best Practices Badge level. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
+      operationId: CII Best Practices Badge (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                badge_level:
+                  description: 'Example: passing'
+                  type: string
+                repo_name:
+                  description: 'Example: trickster'
+                  type: string
+            type: array
+      tags:
+      - risk
   /repo-groups/:repo_group_id/committers:
     get:
       description: 'Number of persons opening an issue for the first time. '
@@ -281,336 +415,6 @@ paths:
                   type: string
                 rg_name:
                   description: 'Example: Comcast'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/average-issue-resolution-time:
-    get:
-      description: 'The average issue resolution time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Average Issue Resolution Time (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                avg_issue_resolution_time:
-                  description: 'Example: 1413 days 15:39:48'
-                  type: string
-                repo_id:
-                  description: 'Example: 21353'
-                  type: integer
-                repo_name:
-                  description: 'Example: open_id_authentication'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/cii-best-practices-badge:
-    get:
-      description: 'The CII Best Practices Badge level. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
-      operationId: CII Best Practices Badge (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                badge_level:
-                  description: 'Example: in_progress'
-                  type: string
-                repo_id:
-                  description: 'Example: 21252'
-                  type: integer
-                repo_name:
-                  description: 'Example: php-legal-licenses'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/fork-count:
-    get:
-      description: 'Fork count. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Fork Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                forks:
-                  description: 'Example: 4'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21364'
-                  type: integer
-                repo_name:
-                  description: 'Example: irs_process_scripts'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/forks:
-    get:
-      description: 'A time series of fork count. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Forks (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-07-03T23:26:42.000Z'
-                  type: string
-                forks:
-                  description: 'Example: 519'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21036'
-                  type: integer
-                repo_name:
-                  description: 'Example: jquery-ujs'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/languages:
-    get:
-      description: 'The primary language of the repository. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
-      operationId: Languages (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                primary_language:
-                  description: 'Example: Go'
-                  type: string
-                repo_id:
-                  description: 'Example: 21277'
-                  type: integer
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/license-count:
-    get:
-      description: 'The declared software package license (fetched from CII Best Practices
-        badging data). '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md
-      operationId: License Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                file_without_licenses:
-                  description: 'Example: True'
-                  type: string
-                name:
-                  description: 'Example: ActorServiceRegistry'
-                  type: string
-                number_of_license:
-                  description: 'Example: 2'
-                  type: integer
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/license-coverage:
-    get:
-      description: 'Number of persons opening an issue for the first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Coverage (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                coverage:
-                  description: 'Example: 0.373'
-                  type: string
-                license_declared_files:
-                  description: 'Example: 19'
-                  type: integer
-                name:
-                  description: 'Example: ActorServiceRegistry'
-                  type: string
-                total_files:
-                  description: 'Example: 51'
-                  type: integer
-            type: array
-      tags:
-      - risk
-  /repo-groups/:repo_group_id/license-declared:
-    get:
-      description: 'Number of persons opening an issue for the first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Declared (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                name:
-                  description: 'Example: trickster'
-                  type: string
-                note:
-                  description: 'Example: '
-                  type: string
-                short_name:
-                  description: 'Example: Apache-2.0'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repos/:repo_id/average-issue-resolution-time:
-    get:
-      description: 'The average issue resolution time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
-      operationId: Average Issue Resolution Time (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                avg_issue_resolution_time:
-                  description: 'Example: 276 days 13:54:13.2'
-                  type: string
-                repo_name:
-                  description: 'Example: maven-release'
-                  type: string
-            type: array
-      tags:
-      - risk
-  /repos/:repo_id/cii-best-practices-badge:
-    get:
-      description: 'The CII Best Practices Badge level. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
-      operationId: CII Best Practices Badge (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                badge_level:
-                  description: 'Example: passing'
-                  type: string
-                repo_name:
-                  description: 'Example: trickster'
                   type: string
             type: array
       tags:
@@ -675,6 +479,38 @@ paths:
             type: array
       tags:
       - risk
+  /repo-groups/:repo_group_id/fork-count:
+    get:
+      description: 'Fork count. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Fork Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                forks:
+                  description: 'Example: 4'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21364'
+                  type: integer
+                repo_name:
+                  description: 'Example: irs_process_scripts'
+                  type: string
+            type: array
+      tags:
+      - risk
   /repos/:repo_id/fork-count:
     get:
       description: 'Fork count. '
@@ -706,6 +542,41 @@ paths:
                   type: integer
                 repo_name:
                   description: 'Example: graphiql'
+                  type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/forks:
+    get:
+      description: 'A time series of fork count. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
+      operationId: Forks (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-07-03T23:26:42.000Z'
+                  type: string
+                forks:
+                  description: 'Example: 519'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21036'
+                  type: integer
+                repo_name:
+                  description: 'Example: jquery-ujs'
                   type: string
             type: array
       tags:
@@ -745,6 +616,41 @@ paths:
                 repo_name:
                   description: 'Example: graphiql'
                   type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/license-coverage:
+    get:
+      description: 'Number of persons opening an issue for the first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
+      operationId: License Coverage (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                coverage:
+                  description: 'Example: 0.373'
+                  type: string
+                license_declared_files:
+                  description: 'Example: 19'
+                  type: integer
+                name:
+                  description: 'Example: ActorServiceRegistry'
+                  type: string
+                total_files:
+                  description: 'Example: 51'
+                  type: integer
             type: array
       tags:
       - risk
@@ -790,6 +696,38 @@ paths:
             type: array
       tags:
       - risk
+  /repo-groups/:repo_group_id/license-declared:
+    get:
+      description: 'Number of persons opening an issue for the first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
+      operationId: License Declared (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                name:
+                  description: 'Example: trickster'
+                  type: string
+                note:
+                  description: 'Example: '
+                  type: string
+                short_name:
+                  description: 'Example: Apache-2.0'
+                  type: string
+            type: array
+      tags:
+      - risk
   /repos/:repo_id/license-declared:
     get:
       description: 'Number of persons contributing with an accepted commit for the
@@ -826,6 +764,68 @@ paths:
                 short_name:
                   description: 'Example: Apache-2.0'
                   type: string
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/languages:
+    get:
+      description: 'The primary language of the repository. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
+      operationId: Languages (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                primary_language:
+                  description: 'Example: Go'
+                  type: string
+                repo_id:
+                  description: 'Example: 21277'
+                  type: integer
+            type: array
+      tags:
+      - risk
+  /repo-groups/:repo_group_id/license-count:
+    get:
+      description: 'The declared software package license (fetched from CII Best Practices
+        badging data). '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md
+      operationId: License Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                file_without_licenses:
+                  description: 'Example: True'
+                  type: string
+                name:
+                  description: 'Example: ActorServiceRegistry'
+                  type: string
+                number_of_license:
+                  description: 'Example: 2'
+                  type: integer
             type: array
       tags:
       - risk

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -801,6 +801,41 @@ paths:
             type: array
       tags:
       - risk
+  /repo-groups/:repo_id/languages:
+    get:
+      description: 'The primary language of the repository. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
+      operationId: Languages (Repo)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                primary_language:
+                  description: 'Example: Go'
+                  type: string
+                repo_id:
+                  description: 'Example: 21277'
+                  type: integer
+            type: array
+      tags:
+      - risk
   /repo-groups/:repo_group_id/license-count:
     get:
       description: 'The declared software package license (fetched from CII Best Practices

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -1718,12 +1718,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes.md
       operationId: Code Changes (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -1830,12 +1824,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes_Lines.md
       operationId: Code Changes Lines (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -1954,12 +1942,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors.md
       operationId: Contributors (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2072,12 +2054,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
       operationId: New Contributors (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2163,12 +2139,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
       operationId: Issue Duration (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2269,12 +2239,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
       operationId: Issue Participants (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2354,12 +2318,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
       operationId: Issue Throughput (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2444,12 +2402,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_Active.md
       operationId: Issues Active (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2553,12 +2505,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
       operationId: Issues Closed (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2650,12 +2596,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-closed-resolution-duration.md
       operationId: Closed Issue Resolution Duration (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2753,12 +2693,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-first-time-closed.md
       operationId: Closed Issues New Contributors (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2862,12 +2796,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-first-time-opened.md
       operationId: New Contributors of Issues (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -2962,12 +2890,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-maintainer-response-duration.md
       operationId: Issue Response Time (Repo)
       parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3065,12 +2987,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
       operationId: Issues New (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3159,12 +3075,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-open-age.md
       operationId: Open Issue Age (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3258,12 +3168,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/pull-requests-merge-contributor-new.md
       operationId: New Contributors of Commits (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3367,12 +3271,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md
       operationId: Review Duration (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3478,12 +3376,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/reviews.md
       operationId: Reviews (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3589,12 +3481,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md
       operationId: Reviews Accepted (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3700,12 +3586,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md
       operationId: Reviews Declined (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3794,12 +3674,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/sub-projects.md
       operationId: Sub-Projects (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -3876,9 +3750,9 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
       operationId: Closed Issues Count (Repo)
       parameters:
-      - description: Repository Group ID
+      - description: Repository ID
         in: path
-        name: repo_group_id
+        name: repo_id
         schema:
           type: string
         type: string
@@ -3961,12 +3835,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md
       operationId: Number of releases (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -9,6 +9,7 @@ info:
   version: 0.12.0
 openapi: 3.0.0
 paths:
+  #utility endpoints
   /repo-groups:
     get:
       description: Get all the downloaded repo groups.
@@ -235,6 +236,10 @@ paths:
             type: array
       tags:
       - utility
+
+
+
+  #risk endpoints
   /repo-groups/:repo_group_id/average-issue-resolution-time:
     get:
       description: 'The average issue resolution time. '
@@ -829,6 +834,10 @@ paths:
             type: array
       tags:
       - risk
+
+
+
+  #experimental endpoints
   /repo-groups/:repo_group_id/aggregate-summary:
     get:
       description: Returns the current count of watchers, stars, and forks and the
@@ -1596,6 +1605,10 @@ paths:
             type: array
       tags:
       - experimental
+
+
+
+  #evolution endpoints
   /repo-groups/:repo_group_id/code-changes:
     get:
       description: 'Time series of number of commits during a certain period. '
@@ -3965,6 +3978,10 @@ paths:
             type: array
       tags:
       - evolution
+
+
+
+  #value endpoints
   /repo-groups/:repo_group_id/watchers:
     get:
       description: A time series of watchers count.
@@ -4221,6 +4238,10 @@ paths:
             type: array
       tags:
       - value
+
+
+      
+  #visualization endpoints
   /contributor_reports/new_contributors_bar/:
     get:
       description: Get bar chart of new contributor counts.

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -9,6 +9,92 @@ info:
   version: 0.12.0
 openapi: 3.0.0
 paths:
+  /repo-groups:
+    get:
+      description: Get all the downloaded repo groups.
+      operationId: Get All Repo Groups
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                data_collection_date:
+                  description: 'Example: 2019-06-05T13:36:25.000Z'
+                  type: string
+                data_source:
+                  description: 'Example: git'
+                  type: string
+                repo_group_id:
+                  description: 'Example: 20'
+                  type: integer
+                rg_description:
+                  description: 'Example: Rails Ecosystem.'
+                  type: string
+                rg_last_modified:
+                  description: 'Example: 2019-06-03T15:55:20.000Z'
+                  type: string
+                rg_name:
+                  description: 'Example: Rails'
+                  type: string
+                rg_recache:
+                  description: 'Example: 0'
+                  type: integer
+                rg_type:
+                  description: 'Example: GitHub Organization'
+                  type: string
+                rg_website:
+                  description: 'Example: '
+                  type: string
+                tool_source:
+                  description: 'Example: load'
+                  type: string
+                tool_version:
+                  description: 'Example: one'
+                  type: string
+            type: array
+      tags:
+      - utility
+  /repos:
+    get:
+      description: Get all the downloaded repos.
+      operationId: Get All Repos
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                base64_url:
+                  description: 'Example: Z2l0aHViLmNvbS9hcGFjaGUvaW5jdWJhdG9yLWFyZ3VzLmdpdA=='
+                  type: string
+                commits_all_time:
+                  description: 'Example: None'
+                  type: string
+                description:
+                  description: 'Example: None'
+                  type: string
+                issues_all_time:
+                  description: 'Example: None'
+                  type: string
+                repo_id:
+                  description: 'Example: 21996'
+                  type: integer
+                repo_name:
+                  description: 'Example: incubator-argus'
+                  type: string
+                repo_status:
+                  description: 'Example: Update'
+                  type: string
+                rg_name:
+                  description: 'Example: Apache'
+                  type: string
+                url:
+                  description: 'Example: github.com/apache/incubator-argus.git'
+                  type: string
+            type: array
+      tags:
+      - utility
   /owner/:owner/repo/:repo:
     get:
       description: Get the repo_group_id and repo_id of a particular repo.
@@ -28,10 +114,85 @@ paths:
             type: array
       tags:
       - utility
-  /repo-groups:
+  /rg-name/:rg_name/repo-name/:repo_name:
+    get:
+      description: Get the repo_group_id and repo_id of a particular repo.
+      operationId: Get Repo by Repo Group Name and Repo Name
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_git:
+                  description: 'Example: https://github.com/rails/rails.git'
+                  type: string
+                repo_group_id:
+                  description: 'Example: 20'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21000'
+                  type: integer
+            type: array
+      tags:
+      - utility
+  /rg-name/:rg_name:
+    get:
+      description: Get the repo_id of a particular repo group.
+      operationId: Get Repo by Repo Name
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_group_id:
+                  description: 'Example: 20'
+                  type: integer
+                rg_name:
+                  description: 'Example: Rails'
+                  type: string
+            type: array
+      tags:
+      - utility
+  /repo-groups/:repo_group_id/repos:
+    get:
+      description: Get all the repos in a repo group.
+      operationId: Get Repos in Repo Group
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                commits_all_time:
+                  description: 'Example: 6874'
+                  type: integer
+                description:
+                  description: 'Example: None'
+                  type: string
+                issues_all_time:
+                  description: 'Example: 81'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21326'
+                  type: integer
+                repo_name:
+                  description: 'Example: graphql-js'
+                  type: string
+                repo_status:
+                  description: 'Example: Complete'
+                  type: string
+                url:
+                  description: 'Example: https://github.com/graphql/graphql-js.git'
+                  type: string
+            type: array
+      tags:
+      - utility
+  /repo-groups/:repo_group_id/top-insights:
     get:
       description: Get all the downloaded repo groups.
-      operationId: Get All Repo Groups
+      operationId: Get Top Insights
       responses:
         '200':
           description: OK
@@ -1744,40 +1905,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/repos:
-    get:
-      description: Get all the repos in a repo group.
-      operationId: Get Repos in Repo Group
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                commits_all_time:
-                  description: 'Example: 6874'
-                  type: integer
-                description:
-                  description: 'Example: None'
-                  type: string
-                issues_all_time:
-                  description: 'Example: 81'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21326'
-                  type: integer
-                repo_name:
-                  description: 'Example: graphql-js'
-                  type: string
-                repo_status:
-                  description: 'Example: Complete'
-                  type: string
-                url:
-                  description: 'Example: https://github.com/graphql/graphql-js.git'
-                  type: string
-            type: array
-      tags:
-      - utility
   /repo-groups/:repo_group_id/review-duration:
     get:
       description: 'Time since an review/pull request is proposed until it is accepted. '
@@ -2199,46 +2326,6 @@ paths:
             type: array
       tags:
       - value
-  /repos:
-    get:
-      description: Get all the downloaded repos.
-      operationId: Get All Repos
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                base64_url:
-                  description: 'Example: Z2l0aHViLmNvbS9hcGFjaGUvaW5jdWJhdG9yLWFyZ3VzLmdpdA=='
-                  type: string
-                commits_all_time:
-                  description: 'Example: None'
-                  type: string
-                description:
-                  description: 'Example: None'
-                  type: string
-                issues_all_time:
-                  description: 'Example: None'
-                  type: string
-                repo_id:
-                  description: 'Example: 21996'
-                  type: integer
-                repo_name:
-                  description: 'Example: incubator-argus'
-                  type: string
-                repo_status:
-                  description: 'Example: Update'
-                  type: string
-                rg_name:
-                  description: 'Example: Apache'
-                  type: string
-                url:
-                  description: 'Example: github.com/apache/incubator-argus.git'
-                  type: string
-            type: array
-      tags:
-      - utility
   /repos/:repo_id/aggregate-summary:
     get:
       description: Returns the current count of watchers, stars, and forks and the
@@ -4134,93 +4221,6 @@ paths:
             type: array
       tags:
       - value
-  /rg-name/:rg_name/repo-name/:repo_name:
-    get:
-      description: Get the repo_group_id and repo_id of a particular repo.
-      operationId: Get Repo by Repo Group Name and Repo Name
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_git:
-                  description: 'Example: https://github.com/rails/rails.git'
-                  type: string
-                repo_group_id:
-                  description: 'Example: 20'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21000'
-                  type: integer
-            type: array
-      tags:
-      - utility
-  /rg-name/:rg_name:
-    get:
-      description: Get the repo_id of a particular repo group.
-      operationId: Get Repo by Repo Name
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_group_id:
-                  description: 'Example: 20'
-                  type: integer
-                rg_name:
-                  description: 'Example: Rails'
-                  type: string
-            type: array
-      tags:
-      - utility
-  /repo-groups/:repo_group_id/top-insights:
-    get:
-      description: Get all the downloaded repo groups.
-      operationId: Get Top Insights
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                data_collection_date:
-                  description: 'Example: 2019-06-05T13:36:25.000Z'
-                  type: string
-                data_source:
-                  description: 'Example: git'
-                  type: string
-                repo_group_id:
-                  description: 'Example: 20'
-                  type: integer
-                rg_description:
-                  description: 'Example: Rails Ecosystem.'
-                  type: string
-                rg_last_modified:
-                  description: 'Example: 2019-06-03T15:55:20.000Z'
-                  type: string
-                rg_name:
-                  description: 'Example: Rails'
-                  type: string
-                rg_recache:
-                  description: 'Example: 0'
-                  type: integer
-                rg_type:
-                  description: 'Example: GitHub Organization'
-                  type: string
-                rg_website:
-                  description: 'Example: '
-                  type: string
-                tool_source:
-                  description: 'Example: load'
-                  type: string
-                tool_version:
-                  description: 'Example: one'
-                  type: string
-            type: array
-      tags:
-      - utility
   /contributor_reports/new_contributors_bar/:
     get:
       description: Get bar chart of new contributor counts.

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -1628,67 +1628,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/watchers:
-    get:
-      description: A time series of watchers count.
-      operationId: Watchers (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-07-03T23:26:42.000Z'
-                  type: string
-                repo_id:
-                  description: 'Example: 21036'
-                  type: integer
-                repo_name:
-                  description: 'Example: jquery-ujs'
-                  type: string
-                watchers:
-                  description: 'Example: 60'
-                  type: integer
-            type: array
-      tags:
-      - value
-  /repo-groups/:repo_group_id/watchers-count:
-    get:
-      description: Watchers count.
-      operationId: Watchers Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_id:
-                  description: 'Example: 21039'
-                  type: integer
-                repo_name:
-                  description: 'Example: rails_xss'
-                  type: string
-                watchers:
-                  description: 'Example: 20'
-                  type: integer
-            type: array
-      tags:
-      - value
   /repo-groups/:repo_group_id/closed-issues-count:
     get:
       description: 'Count of closed issues. '
@@ -2779,67 +2718,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/stars:
-    get:
-      description: A time series of stars count.
-      operationId: Stars (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-07-03T23:23:36.000Z'
-                  type: string
-                repo_id:
-                  description: 'Example: 21491'
-                  type: integer
-                repo_name:
-                  description: 'Example: commons-io'
-                  type: string
-                stars:
-                  description: 'Example: 600'
-                  type: integer
-            type: array
-      tags:
-      - value
-  /repo-groups/:repo_group_id/stars-count:
-    get:
-      description: Stars count.
-      operationId: Stars Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_id:
-                  description: 'Example: 21364'
-                  type: integer
-                repo_name:
-                  description: 'Example: irs_process_scripts'
-                  type: string
-                stars:
-                  description: 'Example: 20'
-                  type: integer
-            type: array
-      tags:
-      - value
   /repo-groups/:repo_group_id/sub-projects:
     get:
       description: 'Number of sub-projects. '
@@ -4043,6 +3921,172 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/sub-projects:
+    get:
+      description: 'Number of sub-projects. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/sub-projects.md
+      operationId: Sub-Projects (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                sub_protject_count:
+                  description: 'Example: 2'
+                  type: integer
+            type: array
+      tags:
+      - evolution
+  /repo-groups/:repo_group_id/watchers:
+    get:
+      description: A time series of watchers count.
+      operationId: Watchers (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-07-03T23:26:42.000Z'
+                  type: string
+                repo_id:
+                  description: 'Example: 21036'
+                  type: integer
+                repo_name:
+                  description: 'Example: jquery-ujs'
+                  type: string
+                watchers:
+                  description: 'Example: 60'
+                  type: integer
+            type: array
+      tags:
+      - value
+  /repo-groups/:repo_group_id/watchers-count:
+    get:
+      description: Watchers count.
+      operationId: Watchers Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_id:
+                  description: 'Example: 21039'
+                  type: integer
+                repo_name:
+                  description: 'Example: rails_xss'
+                  type: string
+                watchers:
+                  description: 'Example: 20'
+                  type: integer
+            type: array
+      tags:
+      - value
+  /repo-groups/:repo_group_id/stars:
+    get:
+      description: A time series of stars count.
+      operationId: Stars (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-07-03T23:23:36.000Z'
+                  type: string
+                repo_id:
+                  description: 'Example: 21491'
+                  type: integer
+                repo_name:
+                  description: 'Example: commons-io'
+                  type: string
+                stars:
+                  description: 'Example: 600'
+                  type: integer
+            type: array
+      tags:
+      - value
+  /repo-groups/:repo_group_id/stars-count:
+    get:
+      description: Stars count.
+      operationId: Stars Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_id:
+                  description: 'Example: 21364'
+                  type: integer
+                repo_name:
+                  description: 'Example: irs_process_scripts'
+                  type: string
+                stars:
+                  description: 'Example: 20'
+                  type: integer
+            type: array
+      tags:
+      - value
   /repos/:repo_id/stars:
     get:
       description: A time series of stars count.
@@ -4110,50 +4154,6 @@ paths:
             type: array
       tags:
       - value
-  /repos/:repo_id/sub-projects:
-    get:
-      description: 'Number of sub-projects. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/sub-projects.md
-      operationId: Sub-Projects (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                sub_protject_count:
-                  description: 'Example: 2'
-                  type: integer
-            type: array
-      tags:
-      - evolution
   /repos/:repo_id/watchers:
     get:
       description: A time series of watchers count.

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -4163,12 +4163,6 @@ paths:
       description: A time series of watchers count.
       operationId: Watchers (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -4227,12 +4221,6 @@ paths:
       description: Watchers count.
       operationId: Watchers Count (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -4291,12 +4279,6 @@ paths:
       description: A time series of stars count.
       operationId: Stars (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -4355,12 +4337,6 @@ paths:
       description: Stars count.
       operationId: Stars Count (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -12,7 +12,7 @@ paths:
   /owner/:owner/repo/:repo:
     get:
       description: Get the repo_group_id and repo_id of a particular repo.
-      operationId: Get Repo
+      operationId: Get Repo by Owner and Repo
       responses:
         '200':
           description: OK
@@ -31,7 +31,7 @@ paths:
   /repo-groups:
     get:
       description: Get all the downloaded repo groups.
-      operationId: Repo Groups
+      operationId: Get All Repo Groups
       responses:
         '200':
           description: OK
@@ -80,7 +80,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/Committers.md
-      operationId: (Repo Group)
+      operationId: Committers (Repo Group)
       parameters:
       - description: Repository Group ID
         in: path
@@ -124,7 +124,7 @@ paths:
             type: array
       tags:
       - risk
-  /repo-groups/:repo_group_id/abandoned_issues:
+  /repo-groups/:repo_group_id/abandoned-issues:
     get:
       description: List of abandoned issues (last updated &gt;= 1 year ago)
       operationId: Abandoned Issues (Repo)
@@ -215,7 +215,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Commit Count Ranked by New Repo in Repo Group(Repo)
+      operationId: Annual Commit Count Ranked by New Repo in Repo Group (Repo)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -275,7 +275,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Commit Count Ranked by Repo in Repo Group(Repo)
+      operationId: Annual Commit Count Ranked by Repo in Repo Group (Repo)
       parameters:
       - description: Base64 version of the URL of the GitHub repository as it appears
           in the Facade DB
@@ -309,7 +309,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Lines of Code Ranked by New Repo in Repo Group(Repo)
+      operationId: Annual Lines of Code Ranked by New Repo in Repo Group (Repo)
       parameters:
       - description: Base64 version of the URL of the GitHub repository as it appears
           in the Facade DB
@@ -343,7 +343,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Lines of Code Ranked by Repo in Repo Group(Repo)
+      operationId: Annual Lines of Code Ranked by Repo in Repo Group (Repo)
       parameters:
       - description: Base64 version of the URL of the GitHub repository as it appears
           in the Facade DB
@@ -373,7 +373,7 @@ paths:
             type: array
       tags:
       - experimental
-  /repo-groups/:repo_group_id/avgerage-issue-resolution-time:
+  /repo-groups/:repo_group_id/average-issue-resolution-time:
     get:
       description: 'The average issue resolution time. '
       externalDocs:
@@ -1465,7 +1465,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Coverage(Repo Group)
+      operationId: License Coverage (Repo Group)
       parameters:
       - description: Repository Group ID
         in: path
@@ -1500,7 +1500,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Declared(Repo Group)
+      operationId: License Declared (Repo Group)
       parameters:
       - description: Repository Group ID
         in: path
@@ -1532,7 +1532,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
-      operationId: Lines Changed by Author(Repo)
+      operationId: Lines Changed by Author (Repo)
       parameters:
       - description: Repository Group ID
         in: path
@@ -1652,10 +1652,10 @@ paths:
             type: array
       tags:
       - experimental
-  /repo-groups/:repo_group_id/pull-request-closed-no-merge:
+  /repo-groups/:repo_group_id/pull-requests-closed-no-merge:
     get:
       description: Timeseries of pull request which were closed but not merged
-      operationId: Pull Request Closed but not merged(Repo)
+      operationId: Pull Request Closed but Not Merged (Repo)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -1747,7 +1747,7 @@ paths:
   /repo-groups/:repo_group_id/repos:
     get:
       description: Get all the repos in a repo group.
-      operationId: Repos in Repo Group
+      operationId: Get Repos in Repo Group
       responses:
         '200':
           description: OK
@@ -2202,7 +2202,7 @@ paths:
   /repos:
     get:
       description: Get all the downloaded repos.
-      operationId: Repos
+      operationId: Get All Repos
       responses:
         '200':
           description: OK
@@ -2521,7 +2521,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/Committers.md
-      operationId: Committers(Repo)
+      operationId: Committers (Repo)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -3420,7 +3420,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Coverage(Repo)
+      operationId: License Coverage (Repo)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -3462,7 +3462,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
-      operationId: License Declared(Repo)
+      operationId: License Declared (Repo)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -3540,10 +3540,10 @@ paths:
             type: array
       tags:
       - experimental
-  /repos/:repo_id/pull-request-closed-no-merge:
+  /repos/:repo_id/pull-requests-closed-no-merge:
     get:
       description: ''
-      operationId: Pull Request Closed but not merged(Repo)
+      operationId: Pull Request Closed but Not Merged (Repo)
       parameters:
       - description: Repository ID.
         in: path
@@ -3683,7 +3683,7 @@ paths:
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md
-      operationId: review Duration (Repo)
+      operationId: Review Duration (Repo)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -4105,7 +4105,7 @@ paths:
   /repos/:repo_id/watchers-count:
     get:
       description: Watchers count.
-      operationId: watchers Count (Repo)
+      operationId: Watchers Count (Repo)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -4137,7 +4137,7 @@ paths:
   /rg-name/:rg_name/repo-name/:repo_name:
     get:
       description: Get the repo_group_id and repo_id of a particular repo.
-      operationId: Get Repo
+      operationId: Get Repo by Repo Group Name and Repo Name
       responses:
         '200':
           description: OK
@@ -4156,10 +4156,10 @@ paths:
             type: array
       tags:
       - utility
-  /rg-names/:rg_name:
+  /rg-name/:rg_name:
     get:
       description: Get the repo_id of a particular repo group.
-      operationId: Get Repo
+      operationId: Get Repo by Repo Name
       responses:
         '200':
           description: OK
@@ -4175,10 +4175,10 @@ paths:
             type: array
       tags:
       - utility
-  /top-insights:
+  /repo-groups/:repo_group_id/top-insights:
     get:
       description: Get all the downloaded repo groups.
-      operationId: Top Insights
+      operationId: Get Top Insights
       responses:
         '200':
           description: OK

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -280,12 +280,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
       operationId: Average Issue Resolution Time (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -347,12 +341,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
       operationId: CII Best Practices Badge (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -433,12 +421,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/Committers.md
       operationId: Committers (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -524,12 +506,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
       operationId: Fork Count (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -594,12 +570,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/business-risk.md
       operationId: Forks (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -668,12 +638,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
       operationId: License Coverage (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -742,12 +706,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/metrics/License_Coverage.md
       operationId: License Declared (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -809,12 +767,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/security.md
       operationId: Languages (Repo)
       parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -878,12 +830,6 @@ paths:
         url: https://github.com/chaoss/wg-risk/blob/master/focus-areas/licensing.md
       operationId: License Count (Repo)
       parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -1596,76 +1596,6 @@ paths:
             type: array
       tags:
       - experimental
-  /repo-groups/:repo_group_id/open-issues-count:
-    get:
-      description: 'Count of open issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
-      operationId: Open Issues Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2017-09-11T00:00:00.000Z'
-                  type: string
-                open_count:
-                  description: 'Example: 1'
-                  type: integer
-                rg_name:
-                  description: 'Example: Netflix'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repo-groups/:repo_group_id/closed-issues-count:
-    get:
-      description: 'Count of closed issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
-      operationId: Closed Issues Count (Repo)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                closed_count:
-                  description: 'Example: 26'
-                  type: integer
-                date:
-                  description: 'Example: 2018-11-26T00:00:00.000Z'
-                  type: string
-                repo_id:
-                  description: 'Example: 21681'
-                  type: integer
-            type: array
-      tags:
-      - evolution
   /repo-groups/:repo_group_id/code-changes:
     get:
       description: 'Time series of number of commits during a certain period. '
@@ -1715,6 +1645,62 @@ paths:
                   type: integer
                 repo_name:
                   description: 'Example: graphql-wg'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/code-changes:
+    get:
+      description: 'Time series number of commits during a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes.md
+      operationId: Code Changes (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                commit_count:
+                  description: 'Example: 90'
+                  type: integer
+                date:
+                  description: 'Example: 2015-01-01T00:00:00.000Z'
+                  type: string
+                repo_name:
+                  description: 'Example: graphql'
                   type: string
             type: array
       tags:
@@ -1771,6 +1757,65 @@ paths:
                   type: integer
                 repo_name:
                   description: 'Example: graphql-wg'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/code-changes-lines:
+    get:
+      description: 'Time series of lines added and removed during a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes_Lines.md
+      operationId: Code Changes Lines (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                added:
+                  description: 'Example: 17613'
+                  type: integer
+                date:
+                  description: 'Example: 2015-06-01T00:00:00.000Z'
+                  type: string
+                removed:
+                  description: 'Example: 106'
+                  type: integer
+                repo_name:
+                  description: 'Example: graphql-js'
                   type: string
             type: array
       tags:
@@ -1840,6 +1885,71 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/contributors:
+    get:
+      description: 'List of contributors and their contributions. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors.md
+      operationId: Contributors (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                commit_comments:
+                  description: 'Example: 0'
+                  type: integer
+                commits:
+                  description: 'Example: 0'
+                  type: integer
+                issue_comments:
+                  description: 'Example: 0'
+                  type: integer
+                issues:
+                  description: 'Example: 2'
+                  type: integer
+                pull_request_comments:
+                  description: 'Example: 0'
+                  type: integer
+                pull_requests:
+                  description: 'Example: 0'
+                  type: integer
+                total:
+                  description: 'Example: 2'
+                  type: integer
+                user:
+                  description: 'Example: 1'
+                  type: integer
+            type: array
+      tags:
+      - evolution
   /repo-groups/:repo_group_id/contributors-new:
     get:
       description: 'Time series of number of new contributors during a certain period. '
@@ -1851,6 +1961,65 @@ paths:
       - description: Repository Group ID
         in: path
         name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2018-05-20T00:00:00.000Z'
+                  type: string
+                new_contributors:
+                  description: 'Example: 3'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21000'
+                  type: integer
+                repo_name:
+                  description: 'Example: rails'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/contributors-new:
+    get:
+      description: 'Time series of number of new contributors during a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
+      operationId: New Contributors (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
         schema:
           type: string
         type: string
@@ -1925,17 +2094,23 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/issue-duration:
+  /repos/:repo_id/issue-backlog:
     get:
       description: 'Time since an issue is proposed until it is closed. '
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
-      operationId: Issue Duration (Repo Group)
+      operationId: Issue Duration (Repo)
       parameters:
-      - description: Repository Group ID
+      - description: Repository Group ID.
         in: path
         name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
         schema:
           type: string
         type: string
@@ -1958,22 +2133,19 @@ paths:
             items:
               properties:
                 closed_at:
-                  description: 'Example: 2011-05-06T20:21:47.000Z'
+                  description: 'Example: 2011-04-14T23:27:33.000Z'
                   type: string
                 created_at:
-                  description: 'Example: 2011-05-06T20:20:05.000Z'
+                  description: 'Example: 2011-02-13T03:46:06.000Z'
                   type: string
                 duration:
-                  description: 'Example: 0 days 00:01:42.000000000'
+                  description: 'Example: 60 days 19:41:27.000000000'
                   type: string
                 issue_id:
-                  description: 'Example: 50320'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21017'
+                  description: 'Example: 50306'
                   type: integer
                 repo_name:
-                  description: 'Example: ssl_requirement'
+                  description: 'Example: exception_notification'
                   type: string
             type: array
       tags:
@@ -2028,6 +2200,59 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/issue-participants:
+    get:
+      description: 'How many persons participated in the discussion of issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
+      operationId: Issue Participants (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                created_at:
+                  description: 'Example: 2017-03-02T21:14:46.000Z'
+                  type: string
+                issue_id:
+                  description: 'Example: 50796'
+                  type: integer
+                participants:
+                  description: 'Example: 1'
+                  type: integer
+                repo_name:
+                  description: 'Example: arel'
+                  type: string
+            type: array
+      tags:
+      - evolution
   /repo-groups/:repo_group_id/issue-throughput:
     get:
       description: 'Ratio of issues closed to total issues. '
@@ -2056,6 +2281,41 @@ paths:
                   type: string
                 throughput:
                   description: 'Example: 0.819125'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/issue-throughput:
+    get:
+      description: 'Ratio of issues closed to total issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
+      operationId: Issue Throughput (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_name:
+                  description: 'Example: rails-contributors'
+                  type: string
+                throughput:
+                  description: 'Example: 0.997531'
                   type: string
             type: array
       tags:
@@ -2114,6 +2374,63 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/issues-active:
+    get:
+      description: 'Time series of number of issues that showed some activity during
+        a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_Active.md
+      operationId: Issues Active (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2011-01-01T00:00:00.000Z'
+                  type: string
+                issues:
+                  description: 'Example: 30'
+                  type: integer
+                repo_name:
+                  description: 'Example: rails'
+                  type: string
+            type: array
+      tags:
+      - evolution
   /repo-groups/:repo_group_id/issues-closed:
     get:
       description: 'Time series of number of issues closed during a certain period. '
@@ -2167,6 +2484,62 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/issues-closed:
+    get:
+      description: 'Time series of number of issues closed during a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
+      operationId: Issues Closed (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2012-01-01T00:00:00.000Z'
+                  type: string
+                issues:
+                  description: 'Example: 97'
+                  type: integer
+                repo_name:
+                  description: 'Example: incubator-pagespeed-ngx'
+                  type: string
+            type: array
+      tags:
+      - evolution
   /repo-groups/:repo_group_id/issues-closed-resolution-duration:
     get:
       description: 'Duration of time for issues to be resolved. '
@@ -2202,6 +2575,56 @@ paths:
                 issue_title:
                   description: 'Example: rm incubating word'
                   type: string
+                repo_name:
+                  description: 'Example: incubator-dubbo'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/issues-closed-resolution-duration:
+    get:
+      description: 'Duration of time for issues to be resolved. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-closed-resolution-duration.md
+      operationId: Closed Issue Resolution Duration (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                closed_at:
+                  description: 'Example: 2019-06-17T03:12:48.000Z'
+                  type: string
+                created_at:
+                  description: 'Example: 2019-05-31T07:55:44.000Z'
+                  type: string
+                diffdate:
+                  description: 'Example: 16.0'
+                  type: string
+                gh_issue_number:
+                  description: 'Example: 4223'
+                  type: integer
+                issue_title:
+                  description: 'Example: Cloud Native PR'
+                  type: string
+                repo_id:
+                  description: 'Example: 21682'
+                  type: integer
                 repo_name:
                   description: 'Example: incubator-dubbo'
                   type: string
@@ -2261,6 +2684,62 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/issues-first-time-closed:
+    get:
+      description: 'Number of persons closing an issue for the first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-first-time-closed.md
+      operationId: Closed Issues New Contributors (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                count:
+                  description: 'Example: 3'
+                  type: integer
+                issue_date:
+                  description: 'Example: 2018-05-20T00:00:00.000Z'
+                  type: string
+                repo_name:
+                  description: 'Example: rails'
+                  type: string
+            type: array
+      tags:
+      - evolution
   /repo-groups/:repo_group_id/issues-first-time-opened:
     get:
       description: 'Number of persons opening an issue for the first time. '
@@ -2314,6 +2793,62 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/issues-first-time-opened:
+    get:
+      description: 'Number of persons opening an issue for the first time. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-first-time-opened.md
+      operationId: New Contributors of Issues (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                count:
+                  description: 'Example: 3'
+                  type: integer
+                issue_date:
+                  description: 'Example: 2018-05-20T00:00:00.000Z'
+                  type: string
+                repo_name:
+                  description: 'Example: rails'
+                  type: string
+            type: array
+      tags:
+      - evolution
   /repo-groups/:repo_group_id/issues-maintainer-response-duration:
     get:
       description: 'Duration of time for issues to be resolved. '
@@ -2325,6 +2860,56 @@ paths:
       - description: Repository Group ID
         in: path
         name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                average_days_comment:
+                  description: 'Example: 27.1111111111'
+                  type: string
+                repo_id:
+                  description: 'Example: 21987'
+                  type: integer
+                repo_name:
+                  description: 'Example: qpid-proton'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/issues-maintainer-response-duration:
+    get:
+      description: 'Duration of time for issues to be resolved. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-maintainer-response-duration.md
+      operationId: Issue Response Time (Repo)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
         schema:
           type: string
         type: string
@@ -2411,6 +2996,62 @@ paths:
             type: array
       tags:
       - evolution
+  /repos/:repo_id/issues-new:
+    get:
+      description: 'Time series of number of new issues opened during a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
+      operationId: Issues New (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2015-01-01T00:00:00.000Z'
+                  type: string
+                issues:
+                  description: 'Example: 116'
+                  type: integer
+                repo_name:
+                  description: 'Example: rails'
+                  type: string
+            type: array
+      tags:
+      - evolution
   /repo-groups/:repo_group_id/issues-open-age:
     get:
       description: 'Age of open issues. '
@@ -2422,6 +3063,50 @@ paths:
       - description: Repository Group ID
         in: path
         name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2009-05-15T19:48:43.000Z'
+                  type: string
+                issue_id:
+                  description: 'Example: 38318'
+                  type: integer
+                open_date:
+                  description: 'Example: 3696'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21000'
+                  type: integer
+                repo_name:
+                  description: 'Example: rails'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/issues-open-age:
+    get:
+      description: 'Age of open issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-open-age.md
+      operationId: Open Issue Age (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
         schema:
           type: string
         type: string
@@ -2503,1099 +3188,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/review-duration:
-    get:
-      description: 'Time since an review/pull request is proposed until it is accepted. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md
-      operationId: Review Duration (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                created_at:
-                  description: 'Example: 2010-09-28T19:07:15.000Z'
-                  type: string
-                duration:
-                  description: 'Example: 0 days 22:39:44.000000000'
-                  type: string
-                merged_at:
-                  description: 'Example: 2010-09-29T17:46:59.000Z'
-                  type: string
-                pull_request_id:
-                  description: 'Example: 25386'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21035'
-                  type: integer
-                repo_name:
-                  description: 'Example: prototype-ujs'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repo-groups/:repo_group_id/reviews:
-    get:
-      description: 'Time series of number of new reviews / pull requests opened within
-        a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/reviews.md
-      operationId: Reviews (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2010-01-01T00:00:00.000Z'
-                  type: string
-                pull_requests:
-                  description: 'Example: 1'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21035'
-                  type: integer
-                repo_name:
-                  description: 'Example: prototype-ujs'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repo-groups/:repo_group_id/reviews-accepted:
-    get:
-      description: 'Time series of number of accepted reviews / pull requests opened
-        within a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md
-      operationId: Reviews Accepted (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2010-01-01T00:00:00.000Z'
-                  type: string
-                pull_requests:
-                  description: 'Example: 1'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21035'
-                  type: integer
-                repo_name:
-                  description: 'Example: prototype-ujs'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repo-groups/:repo_group_id/reviews-declined:
-    get:
-      description: 'Time series of number of declined reviews / pull requests opened
-        within a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md
-      operationId: Reviews Declined (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2010-01-01T00:00:00.000Z'
-                  type: string
-                pull_requests:
-                  description: 'Example: 1'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21035'
-                  type: integer
-                repo_name:
-                  description: 'Example: prototype-ujs'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repo-groups/:repo_group_id/sub-projects:
-    get:
-      description: 'Number of sub-projects. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/sub-projects.md
-      operationId: Sub-Projects (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                sub_protject_count:
-                  description: 'Example: 2'
-                  type: integer
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/closed-issues-count:
-    get:
-      description: 'Count of closed issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
-      operationId: Closed Issues Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                closed_count:
-                  description: 'Example: 4'
-                  type: integer
-                date:
-                  description: 'Example: 2014-06-02T00:00:00.000Z'
-                  type: string
-                rg_name:
-                  description: 'Example: Apache'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/code-changes:
-    get:
-      description: 'Time series number of commits during a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes.md
-      operationId: Code Changes (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                commit_count:
-                  description: 'Example: 90'
-                  type: integer
-                date:
-                  description: 'Example: 2015-01-01T00:00:00.000Z'
-                  type: string
-                repo_name:
-                  description: 'Example: graphql'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/code-changes-lines:
-    get:
-      description: 'Time series of lines added and removed during a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Code_Changes_Lines.md
-      operationId: Code Changes Lines (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                added:
-                  description: 'Example: 17613'
-                  type: integer
-                date:
-                  description: 'Example: 2015-06-01T00:00:00.000Z'
-                  type: string
-                removed:
-                  description: 'Example: 106'
-                  type: integer
-                repo_name:
-                  description: 'Example: graphql-js'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/contributors:
-    get:
-      description: 'List of contributors and their contributions. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors.md
-      operationId: Contributors (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                commit_comments:
-                  description: 'Example: 0'
-                  type: integer
-                commits:
-                  description: 'Example: 0'
-                  type: integer
-                issue_comments:
-                  description: 'Example: 0'
-                  type: integer
-                issues:
-                  description: 'Example: 2'
-                  type: integer
-                pull_request_comments:
-                  description: 'Example: 0'
-                  type: integer
-                pull_requests:
-                  description: 'Example: 0'
-                  type: integer
-                total:
-                  description: 'Example: 2'
-                  type: integer
-                user:
-                  description: 'Example: 1'
-                  type: integer
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/contributors-new:
-    get:
-      description: 'Time series of number of new contributors during a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
-      operationId: New Contributors (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2018-05-20T00:00:00.000Z'
-                  type: string
-                new_contributors:
-                  description: 'Example: 3'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21000'
-                  type: integer
-                repo_name:
-                  description: 'Example: rails'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issue-backlog:
-    get:
-      description: 'Time since an issue is proposed until it is closed. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
-      operationId: Issue Duration (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                closed_at:
-                  description: 'Example: 2011-04-14T23:27:33.000Z'
-                  type: string
-                created_at:
-                  description: 'Example: 2011-02-13T03:46:06.000Z'
-                  type: string
-                duration:
-                  description: 'Example: 60 days 19:41:27.000000000'
-                  type: string
-                issue_id:
-                  description: 'Example: 50306'
-                  type: integer
-                repo_name:
-                  description: 'Example: exception_notification'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issue-participants:
-    get:
-      description: 'How many persons participated in the discussion of issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
-      operationId: Issue Participants (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                created_at:
-                  description: 'Example: 2017-03-02T21:14:46.000Z'
-                  type: string
-                issue_id:
-                  description: 'Example: 50796'
-                  type: integer
-                participants:
-                  description: 'Example: 1'
-                  type: integer
-                repo_name:
-                  description: 'Example: arel'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issue-throughput:
-    get:
-      description: 'Ratio of issues closed to total issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
-      operationId: Issue Throughput (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_name:
-                  description: 'Example: rails-contributors'
-                  type: string
-                throughput:
-                  description: 'Example: 0.997531'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-active:
-    get:
-      description: 'Time series of number of issues that showed some activity during
-        a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_Active.md
-      operationId: Issues Active (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2011-01-01T00:00:00.000Z'
-                  type: string
-                issues:
-                  description: 'Example: 30'
-                  type: integer
-                repo_name:
-                  description: 'Example: rails'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-closed:
-    get:
-      description: 'Time series of number of issues closed during a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
-      operationId: Issues Closed (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2012-01-01T00:00:00.000Z'
-                  type: string
-                issues:
-                  description: 'Example: 97'
-                  type: integer
-                repo_name:
-                  description: 'Example: incubator-pagespeed-ngx'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-closed-resolution-duration:
-    get:
-      description: 'Duration of time for issues to be resolved. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-closed-resolution-duration.md
-      operationId: Closed Issue Resolution Duration (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                closed_at:
-                  description: 'Example: 2019-06-17T03:12:48.000Z'
-                  type: string
-                created_at:
-                  description: 'Example: 2019-05-31T07:55:44.000Z'
-                  type: string
-                diffdate:
-                  description: 'Example: 16.0'
-                  type: string
-                gh_issue_number:
-                  description: 'Example: 4223'
-                  type: integer
-                issue_title:
-                  description: 'Example: Cloud Native PR'
-                  type: string
-                repo_id:
-                  description: 'Example: 21682'
-                  type: integer
-                repo_name:
-                  description: 'Example: incubator-dubbo'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-first-time-closed:
-    get:
-      description: 'Number of persons closing an issue for the first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-first-time-closed.md
-      operationId: Closed Issues New Contributors (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                count:
-                  description: 'Example: 3'
-                  type: integer
-                issue_date:
-                  description: 'Example: 2018-05-20T00:00:00.000Z'
-                  type: string
-                repo_name:
-                  description: 'Example: rails'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-first-time-opened:
-    get:
-      description: 'Number of persons opening an issue for the first time. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-first-time-opened.md
-      operationId: New Contributors of Issues (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                count:
-                  description: 'Example: 3'
-                  type: integer
-                issue_date:
-                  description: 'Example: 2018-05-20T00:00:00.000Z'
-                  type: string
-                repo_name:
-                  description: 'Example: rails'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-maintainer-response-duration:
-    get:
-      description: 'Duration of time for issues to be resolved. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-maintainer-response-duration.md
-      operationId: Issue Response Time (Repo)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                average_days_comment:
-                  description: 'Example: 27.1111111111'
-                  type: string
-                repo_id:
-                  description: 'Example: 21987'
-                  type: integer
-                repo_name:
-                  description: 'Example: qpid-proton'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-new:
-    get:
-      description: 'Time series of number of new issues opened during a certain period. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
-      operationId: Issues New (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: Periodicity specification.
-        in: path
-        name: period
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2015-01-01T00:00:00.000Z'
-                  type: string
-                issues:
-                  description: 'Example: 116'
-                  type: integer
-                repo_name:
-                  description: 'Example: rails'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repos/:repo_id/issues-open-age:
-    get:
-      description: 'Age of open issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/issues-open-age.md
-      operationId: Open Issue Age (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2009-05-15T19:48:43.000Z'
-                  type: string
-                issue_id:
-                  description: 'Example: 38318'
-                  type: integer
-                open_date:
-                  description: 'Example: 3696'
-                  type: integer
-                repo_id:
-                  description: 'Example: 21000'
-                  type: integer
-                repo_name:
-                  description: 'Example: rails'
-                  type: string
-            type: array
-      tags:
-      - evolution
   /repos/:repo_id/pull-requests-merge-contributor-new:
     get:
       description: 'Number of persons contributing with an accepted commit for the
@@ -3653,23 +3245,29 @@ paths:
             type: array
       tags:
       - evolution
-  /repos/:repo_id/releases:
+  /repo-groups/:repo_group_id/review-duration:
     get:
       description: 'Time since an review/pull request is proposed until it is accepted. '
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md
-      operationId: Number of releases (Repo)
+      operationId: Review Duration (Repo Group)
       parameters:
-      - description: Repository Group ID.
+      - description: Repository Group ID
         in: path
         name: repo_group_id
         schema:
           type: string
         type: string
-      - description: Repository ID.
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
         in: path
-        name: repo_id
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
         schema:
           type: string
         type: string
@@ -3679,18 +3277,24 @@ paths:
           schema:
             items:
               properties:
-                latest:
-                  description: 'Example: 2019-11-02T11:02:08.000Z'
+                created_at:
+                  description: 'Example: 2010-09-28T19:07:15.000Z'
                   type: string
-                total_count:
-                  description: 'Example: 35'
-                  type: integer
-                latest_patch_release:
-                  description: 'Example: 2019-01-02T15:20:07.000Z'
+                duration:
+                  description: 'Example: 0 days 22:39:44.000000000'
                   type: string
-                total_patch_count:
-                  description: 'Example: 21'
+                merged_at:
+                  description: 'Example: 2010-09-29T17:46:59.000Z'
+                  type: string
+                pull_request_id:
+                  description: 'Example: 25386'
                   type: integer
+                repo_id:
+                  description: 'Example: 21035'
+                  type: integer
+                repo_name:
+                  description: 'Example: prototype-ujs'
+                  type: string
             type: array
       tags:
       - evolution
@@ -3746,6 +3350,60 @@ paths:
                   type: integer
                 repo_name:
                   description: 'Example: graphql-spec'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repo-groups/:repo_group_id/reviews:
+    get:
+      description: 'Time series of number of new reviews / pull requests opened within
+        a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/reviews.md
+      operationId: Reviews (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2010-01-01T00:00:00.000Z'
+                  type: string
+                pull_requests:
+                  description: 'Example: 1'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21035'
+                  type: integer
+                repo_name:
+                  description: 'Example: prototype-ujs'
                   type: string
             type: array
       tags:
@@ -3807,6 +3465,60 @@ paths:
             type: array
       tags:
       - evolution
+  /repo-groups/:repo_group_id/reviews-accepted:
+    get:
+      description: 'Time series of number of accepted reviews / pull requests opened
+        within a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md
+      operationId: Reviews Accepted (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2010-01-01T00:00:00.000Z'
+                  type: string
+                pull_requests:
+                  description: 'Example: 1'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21035'
+                  type: integer
+                repo_name:
+                  description: 'Example: prototype-ujs'
+                  type: string
+            type: array
+      tags:
+      - evolution
   /repos/:repo_id/reviews-accepted:
     get:
       description: 'Time series of number of accepted reviews / pull requests opened
@@ -3860,6 +3572,60 @@ paths:
                   type: integer
                 repo_name:
                   description: 'Example: graphql-spec'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repo-groups/:repo_group_id/reviews-declined:
+    get:
+      description: 'Time series of number of declined reviews / pull requests opened
+        within a certain period. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Accepted.md
+      operationId: Reviews Declined (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Periodicity specification.
+        in: path
+        name: period
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2010-01-01T00:00:00.000Z'
+                  type: string
+                pull_requests:
+                  description: 'Example: 1'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21035'
+                  type: integer
+                repo_name:
+                  description: 'Example: prototype-ujs'
                   type: string
             type: array
       tags:
@@ -3921,6 +3687,44 @@ paths:
             type: array
       tags:
       - evolution
+  /repo-groups/:repo_group_id/sub-projects:
+    get:
+      description: 'Number of sub-projects. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/sub-projects.md
+      operationId: Sub-Projects (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                sub_protject_count:
+                  description: 'Example: 2'
+                  type: integer
+            type: array
+      tags:
+      - evolution
   /repos/:repo_id/sub-projects:
     get:
       description: 'Number of sub-projects. '
@@ -3962,6 +3766,202 @@ paths:
                 sub_protject_count:
                   description: 'Example: 2'
                   type: integer
+            type: array
+      tags:
+      - evolution
+  /repo-groups/:repo_group_id/closed-issues-count:
+    get:
+      description: 'Count of closed issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
+      operationId: Closed Issues Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                closed_count:
+                  description: 'Example: 26'
+                  type: integer
+                date:
+                  description: 'Example: 2018-11-26T00:00:00.000Z'
+                  type: string
+                repo_id:
+                  description: 'Example: 21681'
+                  type: integer
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/closed-issues-count:
+    get:
+      description: 'Count of closed issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
+      operationId: Closed Issues Count (Repo)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                closed_count:
+                  description: 'Example: 4'
+                  type: integer
+                date:
+                  description: 'Example: 2014-06-02T00:00:00.000Z'
+                  type: string
+                rg_name:
+                  description: 'Example: Apache'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repo-groups/:repo_group_id/issue-duration:
+    get:
+      description: 'Time since an issue is proposed until it is closed. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/focus_areas/code_development.md
+      operationId: Issue Duration (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                closed_at:
+                  description: 'Example: 2011-05-06T20:21:47.000Z'
+                  type: string
+                created_at:
+                  description: 'Example: 2011-05-06T20:20:05.000Z'
+                  type: string
+                duration:
+                  description: 'Example: 0 days 00:01:42.000000000'
+                  type: string
+                issue_id:
+                  description: 'Example: 50320'
+                  type: integer
+                repo_id:
+                  description: 'Example: 21017'
+                  type: integer
+                repo_name:
+                  description: 'Example: ssl_requirement'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repos/:repo_id/releases:
+    get:
+      description: 'Time since an review/pull request is proposed until it is accepted. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Reviews_Duration.md
+      operationId: Number of releases (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                latest:
+                  description: 'Example: 2019-11-02T11:02:08.000Z'
+                  type: string
+                total_count:
+                  description: 'Example: 35'
+                  type: integer
+                latest_patch_release:
+                  description: 'Example: 2019-01-02T15:20:07.000Z'
+                  type: string
+                total_patch_count:
+                  description: 'Example: 21'
+                  type: integer
+            type: array
+      tags:
+      - evolution
+  /repo-groups/:repo_group_id/open-issues-count:
+    get:
+      description: 'Count of open issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
+      operationId: Open Issues Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2017-09-11T00:00:00.000Z'
+                  type: string
+                open_count:
+                  description: 'Example: 1'
+                  type: integer
+                rg_name:
+                  description: 'Example: Netflix'
+                  type: string
             type: array
       tags:
       - evolution

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -3997,6 +3997,41 @@ paths:
             type: array
       tags:
       - value
+  /repos/:repo_id/watchers:
+    get:
+      description: A time series of watchers count.
+      operationId: Watchers (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-07-03T23:22:26.000Z'
+                  type: string
+                repo_name:
+                  description: 'Example: airflow'
+                  type: string
+                watchers:
+                  description: 'Example: 649'
+                  type: integer
+            type: array
+      tags:
+      - value
   /repo-groups/:repo_group_id/watchers-count:
     get:
       description: Watchers count.
@@ -4022,6 +4057,38 @@ paths:
                   type: string
                 watchers:
                   description: 'Example: 20'
+                  type: integer
+            type: array
+      tags:
+      - value
+  /repos/:repo_id/watchers-count:
+    get:
+      description: Watchers count.
+      operationId: Watchers Count (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_name:
+                  description: 'Example: airflow'
+                  type: string
+                watchers:
+                  description: 'Example: 649'
                   type: integer
             type: array
       tags:
@@ -4054,35 +4121,6 @@ paths:
                   type: string
                 stars:
                   description: 'Example: 600'
-                  type: integer
-            type: array
-      tags:
-      - value
-  /repo-groups/:repo_group_id/stars-count:
-    get:
-      description: Stars count.
-      operationId: Stars Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_id:
-                  description: 'Example: 21364'
-                  type: integer
-                repo_name:
-                  description: 'Example: irs_process_scripts'
-                  type: string
-                stars:
-                  description: 'Example: 20'
                   type: integer
             type: array
       tags:
@@ -4122,6 +4160,35 @@ paths:
             type: array
       tags:
       - value
+  /repo-groups/:repo_group_id/stars-count:
+    get:
+      description: Stars count.
+      operationId: Stars Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_id:
+                  description: 'Example: 21364'
+                  type: integer
+                repo_name:
+                  description: 'Example: irs_process_scripts'
+                  type: string
+                stars:
+                  description: 'Example: 20'
+                  type: integer
+            type: array
+      tags:
+      - value
   /repos/:repo_id/stars-count:
     get:
       description: Stars count.
@@ -4150,73 +4217,6 @@ paths:
                   type: string
                 stars:
                   description: 'Example: 8653'
-                  type: integer
-            type: array
-      tags:
-      - value
-  /repos/:repo_id/watchers:
-    get:
-      description: A time series of watchers count.
-      operationId: Watchers (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-07-03T23:22:26.000Z'
-                  type: string
-                repo_name:
-                  description: 'Example: airflow'
-                  type: string
-                watchers:
-                  description: 'Example: 649'
-                  type: integer
-            type: array
-      tags:
-      - value
-  /repos/:repo_id/watchers-count:
-    get:
-      description: Watchers count.
-      operationId: Watchers Count (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_name:
-                  description: 'Example: airflow'
-                  type: string
-                watchers:
-                  description: 'Example: 649'
                   type: integer
             type: array
       tags:

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -829,41 +829,6 @@ paths:
             type: array
       tags:
       - risk
-  /repo-groups/:repo_group_id/abandoned-issues:
-    get:
-      description: List of abandoned issues (last updated &gt;= 1 year ago)
-      operationId: Abandoned Issues (Repo)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                issue_id:
-                  description: 'Example: 125071'
-                  type: integer
-                repo_id:
-                  description: 'Example: 22004'
-                  type: integer
-                updated_at:
-                  description: 'Example: 2017-10-30T06:52:19.000Z'
-                  type: string
-            type: array
-      tags:
-      - experimental
   /repo-groups/:repo_group_id/aggregate-summary:
     get:
       description: Returns the current count of watchers, stars, and forks and the
@@ -912,6 +877,64 @@ paths:
                   type: integer
                 watcher_count:
                   description: 'Example: 69106'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/aggregate-summary:
+    get:
+      description: Returns the current count of watchers, stars, and forks and the
+        counts of all commits, committers, and pull requests merged between a given
+        beginning and end date (default between now and 365 days ago).
+      operationId: Aggregate Summary (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                commit_count:
+                  description: 'Example: 133'
+                  type: integer
+                committer_count:
+                  description: 'Example: 5'
+                  type: integer
+                fork_count:
+                  description: 'Example: 449'
+                  type: integer
+                merged_count:
+                  description: 'Example: 0'
+                  type: integer
+                star_count:
+                  description: 'Example: 581'
+                  type: integer
+                watcher_count:
+                  description: 'Example: 83'
                   type: integer
             type: array
       tags:
@@ -1114,6 +1137,41 @@ paths:
             type: array
       tags:
       - experimental
+  /repos/:repo_id/issue-comments-mean:
+    get:
+      description: Mean(Average) of issue comments per day.
+      operationId: Issue Comments Mean (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2018-01-01T00:00:00.000Z'
+                  type: string
+                mean:
+                  description: 'Example: 0.6191780822'
+                  type: string
+                repo_id:
+                  description: 'Example: 21326'
+                  type: integer
+            type: array
+      tags:
+      - experimental
   /repo-groups/:repo_group_id/issue-comments-mean-std:
     get:
       description: Mean(Average) and Standard Deviation of issue comments per day.
@@ -1150,15 +1208,12 @@ paths:
             type: array
       tags:
       - experimental
-  /repo-groups/:repo_group_id/lines-changed-by-author:
+  /repos/:repo_id/issue-comments-mean-std:
     get:
-      description: 'Count of closed issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
-      operationId: Lines Changed by Author (Repo)
+      description: Mean(Average) and Standard Deviation of issue comments per day.
+      operationId: Issue Comments Mean Std (Repo)
       parameters:
-      - description: Repository Group ID
+      - description: Repository Group ID.
         in: path
         name: repo_group_id
         schema:
@@ -1176,24 +1231,18 @@ paths:
           schema:
             items:
               properties:
-                additions:
-                  description: 'Example: 25611'
-                  type: integer
-                affiliation:
-                  description: 'Example: NULL'
+                average:
+                  description: 'Example: 2.5'
                   type: string
-                cmt_author_date:
-                  description: 'Example: 2004-11-24'
+                date:
+                  description: 'Example: 2011-01-01T00:00:00.000Z'
                   type: string
-                cmt_author_email:
-                  description: 'Example: david@loudthinking.com'
+                repo_id:
+                  description: 'Example: 21000'
+                  type: integer
+                standard_deviation:
+                  description: 'Example: 1.7159383568'
                   type: string
-                deletions:
-                  description: 'Example: 296'
-                  type: integer
-                whitespace:
-                  description: 'Example: 5279'
-                  type: integer
             type: array
       tags:
       - experimental
@@ -1244,6 +1293,52 @@ paths:
             type: array
       tags:
       - experimental
+  /repos/:repo_id/pull-request-acceptance-rate:
+    get:
+      description: Timeseries of pull request acceptance rate (expressed as the ratio
+        of pull requests merged on a date to the count of pull requests opened on
+        a date)
+      operationId: Pull Request Acceptance Rate (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-01-01T00:00:00.000Z'
+                  type: string
+                rate:
+                  description: 'Example: 5.3333333333'
+                  type: string
+            type: array
+      tags:
+      - experimental
   /repo-groups/:repo_group_id/pull-requests-closed-no-merge:
     get:
       description: Timeseries of pull request which were closed but not merged
@@ -1262,6 +1357,45 @@ paths:
           type: string
         type: string
       - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-01-01T00:00:00.000Z'
+                  type: string
+                pr_count:
+                  description: 'Example: 3'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/pull-requests-closed-no-merge:
+    get:
+      description: ''
+      operationId: Pull Request Closed but Not Merged (Repo)
+      parameters:
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01
+          ___'
         in: path
         name: end_date
         schema:
@@ -1328,222 +1462,6 @@ paths:
             type: array
       tags:
       - experimental
-  /repos/:repo_id/aggregate-summary:
-    get:
-      description: Returns the current count of watchers, stars, and forks and the
-        counts of all commits, committers, and pull requests merged between a given
-        beginning and end date (default between now and 365 days ago).
-      operationId: Aggregate Summary (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                commit_count:
-                  description: 'Example: 133'
-                  type: integer
-                committer_count:
-                  description: 'Example: 5'
-                  type: integer
-                fork_count:
-                  description: 'Example: 449'
-                  type: integer
-                merged_count:
-                  description: 'Example: 0'
-                  type: integer
-                star_count:
-                  description: 'Example: 581'
-                  type: integer
-                watcher_count:
-                  description: 'Example: 83'
-                  type: integer
-            type: array
-      tags:
-      - experimental
-  /repos/:repo_id/issue-comments-mean:
-    get:
-      description: Mean(Average) of issue comments per day.
-      operationId: Issue Comments Mean (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2018-01-01T00:00:00.000Z'
-                  type: string
-                mean:
-                  description: 'Example: 0.6191780822'
-                  type: string
-                repo_id:
-                  description: 'Example: 21326'
-                  type: integer
-            type: array
-      tags:
-      - experimental
-  /repos/:repo_id/issue-comments-mean-std:
-    get:
-      description: Mean(Average) and Standard Deviation of issue comments per day.
-      operationId: Issue Comments Mean Std (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                average:
-                  description: 'Example: 2.5'
-                  type: string
-                date:
-                  description: 'Example: 2011-01-01T00:00:00.000Z'
-                  type: string
-                repo_id:
-                  description: 'Example: 21000'
-                  type: integer
-                standard_deviation:
-                  description: 'Example: 1.7159383568'
-                  type: string
-            type: array
-      tags:
-      - experimental
-  /repos/:repo_id/pull-request-acceptance-rate:
-    get:
-      description: Timeseries of pull request acceptance rate (expressed as the ratio
-        of pull requests merged on a date to the count of pull requests opened on
-        a date)
-      operationId: Pull Request Acceptance Rate (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-01-01T00:00:00.000Z'
-                  type: string
-                rate:
-                  description: 'Example: 5.3333333333'
-                  type: string
-            type: array
-      tags:
-      - experimental
-  /repos/:repo_id/pull-requests-closed-no-merge:
-    get:
-      description: ''
-      operationId: Pull Request Closed but Not Merged (Repo)
-      parameters:
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01
-          ___'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-01-01T00:00:00.000Z'
-                  type: string
-                pr_count:
-                  description: 'Example: 3'
-                  type: integer
-            type: array
-      tags:
-      - experimental
   /repos/:repo_id/top-committers:
     get:
       description: Returns a list of contributors contributing N% of all commits.
@@ -1593,6 +1511,88 @@ paths:
                 repo_name:
                   description: 'Example: graphql'
                   type: string
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/abandoned-issues:
+    get:
+      description: List of abandoned issues (last updated &gt;= 1 year ago)
+      operationId: Abandoned Issues (Repo)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                issue_id:
+                  description: 'Example: 125071'
+                  type: integer
+                repo_id:
+                  description: 'Example: 22004'
+                  type: integer
+                updated_at:
+                  description: 'Example: 2017-10-30T06:52:19.000Z'
+                  type: string
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/lines-changed-by-author:
+    get:
+      description: 'Count of closed issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
+      operationId: Lines Changed by Author (Repo)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                additions:
+                  description: 'Example: 25611'
+                  type: integer
+                affiliation:
+                  description: 'Example: NULL'
+                  type: string
+                cmt_author_date:
+                  description: 'Example: 2004-11-24'
+                  type: string
+                cmt_author_email:
+                  description: 'Example: david@loudthinking.com'
+                  type: string
+                deletions:
+                  description: 'Example: 296'
+                  type: integer
+                whitespace:
+                  description: 'Example: 5279'
+                  type: integer
             type: array
       tags:
       - experimental

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -917,12 +917,6 @@ paths:
         beginning and end date (default between now and 365 days ago).
       operationId: Aggregate Summary (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -972,7 +966,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Commit Count Ranked by New Repo in Repo Group (Repo)
+      operationId: Annual Commit Count Ranked by New Repo in Repo Group (Repo Group)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -1032,7 +1026,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Commit Count Ranked by Repo in Repo Group (Repo)
+      operationId: Annual Commit Count Ranked by Repo in Repo Group (Repo Group)
       parameters:
       - description: Base64 version of the URL of the GitHub repository as it appears
           in the Facade DB
@@ -1066,7 +1060,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Lines of Code Ranked by New Repo in Repo Group (Repo)
+      operationId: Annual Lines of Code Ranked by New Repo in Repo Group (Repo Group)
       parameters:
       - description: Base64 version of the URL of the GitHub repository as it appears
           in the Facade DB
@@ -1100,7 +1094,7 @@ paths:
     get:
       description: 'This is an Augur-specific metric. We are currently working to
         define these more formally. '
-      operationId: Annual Lines of Code Ranked by Repo in Repo Group (Repo)
+      operationId: Annual Lines of Code Ranked by Repo in Repo Group (Repo Group)
       parameters:
       - description: Base64 version of the URL of the GitHub repository as it appears
           in the Facade DB
@@ -1171,12 +1165,6 @@ paths:
       description: Mean(Average) of issue comments per day.
       operationId: Issue Comments Mean (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -1242,12 +1230,6 @@ paths:
       description: Mean(Average) and Standard Deviation of issue comments per day.
       operationId: Issue Comments Mean Std (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -1329,12 +1311,6 @@ paths:
         a date)
       operationId: Pull Request Acceptance Rate (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -1371,7 +1347,7 @@ paths:
   /repo-groups/:repo_group_id/pull-requests-closed-no-merge:
     get:
       description: Timeseries of pull request which were closed but not merged
-      operationId: Pull Request Closed but Not Merged (Repo)
+      operationId: Pull Request Closed but Not Merged (Repo Group)
       parameters:
       - description: Repository Group ID.
         in: path
@@ -1496,12 +1472,6 @@ paths:
       description: Returns a list of contributors contributing N% of all commits.
       operationId: Top Committers (Repo)
       parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -1577,12 +1547,6 @@ paths:
       description: List of abandoned issues (last updated &gt;= 1 year ago)
       operationId: Abandoned Issues (Repo)
       parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id
@@ -1656,12 +1620,6 @@ paths:
         url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
       operationId: Lines Changed by Author (Repo)
       parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
       - description: Repository ID.
         in: path
         name: repo_id

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -1078,6 +1078,617 @@ paths:
             type: array
       tags:
       - experimental
+  /repo-groups/:repo_group_id/issue-comments-mean:
+    get:
+      description: Mean(Average) of issue comments per day.
+      operationId: Issue Comments Mean (Repo Group)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Allows for results to be grouped by day, week, month, or year.
+          E.g. values: year, day, month'
+        in: path
+        name: group_by
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2018-01-01T00:00:00.000Z'
+                  type: string
+                mean:
+                  description: 'Example: 0.6191780822'
+                  type: string
+                repo_id:
+                  description: 'Example: 21326'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/issue-comments-mean-std:
+    get:
+      description: Mean(Average) and Standard Deviation of issue comments per day.
+      operationId: Issue Comments Mean Std (Repo Group)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Allows for results to be grouped by day, week, month, or year.
+          E.g. values: year, day, month'
+        in: path
+        name: group_by
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2018-01-01T00:00:00.000Z'
+                  type: string
+                mean:
+                  description: 'Example: 0.6191780822'
+                  type: string
+                repo_id:
+                  description: 'Example: 21326'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/lines-changed-by-author:
+    get:
+      description: 'Count of closed issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
+      operationId: Lines Changed by Author (Repo)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                additions:
+                  description: 'Example: 25611'
+                  type: integer
+                affiliation:
+                  description: 'Example: NULL'
+                  type: string
+                cmt_author_date:
+                  description: 'Example: 2004-11-24'
+                  type: string
+                cmt_author_email:
+                  description: 'Example: david@loudthinking.com'
+                  type: string
+                deletions:
+                  description: 'Example: 296'
+                  type: integer
+                whitespace:
+                  description: 'Example: 5279'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/pull-request-acceptance-rate:
+    get:
+      description: Timeseries of pull request acceptance rate (expressed as the ratio
+        of pull requests merged on a date to the count of pull requests opened on
+        a date)
+      operationId: Pull Request Acceptance Rate (Repo Group)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      - description: 'Allows for results to be grouped by day, week, month, or year.
+          E.g. values: year, day, month'
+        in: path
+        name: group_by
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-02-11T00:00:00.000Z'
+                  type: string
+                rate:
+                  description: 'Example: 120.5'
+                  type: string
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/pull-requests-closed-no-merge:
+    get:
+      description: Timeseries of pull request which were closed but not merged
+      operationId: Pull Request Closed but Not Merged (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-01-01T00:00:00.000Z'
+                  type: string
+                pr_count:
+                  description: 'Example: 3'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/top-committers:
+    get:
+      description: Returns a list of contributors contributing N% of all commits.
+      operationId: Top Committers (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: 'Specify the year to return the results for. Default value: current
+          year'
+        in: path
+        name: year
+        schema:
+          type: string
+        type: string
+      - description: Specify N%. Accepts a value between 0 &amp; 1 where 0 specifies
+          0% and 1 specifies 100%.
+        in: path
+        name: threshold
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                commits:
+                  description: 'Example: 502'
+                  type: integer
+                email:
+                  description: 'Example: kamipo@gmail.com'
+                  type: string
+                repo_group_id:
+                  description: 'Example: 20'
+                  type: integer
+                repo_group_name:
+                  description: 'Example: Rails'
+                  type: string
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/aggregate-summary:
+    get:
+      description: Returns the current count of watchers, stars, and forks and the
+        counts of all commits, committers, and pull requests merged between a given
+        beginning and end date (default between now and 365 days ago).
+      operationId: Aggregate Summary (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                commit_count:
+                  description: 'Example: 133'
+                  type: integer
+                committer_count:
+                  description: 'Example: 5'
+                  type: integer
+                fork_count:
+                  description: 'Example: 449'
+                  type: integer
+                merged_count:
+                  description: 'Example: 0'
+                  type: integer
+                star_count:
+                  description: 'Example: 581'
+                  type: integer
+                watcher_count:
+                  description: 'Example: 83'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/issue-comments-mean:
+    get:
+      description: Mean(Average) of issue comments per day.
+      operationId: Issue Comments Mean (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2018-01-01T00:00:00.000Z'
+                  type: string
+                mean:
+                  description: 'Example: 0.6191780822'
+                  type: string
+                repo_id:
+                  description: 'Example: 21326'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/issue-comments-mean-std:
+    get:
+      description: Mean(Average) and Standard Deviation of issue comments per day.
+      operationId: Issue Comments Mean Std (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                average:
+                  description: 'Example: 2.5'
+                  type: string
+                date:
+                  description: 'Example: 2011-01-01T00:00:00.000Z'
+                  type: string
+                repo_id:
+                  description: 'Example: 21000'
+                  type: integer
+                standard_deviation:
+                  description: 'Example: 1.7159383568'
+                  type: string
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/pull-request-acceptance-rate:
+    get:
+      description: Timeseries of pull request acceptance rate (expressed as the ratio
+        of pull requests merged on a date to the count of pull requests opened on
+        a date)
+      operationId: Pull Request Acceptance Rate (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-01-01T00:00:00.000Z'
+                  type: string
+                rate:
+                  description: 'Example: 5.3333333333'
+                  type: string
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/pull-requests-closed-no-merge:
+    get:
+      description: ''
+      operationId: Pull Request Closed but Not Merged (Repo)
+      parameters:
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
+        in: path
+        name: begin_date
+        schema:
+          type: string
+        type: string
+      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01
+          ___'
+        in: path
+        name: end_date
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-01-01T00:00:00.000Z'
+                  type: string
+                pr_count:
+                  description: 'Example: 3'
+                  type: integer
+            type: array
+      tags:
+      - experimental
+  /repos/:repo_id/top-committers:
+    get:
+      description: Returns a list of contributors contributing N% of all commits.
+      operationId: Top Committers (Repo)
+      parameters:
+      - description: Repository Group ID.
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      - description: Repository ID.
+        in: path
+        name: repo_id
+        schema:
+          type: string
+        type: string
+      - description: 'Specify the year to return the results for. Default value: current
+          year'
+        in: path
+        name: year
+        schema:
+          type: string
+        type: string
+      - description: Specify N%. Accepts a value between 0 &amp; 1 where 0 specifies
+          0% and 1 specifies 100%.
+        in: path
+        name: threshold
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                commits:
+                  description: 'Example: 4'
+                  type: integer
+                email:
+                  description: 'Example: caniszczyk@gmail.com'
+                  type: string
+                repo_id:
+                  description: 'Example: 21334'
+                  type: integer
+                repo_name:
+                  description: 'Example: graphql'
+                  type: string
+            type: array
+      tags:
+      - experimental
+  /repo-groups/:repo_group_id/open-issues-count:
+    get:
+      description: 'Count of open issues. '
+      externalDocs:
+        description: CHAOSS Metric Definition
+        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
+      operationId: Open Issues Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2017-09-11T00:00:00.000Z'
+                  type: string
+                open_count:
+                  description: 'Example: 1'
+                  type: integer
+                rg_name:
+                  description: 'Example: Netflix'
+                  type: string
+            type: array
+      tags:
+      - evolution
+  /repo-groups/:repo_group_id/watchers:
+    get:
+      description: A time series of watchers count.
+      operationId: Watchers (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                date:
+                  description: 'Example: 2019-07-03T23:26:42.000Z'
+                  type: string
+                repo_id:
+                  description: 'Example: 21036'
+                  type: integer
+                repo_name:
+                  description: 'Example: jquery-ujs'
+                  type: string
+                watchers:
+                  description: 'Example: 60'
+                  type: integer
+            type: array
+      tags:
+      - value
+  /repo-groups/:repo_group_id/watchers-count:
+    get:
+      description: Watchers count.
+      operationId: Watchers Count (Repo Group)
+      parameters:
+      - description: Repository Group ID
+        in: path
+        name: repo_group_id
+        schema:
+          type: string
+        type: string
+      responses:
+        '200':
+          description: OK
+          schema:
+            items:
+              properties:
+                repo_id:
+                  description: 'Example: 21039'
+                  type: integer
+                repo_name:
+                  description: 'Example: rails_xss'
+                  type: string
+                watchers:
+                  description: 'Example: 20'
+                  type: integer
+            type: array
+      tags:
+      - value
   /repo-groups/:repo_group_id/closed-issues-count:
     get:
       description: 'Count of closed issues. '
@@ -1375,78 +1986,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/issue-comments-mean:
-    get:
-      description: Mean(Average) of issue comments per day.
-      operationId: Issue Comments Mean (Repo Group)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: 'Allows for results to be grouped by day, week, month, or year.
-          E.g. values: year, day, month'
-        in: path
-        name: group_by
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2018-01-01T00:00:00.000Z'
-                  type: string
-                mean:
-                  description: 'Example: 0.6191780822'
-                  type: string
-                repo_id:
-                  description: 'Example: 21326'
-                  type: integer
-            type: array
-      tags:
-      - experimental
-  /repo-groups/:repo_group_id/issue-comments-mean-std:
-    get:
-      description: Mean(Average) and Standard Deviation of issue comments per day.
-      operationId: Issue Comments Mean Std (Repo Group)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: 'Allows for results to be grouped by day, week, month, or year.
-          E.g. values: year, day, month'
-        in: path
-        name: group_by
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2018-01-01T00:00:00.000Z'
-                  type: string
-                mean:
-                  description: 'Example: 0.6191780822'
-                  type: string
-                repo_id:
-                  description: 'Example: 21326'
-                  type: integer
-            type: array
-      tags:
-      - experimental
   /repo-groups/:repo_group_id/issue-duration:
     get:
       description: 'Time since an issue is proposed until it is closed. '
@@ -1971,170 +2510,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/lines-changed-by-author:
-    get:
-      description: 'Count of closed issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/contributors-new.md
-      operationId: Lines Changed by Author (Repo)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                additions:
-                  description: 'Example: 25611'
-                  type: integer
-                affiliation:
-                  description: 'Example: NULL'
-                  type: string
-                cmt_author_date:
-                  description: 'Example: 2004-11-24'
-                  type: string
-                cmt_author_email:
-                  description: 'Example: david@loudthinking.com'
-                  type: string
-                deletions:
-                  description: 'Example: 296'
-                  type: integer
-                whitespace:
-                  description: 'Example: 5279'
-                  type: integer
-            type: array
-      tags:
-      - experimental
-  /repo-groups/:repo_group_id/open-issues-count:
-    get:
-      description: 'Count of open issues. '
-      externalDocs:
-        description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-evolution/blob/master/metrics/Issues_New.md
-      operationId: Open Issues Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2017-09-11T00:00:00.000Z'
-                  type: string
-                open_count:
-                  description: 'Example: 1'
-                  type: integer
-                rg_name:
-                  description: 'Example: Netflix'
-                  type: string
-            type: array
-      tags:
-      - evolution
-  /repo-groups/:repo_group_id/pull-request-acceptance-rate:
-    get:
-      description: Timeseries of pull request acceptance rate (expressed as the ratio
-        of pull requests merged on a date to the count of pull requests opened on
-        a date)
-      operationId: Pull Request Acceptance Rate (Repo Group)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      - description: 'Allows for results to be grouped by day, week, month, or year.
-          E.g. values: year, day, month'
-        in: path
-        name: group_by
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-02-11T00:00:00.000Z'
-                  type: string
-                rate:
-                  description: 'Example: 120.5'
-                  type: string
-            type: array
-      tags:
-      - experimental
-  /repo-groups/:repo_group_id/pull-requests-closed-no-merge:
-    get:
-      description: Timeseries of pull request which were closed but not merged
-      operationId: Pull Request Closed but Not Merged (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-01-01T00:00:00.000Z'
-                  type: string
-                pr_count:
-                  description: 'Example: 3'
-                  type: integer
-            type: array
-      tags:
-      - experimental
   /repo-groups/:repo_group_id/pull-requests-merge-contributor-new:
     get:
       description: 'Number of persons contributing with an accepted commit for the
@@ -2503,171 +2878,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repo-groups/:repo_group_id/top-committers:
-    get:
-      description: Returns a list of contributors contributing N% of all commits.
-      operationId: Top Committers (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: 'Specify the year to return the results for. Default value: current
-          year'
-        in: path
-        name: year
-        schema:
-          type: string
-        type: string
-      - description: Specify N%. Accepts a value between 0 &amp; 1 where 0 specifies
-          0% and 1 specifies 100%.
-        in: path
-        name: threshold
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                commits:
-                  description: 'Example: 502'
-                  type: integer
-                email:
-                  description: 'Example: kamipo@gmail.com'
-                  type: string
-                repo_group_id:
-                  description: 'Example: 20'
-                  type: integer
-                repo_group_name:
-                  description: 'Example: Rails'
-                  type: string
-            type: array
-      tags:
-      - experimental
-  /repo-groups/:repo_group_id/watchers:
-    get:
-      description: A time series of watchers count.
-      operationId: Watchers (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-07-03T23:26:42.000Z'
-                  type: string
-                repo_id:
-                  description: 'Example: 21036'
-                  type: integer
-                repo_name:
-                  description: 'Example: jquery-ujs'
-                  type: string
-                watchers:
-                  description: 'Example: 60'
-                  type: integer
-            type: array
-      tags:
-      - value
-  /repo-groups/:repo_group_id/watchers-count:
-    get:
-      description: Watchers count.
-      operationId: Watchers Count (Repo Group)
-      parameters:
-      - description: Repository Group ID
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                repo_id:
-                  description: 'Example: 21039'
-                  type: integer
-                repo_name:
-                  description: 'Example: rails_xss'
-                  type: string
-                watchers:
-                  description: 'Example: 20'
-                  type: integer
-            type: array
-      tags:
-      - value
-  /repos/:repo_id/aggregate-summary:
-    get:
-      description: Returns the current count of watchers, stars, and forks and the
-        counts of all commits, committers, and pull requests merged between a given
-        beginning and end date (default between now and 365 days ago).
-      operationId: Aggregate Summary (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                commit_count:
-                  description: 'Example: 133'
-                  type: integer
-                committer_count:
-                  description: 'Example: 5'
-                  type: integer
-                fork_count:
-                  description: 'Example: 449'
-                  type: integer
-                merged_count:
-                  description: 'Example: 0'
-                  type: integer
-                star_count:
-                  description: 'Example: 581'
-                  type: integer
-                watcher_count:
-                  description: 'Example: 83'
-                  type: integer
-            type: array
-      tags:
-      - experimental
   /repos/:repo_id/closed-issues-count:
     get:
       description: 'Count of closed issues. '
@@ -2995,79 +3205,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repos/:repo_id/issue-comments-mean:
-    get:
-      description: Mean(Average) of issue comments per day.
-      operationId: Issue Comments Mean (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2018-01-01T00:00:00.000Z'
-                  type: string
-                mean:
-                  description: 'Example: 0.6191780822'
-                  type: string
-                repo_id:
-                  description: 'Example: 21326'
-                  type: integer
-            type: array
-      tags:
-      - experimental
-  /repos/:repo_id/issue-comments-mean-std:
-    get:
-      description: Mean(Average) and Standard Deviation of issue comments per day.
-      operationId: Issue Comments Mean Std (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                average:
-                  description: 'Example: 2.5'
-                  type: string
-                date:
-                  description: 'Example: 2011-01-01T00:00:00.000Z'
-                  type: string
-                repo_id:
-                  description: 'Example: 21000'
-                  type: integer
-                standard_deviation:
-                  description: 'Example: 1.7159383568'
-                  type: string
-            type: array
-      tags:
-      - experimental
   /repos/:repo_id/issue-participants:
     get:
       description: 'How many persons participated in the discussion of issues. '
@@ -3581,91 +3718,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repos/:repo_id/pull-request-acceptance-rate:
-    get:
-      description: Timeseries of pull request acceptance rate (expressed as the ratio
-        of pull requests merged on a date to the count of pull requests opened on
-        a date)
-      operationId: Pull Request Acceptance Rate (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-01-01T00:00:00.000Z'
-                  type: string
-                rate:
-                  description: 'Example: 5.3333333333'
-                  type: string
-            type: array
-      tags:
-      - experimental
-  /repos/:repo_id/pull-requests-closed-no-merge:
-    get:
-      description: ''
-      operationId: Pull Request Closed but Not Merged (Repo)
-      parameters:
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Beginning date specification. E.g. values: 2018, 2018-05, 2019-05-01'
-        in: path
-        name: begin_date
-        schema:
-          type: string
-        type: string
-      - description: 'Ending date specification. E.g. values: 2018, 2018-05, 2019-05-01
-          ___'
-        in: path
-        name: end_date
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                date:
-                  description: 'Example: 2019-01-01T00:00:00.000Z'
-                  type: string
-                pr_count:
-                  description: 'Example: 3'
-                  type: integer
-            type: array
-      tags:
-      - experimental
   /repos/:repo_id/pull-requests-merge-contributor-new:
     get:
       description: 'Number of persons contributing with an accepted commit for the
@@ -4102,58 +4154,6 @@ paths:
             type: array
       tags:
       - evolution
-  /repos/:repo_id/top-committers:
-    get:
-      description: Returns a list of contributors contributing N% of all commits.
-      operationId: Top Committers (Repo)
-      parameters:
-      - description: Repository Group ID.
-        in: path
-        name: repo_group_id
-        schema:
-          type: string
-        type: string
-      - description: Repository ID.
-        in: path
-        name: repo_id
-        schema:
-          type: string
-        type: string
-      - description: 'Specify the year to return the results for. Default value: current
-          year'
-        in: path
-        name: year
-        schema:
-          type: string
-        type: string
-      - description: Specify N%. Accepts a value between 0 &amp; 1 where 0 specifies
-          0% and 1 specifies 100%.
-        in: path
-        name: threshold
-        schema:
-          type: string
-        type: string
-      responses:
-        '200':
-          description: OK
-          schema:
-            items:
-              properties:
-                commits:
-                  description: 'Example: 4'
-                  type: integer
-                email:
-                  description: 'Example: caniszczyk@gmail.com'
-                  type: string
-                repo_id:
-                  description: 'Example: 21334'
-                  type: integer
-                repo_name:
-                  description: 'Example: graphql'
-                  type: string
-            type: array
-      tags:
-      - experimental
   /repos/:repo_id/watchers:
     get:
       description: A time series of watchers count.


### PR DESCRIPTION
1. Fixed typos in the urls for several endpoints
2. The url was different in the docs than the code, but I thought the url in the docs made more sense so I changed the endpoint url to match what the docs had
3. Organized spec.yml by the Chaoss working groups, so all the endpoints in the each working group are all together in the file
4. Then within each working group in the docs I grouped the similar endpoints together rather than grouping all the repo group endpoints and all the repo endpoints together