### PR TITLE
Changes to speed up facade commit contributor resolution

### DIFF
--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -540,6 +540,8 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
         #    f"DEBUG: The data to process looks like this: {new_contribs}"
         # )
 
+        logSkippedSection = True
+
         for contributor in new_contribs:
 
             # Get the email from the commit data
@@ -557,12 +559,20 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                 ).fetchall()
                 if len(alias_table_data) >= 1:
                     # Move on if email resolved
-                    self.logger.info(
-                        f"Email {email} has been resolved earlier.")
+
+                    #Only log the skip the first time to avoid redundancy
+                    if logSkippedSection:
+                        self.logger.info(
+                            f"Email {email} has been resolved earlier.")
+                        logSkippedSection = False
+                    
+
                     continue
             except Exception as e:
                 self.logger.info(
                     f"alias table query failed with error: {e}")
+            
+            logSkippedSection = True
                 
             #Check the unresolved_commits table to avoid hitting endpoints that we know don't have relevant data needlessly
             try:
@@ -573,7 +583,7 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                 ).fetchall()
                 
                 if len(unresolved_query_result) >= 1:
-                    self.logger.info(f"Commit data has been unresolved in the past, skipping...")
+                    self.logger.info(f"Commit data with email {email} has been unresolved in the past, skipping...")
                     continue
             except Exception as e:
                 self.logger.info(f"Failed to query unresolved alias table with error: {e}")

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -571,8 +571,6 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
             except Exception as e:
                 self.logger.info(
                     f"alias table query failed with error: {e}")
-            
-            logSkippedSection = True
                 
             #Check the unresolved_commits table to avoid hitting endpoints that we know don't have relevant data needlessly
             try:
@@ -583,12 +581,16 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
                 ).fetchall()
                 
                 if len(unresolved_query_result) >= 1:
-                    self.logger.info(f"Commit data with email {email} has been unresolved in the past, skipping...")
+                    if logSkippedSection:
+                        self.logger.info(f"Commit data with email {email} has been unresolved in the past, skipping...")
+                    
+                    logSkippedSection = False
                     continue
             except Exception as e:
                 self.logger.info(f"Failed to query unresolved alias table with error: {e}")
             
-                
+            logSkippedSection = True
+
             login = None
             
             #Check the contributors table for a login for the given name

--- a/workers/facade_worker/contributor_interfaceable/contributor_interface.py
+++ b/workers/facade_worker/contributor_interfaceable/contributor_interface.py
@@ -26,7 +26,7 @@ A few interesting ideas: Maybe get the top committers from each repo first? curl
 
 
 class ContributorInterfaceable(WorkerGitInterfaceable):
-    def __init__(self, config={}, logger=None, special_rate_limit=10):
+    def __init__(self, config={}, logger=None):
         # Define the data tables that we are needing
         # Define the tables needed to insert, update, or delete on
 
@@ -93,10 +93,6 @@ class ContributorInterfaceable(WorkerGitInterfaceable):
         self.initialize_database_connections()
         self.logger.info("Facade worker git interface database set up")
         self.logger.info(f"configuration passed is: {str(self.config)}.")
-
-        # set up the max amount of requests this interface is allowed to make before sleeping for 2 minutes
-        self.special_rate_limit = special_rate_limit
-        self.recent_requests_made = 0
 
         # Needs to be an attribute of the class for incremental database insert using paginate_endpoint
         self.pk_source_prs = []

--- a/workers/worker_git_integration.py
+++ b/workers/worker_git_integration.py
@@ -693,17 +693,6 @@ class WorkerGitInterfaceable(Worker):
             # Make sure we know how many requests our api tokens have.
             self.update_rate_limit(response, platform="github")
 
-            # Update the special rate limit
-            self.recent_requests_made += 1
-
-            # Sleep if we have made a lot of requests recently
-            if self.recent_requests_made == self.special_rate_limit:
-                self.recent_requests_made = 0
-                self.logger.info(
-                    f"Special rate limit of {self.special_rate_limit} reached! Sleeping for thirty seconds.")
-                # Sleep for thirty seconds before making a new request.
-                time.sleep(60)
-
             try:
                 response_data = response.json()
             except:


### PR DESCRIPTION
   A number of changes were made to the facade worker to speed up the contributor interface's commit resolution logic including removing the special rate limit for that section as well as some shortcuts to avoid unnecessary API calls. 

Now the facade worker ignores commit data if it has been found to be unresolved in the past, in the future it might be beneficial to process this data after the fact. 

The worker also checks the contributor table for logins before trying to get the login from endpoints now. 
