### PR TITLE
Visualization Error Delivery

### DIFF
--- a/augur/routes/contributor_reports.py
+++ b/augur/routes/contributor_reports.py
@@ -361,12 +361,24 @@ def create_routes(server):
         end_date = str(request.args.get('end_date', "{}-{}-{}".format(now.year, now.month, now.day)))
 
         if repo_id:
-            if start_date < end_date:
-                return int(repo_id), start_date, end_date
-            else:
-                return int(repo_id), None, None
 
-        return None, None, None
+            if start_date < end_date:
+                return int(repo_id), start_date, end_date, None
+            else:
+
+                error = {
+                    "message": "Invalid end_date. end_date is before the start_date",
+                    "status_code": 400
+                }
+
+                return int(repo_id), None, None, error
+
+        else:
+            error = {
+                "message": "repo_id not specified. Use this endpoint to get a list of available repos: http://<your_host>/api/unstable/repos",
+                "status_code": 400
+            }
+            return None, None, None, error
 
     def filter_out_repeats_without_required_contributions_in_required_time(repeat_list, repeats_df, required_time,
                                                                            first_list):
@@ -576,13 +588,12 @@ def create_routes(server):
     @server.app.route('/{}/contributor_reports/new_contributors_bar/'.format(server.api_version), methods=["GET"])
     def new_contributors_bar():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         group_by, required_contributions, required_time = get_new_cntrb_bar_chart_query_params()
 
@@ -747,13 +758,12 @@ def create_routes(server):
                       methods=["GET"])
     def new_contributors_stacked_bar():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         group_by, required_contributions, required_time = get_new_cntrb_bar_chart_query_params()
 
@@ -951,13 +961,12 @@ def create_routes(server):
                       methods=["GET"])
     def returning_contributors_pie_chart():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         required_contributions = int(request.args.get('required_contributions', 4))
         required_time = int(request.args.get('required_time', 365))
@@ -1084,13 +1093,12 @@ def create_routes(server):
                       methods=["GET"])
     def returning_contributors_stacked_bar():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         group_by = str(request.args.get('group_by', "quarter"))
         required_contributions = int(request.args.get('required_contributions', 4))

--- a/augur/routes/contributor_reports.py
+++ b/augur/routes/contributor_reports.py
@@ -361,17 +361,8 @@ def create_routes(server):
         end_date = str(request.args.get('end_date', "{}-{}-{}".format(now.year, now.month, now.day)))
 
         if repo_id:
-
-        else:
-            error = {
-                "message": "No repo_id",
-                ""
-            }
-            return None, None, None,
-
-        if repo_id:
             if start_date < end_date:
-                return int(repo_id), start_date, end_date, None
+                return int(repo_id), start_date, end_date
             else:
                 return int(repo_id), None, None
 
@@ -585,12 +576,13 @@ def create_routes(server):
     @server.app.route('/{}/contributor_reports/new_contributors_bar/'.format(server.api_version), methods=["GET"])
     def new_contributors_bar():
 
-        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
 
-        if error:
-            return Response(response=error['message'],
+        if repo_id is None:
+            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
+                                     "http://<your_host>/api/unstable/repos",
                             mimetype='application/json',
-                            status=error['status_code'])
+                            status=400)
 
         group_by, required_contributions, required_time = get_new_cntrb_bar_chart_query_params()
 
@@ -760,11 +752,6 @@ def create_routes(server):
         if repo_id is None:
             return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
                                      "http://<your_host>/api/unstable/repos",
-                            mimetype='application/json',
-                            status=400)
-
-        if start_date is None:
-            return Response(response="Invalid request. The end_date is less than or equal to the start_date",
                             mimetype='application/json',
                             status=400)
 
@@ -972,11 +959,6 @@ def create_routes(server):
                             mimetype='application/json',
                             status=400)
 
-        if start_date is None:
-            return Response(response="Invalid request. The end_date is less than or equal to the start_date",
-                            mimetype='application/json',
-                            status=400)
-
         required_contributions = int(request.args.get('required_contributions', 4))
         required_time = int(request.args.get('required_time', 365))
 
@@ -1107,11 +1089,6 @@ def create_routes(server):
         if repo_id is None:
             return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
                                      "http://<your_host>/api/unstable/repos",
-                            mimetype='application/json',
-                            status=400)
-
-        if start_date is None:
-            return Response(response="Invalid request. The end_date is less than or equal to the start_date",
                             mimetype='application/json',
                             status=400)
 

--- a/augur/routes/contributor_reports.py
+++ b/augur/routes/contributor_reports.py
@@ -361,7 +361,19 @@ def create_routes(server):
         end_date = str(request.args.get('end_date', "{}-{}-{}".format(now.year, now.month, now.day)))
 
         if repo_id:
-            return int(repo_id), start_date, end_date
+
+        else:
+            error = {
+                "message": "No repo_id",
+                ""
+            }
+            return None, None, None,
+
+        if repo_id:
+            if start_date < end_date:
+                return int(repo_id), start_date, end_date, None
+            else:
+                return int(repo_id), None, None
 
         return None, None, None
 
@@ -573,13 +585,12 @@ def create_routes(server):
     @server.app.route('/{}/contributor_reports/new_contributors_bar/'.format(server.api_version), methods=["GET"])
     def new_contributors_bar():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error['message'],
                             mimetype='application/json',
-                            status=400)
+                            status=error['status_code'])
 
         group_by, required_contributions, required_time = get_new_cntrb_bar_chart_query_params()
 
