### PR TITLE
Isaac commit resolution

### DIFF
--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -626,6 +626,11 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                                   'repo_id': repo_id}).to_json(orient="records"))
 
         # Try to get GitHub API user data from each unique commit email.
+
+        self.logger.info(
+            f"DEBUG: The data to process looks like this: {new_contribs}"
+        )
+
         for contributor in new_contribs:
 
             # Get the email from the commit data

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -428,10 +428,11 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
 
         canonical_email = contributor_table_data[0]['cntrb_canonical']
         #check if the contributor has a NULL canonical email or not
-        self.logger.info(f"The value of the canonical email is : {canonical_email}")
+        #self.logger.info(f"The value of the canonical email is : {canonical_email}")
 
         if canonical_email is not None:
             del cntrb["cntrb_canonical"]
+            self.logger.info("Existing canonical email found in database and will not be overwritten.")
 
         while attempts < max_attempts:
             try:

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -630,10 +630,9 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
 
         # Try to get GitHub API user data from each unique commit email.
 
-        #TODO: Remove debug statements before any merge.
-        self.logger.info(
-            f"DEBUG: The data to process looks like this: {new_contribs}"
-        )
+        #self.logger.info(
+        #    f"DEBUG: The data to process looks like this: {new_contribs}"
+        #)
 
         for contributor in new_contribs:
 

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -842,7 +842,7 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
         # Create endpoint for committers in a repo.
         url = "https://api.github.com/repos/" + repo_path + "/contributors?state=all&direction=asc&per_page=100&page={}"
 
-        self.logger.info(f"Url: {url}")
+        #self.logger.info(f"Url: {url}")
 
         return url
 

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -789,9 +789,14 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                 AND commits.repo_id = :repo_id
         """)
 
+        self.logger.info("DEBUG: got passed the sql statement declaration")
         # Get a list of dicts that contain the emails and cntrb_id's of commits that appear in the contributor's table.
         existing_cntrb_emails = json.loads(pd.read_sql(resolve_email_to_cntrb_id_sql, self.db, params={
                                            'repo_id': repo_id}).to_json(orient="records"))
+
+        self.logger.info("DEBUG: got passed the sql statement's execution")
+
+        self.logger.info(f"DEBUG: Here are the existing emails: {existing_cntrb_emails}")
 
         # iterate through all the commits with emails that appear in contributors and give them the relevant cntrb_id.
         for cntrb_email in existing_cntrb_emails:

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -778,14 +778,17 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                 AND commits.repo_id = :repo_id
             UNION
             SELECT DISTINCT
-                cntrb_id,
+                contributors_aliases.cntrb_id,
+                                contributors.cntrb_login as login, 
                 contributors_aliases.alias_email AS email,
                 commits.cmt_author_raw_email
             FROM
+                              contributors,
                 contributors_aliases,
                 commits
             WHERE
                 contributors_aliases.alias_email = commits.cmt_author_raw_email
+                                AND contributors.cntrb_id = contributors_aliases.cntrb_id
                 AND commits.repo_id = :repo_id
         """)
 

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -627,6 +627,7 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
 
         # Try to get GitHub API user data from each unique commit email.
 
+        #TODO: Remove debug statements before any merge.
         self.logger.info(
             f"DEBUG: The data to process looks like this: {new_contribs}"
         )
@@ -758,6 +759,8 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
             except Exception as e:
                 self.logger.info(
                     f"Deleting now resolved email failed with error: {e}")
+
+        self.logger.info("DEBUG: Got through the new_contribs")
 
         # sql query used to find corresponding cntrb_id's of emails found in the contributor's table
         # i.e., if a contributor already exists, we use it!

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -557,8 +557,7 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
             if item['score'] > match['score']:
                 match = item
 
-        self.logger.info("When searching for a contributor with info {}, we found the following users: {}\n".format(
-            contributor, match))
+        self.logger.info("When searching for a contributor with info {}, we found the following users: {}\n".format(match))
         
         return match['login']
 
@@ -762,7 +761,7 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                 self.logger.info(
                     f"Deleting now resolved email failed with error: {e}")
 
-        self.logger.info("DEBUG: Got through the new_contribs")
+        #self.logger.info("DEBUG: Got through the new_contribs")
 
         # sql query used to find corresponding cntrb_id's of emails found in the contributor's table
         # i.e., if a contributor already exists, we use it!
@@ -794,14 +793,14 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                 AND commits.repo_id = :repo_id
         """)
 
-        self.logger.info("DEBUG: got passed the sql statement declaration")
+        #self.logger.info("DEBUG: got passed the sql statement declaration")
         # Get a list of dicts that contain the emails and cntrb_id's of commits that appear in the contributor's table.
         existing_cntrb_emails = json.loads(pd.read_sql(resolve_email_to_cntrb_id_sql, self.db, params={
                                            'repo_id': repo_id}).to_json(orient="records"))
 
-        self.logger.info("DEBUG: got passed the sql statement's execution")
+        #self.logger.info("DEBUG: got passed the sql statement's execution")
 
-        self.logger.info(f"DEBUG: Here are the existing emails: {existing_cntrb_emails}")
+        #self.logger.info(f"DEBUG: Here are the existing emails: {existing_cntrb_emails}")
 
         # iterate through all the commits with emails that appear in contributors and give them the relevant cntrb_id.
         for cntrb_email in existing_cntrb_emails:

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -557,7 +557,7 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
             if item['score'] > match['score']:
                 match = item
 
-        self.logger.info("When searching for a contributor with info {}, we found the following users: {}\n".format(match))
+        self.logger.info("When searching for a contributor, we found the following users: {}\n".format(match))
         
         return match['login']
 

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -570,11 +570,14 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
         #Send api request
         login_json = self.request_dict_from_endpoint(url)
         
-        if login_json == None or 'sha' not in login_json:
+        if login_json is None or 'sha' not in login_json:
             self.logger.info("Search query returned empty data. Moving on")
             return None
 
-        match = login_json['author']['login']
+        try:
+            match = login_json['author']['login']
+        except:
+            match = None
         
         return match
 

--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -1001,9 +1001,12 @@ class WorkerGitInterfaceable(Worker):
                 self.oauths[0]['rate_limit'] -= 1
                 self.logger.info("Headers did not work, had to decrement")
                 time.sleep(30)
+
         self.logger.info(
             f"Updated rate limit, you have: {self.oauths[0]['rate_limit']} requests remaining."
         )
+
+        #Stalls after here for some reason.
         if self.oauths[0]['rate_limit'] <= 0:
             try:
                 reset_time = response.headers['X-RateLimit-Reset']


### PR DESCRIPTION
The facade worker now uses the commit sha to attempt to resolve commit emails to contributors  before anything else. Also other smaller changes to log statements and minor refactors to make more readable. 