### PR TITLE
CRITICAL: Tensorflow version casuing installation error

### DIFF
--- a/workers/message_insights_worker/setup.py
+++ b/workers/message_insights_worker/setup.py
@@ -37,7 +37,7 @@ setup(
         'emoji==1.2.0',
         'Keras>=2.8.0rc0',
         'Keras-Preprocessing==1.1.2',
-        'tensorflow==2.8.0rc0',
+        'tensorflow==2.8.0',
         'h5py~=3.6.0',
         'scikit-image==0.19.1',
         'joblib==1.0.1',


### PR DESCRIPTION
1. There was an error in the setup.py for the message insights worker that said `tensorflow==2.8.0rc0`, which needs to be `tensorflow==2.8.0`.

This typo was causing `make rebuild-dev` and `make install-dev` to both error when they made it to the message_insights_worker installation.