@@ -749,6 +760,11 @@ def create_routes(server):
         if repo_id is None:
             return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
                                      "http://<your_host>/api/unstable/repos",
+                            mimetype='application/json',
+                            status=400)
+
+        if start_date is None:
+            return Response(response="Invalid request. The end_date is less than or equal to the start_date",
                             mimetype='application/json',
                             status=400)
 
@@ -956,6 +972,11 @@ def create_routes(server):
                             mimetype='application/json',
                             status=400)
 
+        if start_date is None:
+            return Response(response="Invalid request. The end_date is less than or equal to the start_date",
+                            mimetype='application/json',
+                            status=400)
+
         required_contributions = int(request.args.get('required_contributions', 4))
         required_time = int(request.args.get('required_time', 365))
 
@@ -1086,6 +1107,11 @@ def create_routes(server):
         if repo_id is None:
             return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
                                      "http://<your_host>/api/unstable/repos",
+                            mimetype='application/json',
+                            status=400)
+
+        if start_date is None:
+            return Response(response="Invalid request. The end_date is less than or equal to the start_date",
                             mimetype='application/json',
                             status=400)
 

--- a/augur/routes/pull_request_reports.py
+++ b/augur/routes/pull_request_reports.py
@@ -437,23 +437,34 @@ def create_routes(server):
         end_date = str(request.args.get('end_date', "{}-{}-{}".format(now.year, now.month, now.day)))
 
         if repo_id:
-            if start_date < end_date:
-                return int(repo_id), start_date, end_date
-            else:
-                return int(repo_id), None, None
 
-        return None, None, None
+            if start_date < end_date:
+                return int(repo_id), start_date, end_date, None
+            else:
+
+                error = {
+                    "message": "Invalid end_date. end_date is before the start_date",
+                    "status_code": 400
+                }
+
+                return int(repo_id), None, None, error
+
+        else:
+            error = {
+                "message": "repo_id not specified. Use this endpoint to get a list of available repos: http://<your_host>/api/unstable/repos",
+                "status_code": 400
+            }
+            return None, None, None, error
 
     @server.app.route('/{}/pull_request_reports/average_commits_per_PR/'.format(server.api_version), methods=["GET"])
     def average_commits_per_PR():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         group_by = str(request.args.get('group_by', "month"))
         return_json = request.args.get('return_json', "false")
@@ -593,13 +604,12 @@ def create_routes(server):
     @server.app.route('/{}/pull_request_reports/average_comments_per_PR/'.format(server.api_version), methods=["GET"])
     def average_comments_per_PR():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         return_json = request.args.get('return_json', "false")
 
@@ -776,13 +786,12 @@ def create_routes(server):
                       methods=["GET"])
     def PR_counts_by_merged_status():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         return_json = request.args.get('return_json', "false")
 
@@ -969,13 +978,12 @@ def create_routes(server):
                       methods=["GET"])
     def mean_response_times_for_PR():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         return_json = request.args.get('return_json', "false")
 
@@ -1269,13 +1277,12 @@ def create_routes(server):
                       methods=["GET"])
     def mean_days_between_PR_comments():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         return_json = request.args.get('return_json', "false")
 
@@ -1437,13 +1444,12 @@ def create_routes(server):
     @server.app.route('/{}/pull_request_reports/PR_time_to_first_response/'.format(server.api_version), methods=["GET"])
     def PR_time_to_first_response():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         return_json = request.args.get('return_json', "false")
         remove_outliers = str(request.args.get('remove_outliers', "true"))
@@ -1574,13 +1580,12 @@ def create_routes(server):
                       methods=["GET"])
     def average_PR_events_for_closed_PRs():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
 
         return_json = request.args.get('return_json', "false")
         include_comments = str(request.args.get('include_comments', True))
@@ -1763,13 +1768,12 @@ def create_routes(server):
     @server.app.route('/{}/pull_request_reports/Average_PR_duration/'.format(server.api_version), methods=["GET"])
     def Average_PR_duration():
 
-        repo_id, start_date, end_date = get_repo_id_start_date_and_end_date()
+        repo_id, start_date, end_date, error = get_repo_id_start_date_and_end_date()
 
-        if repo_id is None:
-            return Response(response="repo_id not specified. Use this endpoint to get a list of available repos: "
-                                     "http://<your_host>/api/unstable/repos",
+        if error:
+            return Response(response=error["message"],
                             mimetype='application/json',
-                            status=400)
+                            status=error["status_code"])
         
         group_by = str(request.args.get('group_by', "month"))
         return_json = request.args.get('return_json', "false")

--- a/augur/routes/pull_request_reports.py
+++ b/augur/routes/pull_request_reports.py
@@ -437,7 +437,10 @@ def create_routes(server):
         end_date = str(request.args.get('end_date', "{}-{}-{}".format(now.year, now.month, now.day)))
 
         if repo_id:
-            return int(repo_id), start_date, end_date
+            if start_date < end_date:
+                return int(repo_id), start_date, end_date
+            else:
+                return int(repo_id), None, None
 
         return None, None, None
 


### PR DESCRIPTION
1. Added check on start_date and end_date for visualizations. If the end_date is before the start_date, it will respond with an error.
2. With the increasing number of errors being caught, I moved the error checking to the `get_repo_id_start_date_and_end_date()` method, which sends an error object back if an error occurs. Then the endpoint code checks if there is an error object. If there is, it gets the message and status code from the error object and sends them to the user.