### PR TITLE
Fix Workers Connecting to Broker Twice

### DIFF
--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -36,8 +36,6 @@ class WorkerGitInterfaceable(Worker):
         }
 
         # Send broker hello message
-        if self.config['offline_mode'] is False:
-            self.connect_to_broker()
 
 				# Attempts to determine if these attributes exist
 				# If not, it creates them with default values


### PR DESCRIPTION
Many of the workers have shown in the logs that they connected to the broker twice. While it hasn't seemed to cause any issues, it does not need to be happening. I figured out that the method call for a worker to connect to the broker was being made in the `__init__` method of the `Worker` class and the `WorkerGitInterfaceable` class. And since the `WorkerGitInterfaceable` class inherits from the `Worker` class, any time the `WorkerGitInterfaceable` class is instantiated, the broker is connected to twice. With a worker this happens because most of them inherit from `WorkerGitInterfaceable`. As additional proof that this is the issue, you can see that workers (facade worker) that inherit from just the `Worker` class don't have the issue, but workers (github_worker, pr_worker, gitlab_issues_worker) that inherit from `WorkerGitInterfaceable` do. 
