### PR TITLE
NPM extension for Libyear Worker

### DIFF
--- a/workers/deps_libyear_worker/deps_libyear_worker.py
+++ b/workers/deps_libyear_worker/deps_libyear_worker.py
@@ -15,7 +15,7 @@ from sqlalchemy import MetaData
 from workers.worker_base import Worker
 
 # from workers.deps_worker import dependancy_calculator as dep_calc
-from pypi_parser import get_deps_libyear_data
+from libyear_utils import get_deps_libyear_data
 
 class DepsLibyearWorker(WorkerGitInterfaceable):
     def __init__(self, config={}):

--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -10,6 +10,7 @@ from npm_libyear_utils import get_NPM_data, get_npm_release_date, get_npm_latest
 #Files That would be parsed should be added here
 file_list = [
     'Requirement.txt',
+    'requirements.txt',
     'setup.py',
     'Pipfile',
     'Pipfile.lock',
@@ -41,6 +42,9 @@ def get_parsed_deps(path):
         file_handle= open(deps_file)
 
         if f == 'Requirement.txt':
+            dependency_list = parse_requirement_txt(file_handle)
+        
+        elif f == 'requirements.txt':
             dependency_list = parse_requirement_txt(file_handle)
 
         elif f == 'setup.py':

--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -1,6 +1,73 @@
 from distutils.version import LooseVersion
 import dateutil.parser
 from distutils import version
+import os
+from pypi_parser import parse_conda, parse_pipfile,parse_pipfile_lock,parse_poetry,parse_poetry_lock,parse_requirement_txt,parse_setup_py
+from npm_parser import parse_package_json
+from pypi_libyear_util import sort_dependency_requirement,get_pypi_data,get_latest_version,get_release_date
+
+#Files That would be parsed should be added here
+file_list = [
+    'Requirement.txt',
+    'setup.py',
+    'Pipfile',
+    'Pipfile.lock',
+    'pyproject.toml',
+    'poetry.lock',
+    'environment.yml',
+    'environment.yaml',
+    'environment.yml.lock',
+    'environment.yaml.lock'
+]
+
+
+def find(name, path):
+    for root, dirs, files in os.walk(path):
+        if name in files:
+            return os.path.join(root, name)
+
+
+def get_parsed_deps(path):
+
+    deps_file = None
+    dependency_list = list()
+
+    for f in file_list:
+        deps_file = find(f, path)
+        if not deps_file:
+            continue
+        file_handle= open(deps_file)
+
+        if f == 'Requirement.txt':
+            dependency_list = parse_requirement_txt(file_handle)
+
+        elif f == 'setup.py':
+            dependency_list = parse_setup_py(file_handle)
+
+        elif f == 'Pipfile':
+            dependency_list = parse_pipfile(file_handle)
+
+        elif f == 'Pipfile.lock':
+            dependency_list = parse_pipfile_lock(file_handle)
+
+        elif f == 'pyproject.toml':
+            dependency_list = parse_poetry(file_handle)
+
+        elif f == 'poetry.lock':
+            dependency_list = parse_poetry_lock(file_handle)
+
+        elif f == 'environment.yml':
+            dependency_list = parse_conda(file_handle)
+
+        elif f == 'environment.yaml':
+            dependency_list = parse_conda(file_handle)
+
+        elif f == 'environment.yml.lock':
+            dependency_list = parse_conda(file_handle)
+
+        elif f == 'environment.yaml.lock':
+            dependency_list = parse_conda(file_handle)                
+        return dependency_list
 
 
 def get_libyear(current_version, current_release_date, latest_version, latest_release_date):
@@ -21,3 +88,40 @@ def get_libyear(current_version, current_release_date, latest_version, latest_re
     print(libdays)
     libyear = libdays/365
     return libyear
+
+
+def get_deps_libyear_data(path):
+    current_release_date = None
+    libyear = None
+
+    dependencies = get_parsed_deps(path)
+    if dependencies:
+        for dependency in dependencies:
+            data = get_pypi_data(dependency['name'])
+            current_version = sort_dependency_requirement(dependency,data)
+            latest_version = get_latest_version(data)
+            latest_release_date = get_release_date(data, latest_version)
+            if current_version:
+                current_release_date = get_release_date(data, current_version)
+            libyear = get_libyear(current_version, current_release_date, latest_version, latest_release_date)
+            if not latest_release_date:
+                latest_release_date = dateutil.parser.parse('1970-01-01 00:00:00')
+                libyear = -1
+
+            if not latest_version:
+                latest_version = 'unspecified'     
+
+            if not current_version:
+                current_version = latest_version
+                current_release_date = latest_release_date
+
+            if not dependency['requirement']:
+                dependency['requirement'] = 'unspecified'    
+
+            dependency['current_version'] = current_version    
+            dependency['latest_version'] = latest_version
+            dependency['current_release_date'] = current_release_date
+            dependency['latest_release_date'] = latest_release_date
+            dependency['libyear'] = libyear
+
+        return dependencies 

--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -5,6 +5,7 @@ import os
 from pypi_parser import parse_conda, parse_pipfile,parse_pipfile_lock,parse_poetry,parse_poetry_lock,parse_requirement_txt,parse_setup_py
 from npm_parser import parse_package_json
 from pypi_libyear_util import sort_dependency_requirement,get_pypi_data,get_latest_version,get_release_date
+from npm_libyear_utils import get_NPM_data, get_release_date
 
 #Files That would be parsed should be added here
 file_list = [
@@ -97,12 +98,17 @@ def get_deps_libyear_data(path):
     dependencies = get_parsed_deps(path)
     if dependencies:
         for dependency in dependencies:
-            data = get_pypi_data(dependency['name'])
-            current_version = sort_dependency_requirement(dependency,data)
-            latest_version = get_latest_version(data)
-            latest_release_date = get_release_date(data, latest_version)
-            if current_version:
-                current_release_date = get_release_date(data, current_version)
+            #NOTE: Add new if for new package parser
+            if dependency['package'] == 'PYPI':
+                data = get_pypi_data(dependency['name'])
+                current_version = sort_dependency_requirement(dependency,data)
+                latest_version = get_latest_version(data)
+                latest_release_date = get_release_date(data, latest_version)
+                if current_version:
+                    current_release_date = get_release_date(data, current_version)
+            if dependency['package'] == 'NPM':
+                data = get_NPM_data(dependency['name'])
+                
             libyear = get_libyear(current_version, current_release_date, latest_version, latest_release_date)
             if not latest_release_date:
                 latest_release_date = dateutil.parser.parse('1970-01-01 00:00:00')

--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -18,7 +18,8 @@ file_list = [
     'environment.yml',
     'environment.yaml',
     'environment.yml.lock',
-    'environment.yaml.lock'
+    'environment.yaml.lock',
+    'package.json'
 ]
 
 
@@ -67,7 +68,11 @@ def get_parsed_deps(path):
             dependency_list = parse_conda(file_handle)
 
         elif f == 'environment.yaml.lock':
-            dependency_list = parse_conda(file_handle)                
+            dependency_list = parse_conda(file_handle) 
+            
+        elif f == 'package.json':
+            dependency_list = parse_package_json(file_handle)
+        
         return dependency_list
 
 
@@ -98,6 +103,7 @@ def get_deps_libyear_data(path):
     dependencies = get_parsed_deps(path)
     if dependencies:
         for dependency in dependencies:
+
             #NOTE: Add new if for new package parser
             if dependency['package'] == 'PYPI':
                 data = get_pypi_data(dependency['name'])
@@ -106,6 +112,7 @@ def get_deps_libyear_data(path):
                 latest_release_date = get_release_date(data, latest_version)
                 if current_version:
                     current_release_date = get_release_date(data, current_version)
+
             elif dependency['package'] == 'NPM':
                 data = get_NPM_data(dependency['name'])
                 current_version = get_npm_current_version(data, dependency['requirement'])

--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -1,0 +1,23 @@
+from distutils.version import LooseVersion
+import dateutil.parser
+from distutils import version
+
+
+def get_libyear(current_version, current_release_date, latest_version, latest_release_date):
+
+    if not latest_version:
+        return -1
+    
+    if not latest_release_date:
+        return -1
+
+    if not current_version:
+        return 0
+
+    current_release_date= dateutil.parser.parse(current_release_date)
+    latest_release_date = dateutil.parser.parse(latest_release_date)    
+
+    libdays = (latest_release_date - current_release_date).days
+    print(libdays)
+    libyear = libdays/365
+    return libyear

--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -5,7 +5,7 @@ import os
 from pypi_parser import parse_conda, parse_pipfile,parse_pipfile_lock,parse_poetry,parse_poetry_lock,parse_requirement_txt,parse_setup_py
 from npm_parser import parse_package_json
 from pypi_libyear_util import sort_dependency_requirement,get_pypi_data,get_latest_version,get_release_date
-from npm_libyear_utils import get_NPM_data, get_release_date
+from npm_libyear_utils import get_NPM_data, get_npm_release_date, get_npm_latest_version,get_npm_current_version
 
 #Files That would be parsed should be added here
 file_list = [
@@ -106,9 +106,14 @@ def get_deps_libyear_data(path):
                 latest_release_date = get_release_date(data, latest_version)
                 if current_version:
                     current_release_date = get_release_date(data, current_version)
-            if dependency['package'] == 'NPM':
+            elif dependency['package'] == 'NPM':
                 data = get_NPM_data(dependency['name'])
-                
+                current_version = get_npm_current_version(dependency['requirement'])
+                latest_version = get_npm_latest_version(data)
+                latest_release_date = get_npm_release_date(data, latest_version)
+                if current_version:
+                    current_release_date = get_npm_release_date(data, current_version)
+
             libyear = get_libyear(current_version, current_release_date, latest_version, latest_release_date)
             if not latest_release_date:
                 latest_release_date = dateutil.parser.parse('1970-01-01 00:00:00')

--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -108,7 +108,7 @@ def get_deps_libyear_data(path):
                     current_release_date = get_release_date(data, current_version)
             elif dependency['package'] == 'NPM':
                 data = get_NPM_data(dependency['name'])
-                current_version = get_npm_current_version(dependency['requirement'])
+                current_version = get_npm_current_version(data, dependency['requirement'])
                 latest_version = get_npm_latest_version(data)
                 latest_release_date = get_npm_release_date(data, latest_version)
                 if current_version:

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -57,3 +57,7 @@ def get_release_date(data, version):
 
 def get_latest_version(data):
     return data['dist-tags']['latest']
+
+
+def get_current_version(requirement):
+    pass

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -1,0 +1,3 @@
+import json
+import os, re
+import requests

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -40,7 +40,7 @@ def get_lastest_minor(version, data):
         #NOTE: Add error logging here
         pass
     major,minor,patch = version.split('.')
-    consider_version = version
+    consider_version = get_latest_patch(version, data)
     for v in list(versions.keys())[index:]:
         if v.split('.')[0]==major:
             if v.split('.')[1]>minor:
@@ -59,5 +59,10 @@ def get_npm_latest_version(data):
     return data['dist-tags']['latest']
 
 #add code here
-def get_npm_current_version(requirement):
-    pass
+def get_npm_current_version(data, requirement):
+    if requirement[0]=='~':
+        return get_latest_patch(clean_version(requirement), data)
+    elif requirement[0]=='^':
+        return get_lastest_minor(clean_version(requirement), data)
+    else:
+        return requirement

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -10,6 +10,11 @@ def get_NPM_data(package):
     return {}
 
 
+def clean_version(version):
+    version = [v for v in version if v.isdigit() or v == '.']
+    return ''.join(version)
+
+
 def get_latest_patch(version, data):
     versions = data['versions']
     try:
@@ -25,3 +30,19 @@ def get_latest_patch(version, data):
                 if v.split('.')[2]>patch:
                     consider_version = v
     return consider_version
+
+
+def get_lastest_minor(version, data):
+    versions = data['versions']
+    try:
+        index = list(versions.keys()).index(version)
+    except:
+        #NOTE: Add error logging here
+        pass
+    major,minor,patch = version.split('.')
+    consider_version = version
+    for v in list(versions.keys())[index:]:
+        if v.split('.')[0]==major:
+            if v.split('.')[1]>minor:
+                    consider_version = v
+    return consider_version 

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -1,3 +1,12 @@
 import json
 import os, re
 import requests
+
+def get_NPM_data(package):
+    url = "https://registry.npmjs.org/%s" % package
+    r = requests.get(url)
+    if r.status_code < 400:
+        return r.json()
+    return {}
+
+

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -49,7 +49,7 @@ def get_lastest_minor(version, data):
 
 
 def get_npm_release_date(data, version):
-    release_time = data['time']['version']
+    release_time = data['time'][version]
     if release_time:
         return release_time
     return None

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -10,3 +10,18 @@ def get_NPM_data(package):
     return {}
 
 
+def get_latest_patch(version, data):
+    versions = data['versions']
+    try:
+        index = list(versions.keys()).index(version)
+    except:
+        #NOTE: Add error logging here
+        pass
+    major,minor,patch = version.split('.')
+    consider_version = version
+    for v in list(versions.keys())[index:]:
+        if v.split('.')[0]==major:
+            if v.split('.')[1]== minor:
+                if v.split('.')[2]>patch:
+                    consider_version = v
+    return consider_version

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -46,3 +46,14 @@ def get_lastest_minor(version, data):
             if v.split('.')[1]>minor:
                     consider_version = v
     return consider_version 
+
+
+def get_release_date(data, version):
+    release_time = data['time']['version']
+    if release_time:
+        return release_time
+    return None
+
+
+def get_latest_version(data):
+    return data['dist-tags']['latest']

--- a/workers/deps_libyear_worker/npm_libyear_utils.py
+++ b/workers/deps_libyear_worker/npm_libyear_utils.py
@@ -48,16 +48,16 @@ def get_lastest_minor(version, data):
     return consider_version 
 
 
-def get_release_date(data, version):
+def get_npm_release_date(data, version):
     release_time = data['time']['version']
     if release_time:
         return release_time
     return None
 
 
-def get_latest_version(data):
+def get_npm_latest_version(data):
     return data['dist-tags']['latest']
 
-
-def get_current_version(requirement):
+#add code here
+def get_npm_current_version(requirement):
     pass

--- a/workers/deps_libyear_worker/npm_parser.py
+++ b/workers/deps_libyear_worker/npm_parser.py
@@ -1,0 +1,19 @@
+import json
+
+def map_dependencies(dict, key, type):
+    deps = list()
+    if not dict:
+        return []
+    for name, info in dict[key].items():
+        Dict = {'name': name, 'requirement': info, 'type': type, 'package': 'NPM'}
+        deps.append(Dict)
+    return deps
+
+
+def parse_package_json(file_handle):
+    manifest = json.load(file_handle)
+    return map_dependencies(manifest, 'dependencies', 'runtime') + map_dependencies(manifest, 'devDependencies', 'development')
+
+
+# def parse_package_lock(file_handle):
+

--- a/workers/deps_libyear_worker/pypi_parser.py
+++ b/workers/deps_libyear_worker/pypi_parser.py
@@ -176,82 +176,82 @@ def parse_conda(file_handle):
     return deps    
 
 
-def get_parsed_deps(path):
+# def get_parsed_deps(path):
 
-    deps_file = None
-    dependency_list = list()
+#     deps_file = None
+#     dependency_list = list()
 
-    for f in file_list:
-        deps_file = find(f, path)
-        if not deps_file:
-            continue
-        file_handle= open(deps_file)
+#     for f in file_list:
+#         deps_file = find(f, path)
+#         if not deps_file:
+#             continue
+#         file_handle= open(deps_file)
 
-        if f == 'Requirement.txt':
-            dependency_list = parse_requirement_txt(file_handle)
+#         if f == 'Requirement.txt':
+#             dependency_list = parse_requirement_txt(file_handle)
 
-        elif f == 'setup.py':
-            dependency_list = parse_setup_py(file_handle)
+#         elif f == 'setup.py':
+#             dependency_list = parse_setup_py(file_handle)
 
-        elif f == 'Pipfile':
-            dependency_list = parse_pipfile(file_handle)
+#         elif f == 'Pipfile':
+#             dependency_list = parse_pipfile(file_handle)
 
-        elif f == 'Pipfile.lock':
-            dependency_list = parse_pipfile_lock(file_handle)
+#         elif f == 'Pipfile.lock':
+#             dependency_list = parse_pipfile_lock(file_handle)
 
-        elif f == 'pyproject.toml':
-            dependency_list = parse_poetry(file_handle)
+#         elif f == 'pyproject.toml':
+#             dependency_list = parse_poetry(file_handle)
 
-        elif f == 'poetry.lock':
-            dependency_list = parse_poetry_lock(file_handle)
+#         elif f == 'poetry.lock':
+#             dependency_list = parse_poetry_lock(file_handle)
 
-        elif f == 'environment.yml':
-            dependency_list = parse_conda(file_handle)
+#         elif f == 'environment.yml':
+#             dependency_list = parse_conda(file_handle)
 
-        elif f == 'environment.yaml':
-            dependency_list = parse_conda(file_handle)
+#         elif f == 'environment.yaml':
+#             dependency_list = parse_conda(file_handle)
 
-        elif f == 'environment.yml.lock':
-            dependency_list = parse_conda(file_handle)
+#         elif f == 'environment.yml.lock':
+#             dependency_list = parse_conda(file_handle)
 
-        elif f == 'environment.yaml.lock':
-            dependency_list = parse_conda(file_handle)                
-        return dependency_list
+#         elif f == 'environment.yaml.lock':
+#             dependency_list = parse_conda(file_handle)                
+#         return dependency_list
 
 
 
-def get_deps_libyear_data(path):
-    current_release_date = None
-    libyear = None
+# def get_deps_libyear_data(path):
+#     current_release_date = None
+#     libyear = None
 
-    dependencies = get_parsed_deps(path)
-    if dependencies:
-        for dependency in dependencies:
-            data = get_pypi_data(dependency['name'])
-            current_version = sort_dependency_requirement(dependency,data)
-            latest_version = get_latest_version(data)
-            latest_release_date = get_release_date(data, latest_version)
-            if current_version:
-                current_release_date = get_release_date(data, current_version)
-            libyear = get_libyear(current_version, current_release_date, latest_version, latest_release_date)
-            if not latest_release_date:
-                latest_release_date = dateutil.parser.parse('1970-01-01 00:00:00')
-                libyear = -1
+#     dependencies = get_parsed_deps(path)
+#     if dependencies:
+#         for dependency in dependencies:
+#             data = get_pypi_data(dependency['name'])
+#             current_version = sort_dependency_requirement(dependency,data)
+#             latest_version = get_latest_version(data)
+#             latest_release_date = get_release_date(data, latest_version)
+#             if current_version:
+#                 current_release_date = get_release_date(data, current_version)
+#             libyear = get_libyear(current_version, current_release_date, latest_version, latest_release_date)
+#             if not latest_release_date:
+#                 latest_release_date = dateutil.parser.parse('1970-01-01 00:00:00')
+#                 libyear = -1
 
-            if not latest_version:
-                latest_version = 'unspecified'     
+#             if not latest_version:
+#                 latest_version = 'unspecified'     
 
-            if not current_version:
-                current_version = latest_version
-                current_release_date = latest_release_date
+#             if not current_version:
+#                 current_version = latest_version
+#                 current_release_date = latest_release_date
 
-            if not dependency['requirement']:
-                dependency['requirement'] = 'unspecified'    
+#             if not dependency['requirement']:
+#                 dependency['requirement'] = 'unspecified'    
 
-            dependency['current_version'] = current_version    
-            dependency['latest_version'] = latest_version
-            dependency['current_release_date'] = current_release_date
-            dependency['latest_release_date'] = latest_release_date
-            dependency['libyear'] = libyear
+#             dependency['current_version'] = current_version    
+#             dependency['latest_version'] = latest_version
+#             dependency['current_release_date'] = current_release_date
+#             dependency['latest_release_date'] = latest_release_date
+#             dependency['libyear'] = libyear
 
-        return dependencies    
+#         return dependencies    


### PR DESCRIPTION
This introduces parser for package.json 
'~' kind of version representation considers the latest patch 
'^' kind of version representation considers the latest minor/patch
For calculating libyear, The lastest **STABLE** version is considered and not alpha/beta

Changes in the structure of the worker to make code understandable