### PR TITLE
Fix _add_nested_columns method

### DIFF
--- a/workers/worker_persistance.py
+++ b/workers/worker_persistance.py
@@ -913,6 +913,10 @@ class Persistant():
             self.logger.debug(f"column included: {column}.")
             if '.' not in column:
                 continue
+            # if the column is already present then we
+            # dont' need to try to add it again
+            if column in df.columns:
+                continue
             root = column.split('.')[0]
             if root not in df.columns:
                 df[root] = None


### PR DESCRIPTION
I added an if statement that checks if the nested column has already been inserted. 

The error was happening because it was trying to add two json fields that are nested in the user field. So the first one ran fine and got all the user fields, but when it tried to add the second one it already had those fields added so it errored. Therefore we needed an if statement to check if the column has already been inserted, and if it has we need to continue