### PR TITLE
In rare cases, when running multiple workers, duplicate entries were created for some objects

### DIFF
--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -12,6 +12,7 @@ PostgreSQL Installation
 	sudo apt update
 	sudo apt upgrade
 	sudo apt install software-properties-common
+	sudo apt install python3-dev
 	sudo apt install postgresql postgresql-contrib postgresql-client
 	sudo apt install build-essential
 
@@ -62,20 +63,20 @@ Python Virtual Environment Configuration
 
 .. code-block:: bash
 
-	su - ubuntu
+	# make sure you are logged in as your own user (i.e. "sean")
 	git clone https://github.com/chaoss/augur.git
 	cd augur/
 	sudo apt install make
-	sudo add-apt-repository ppa:deadsnakes/ppa
 	sudo apt-get install python3-venv 
 	python3 -m venv $HOME/.virtualenvs/augur_env
 	source $HOME/.virtualenvs/augur_env/bin/activate
+	sudo apt install python-pip-whl
 	sudo apt install python3-pip
 	sudo apt install pythonpy
 	python -m pip install --upgrade pip
 	make install-dev {Follow prompts. You will need database credentials, a file location for cloned repositories, a GitHub Token, and a GitLab token.}
 
-- Load a sample set of repositories. This can be accomplished through the Augur Command Line Interface (CLI). You can see available commands using 
+- Seven sample repositories are loaded by default. You can delete them if you want to use your own repositories by deleting the records from the `repo` table first, then deleting the records from the `repo_groups` table. 
 
 .. code-block:: bash
 
@@ -83,6 +84,8 @@ Python Virtual Environment Configuration
 	augur db --help
 	augur backend --help
 
+Loading Repositories
+~~~~~~~~~~~~~~~~~~~~~~~~
 The commands for loading repos are: 
 
 .. code-block:: bash

--- a/metadata.py
+++ b/metadata.py
@@ -5,8 +5,8 @@ __url__ = "https://github.com/chaoss/augur"
 
 __short_description__ = "Python 3 package for free/libre and open-source software community metrics, models & data collection"
 
-__version__ = "0.25.6"
-__release__ = "v0.25.6"
+__version__ = "0.25.10"
+__release__ = "v0.25.10"
 
 
 __license__ = "MIT"

--- a/metadata.py
+++ b/metadata.py
@@ -5,8 +5,8 @@ __url__ = "https://github.com/chaoss/augur"
 
 __short_description__ = "Python 3 package for free/libre and open-source software community metrics, models & data collection"
 
-__version__ = "0.25.10"
-__release__ = "v0.25.10"
+__version__ = "0.25.11"
+__release__ = "v0.25.11"
 
 
 __license__ = "MIT"

--- a/schema/create_schema.sql
+++ b/schema/create_schema.sql
@@ -19,6 +19,7 @@
 \i schema/generate/92-schema_update_94.sql
 \i schema/generate/93-schema_update_95.sql
 \i schema/generate/94-schema_update_96.sql
+\i schema/generate/95-schema_update_97.sql
 
 -- prior update scripts incorporated into 
 -- augur.sql file for release v0.21.1

--- a/schema/create_schema.sql
+++ b/schema/create_schema.sql
@@ -20,6 +20,7 @@
 \i schema/generate/93-schema_update_95.sql
 \i schema/generate/94-schema_update_96.sql
 \i schema/generate/95-schema_update_97.sql
+\i schema/generate/96-schema_update_98.sql
 
 -- prior update scripts incorporated into 
 -- augur.sql file for release v0.21.1

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -38,7 +38,7 @@ ALTER TABLE "augur_data"."pull_request_assignees"
 ALTER TABLE "augur_data"."pull_requests" 
   ADD CONSTRAINT "unique-pr" UNIQUE ("repo_id", "pr_src_id");
 
-update "augur_operations"."augur_settings" set value = 96
+update "augur_operations"."augur_settings" set value = 97
   where setting = 'augur_data_version'; 
 COMMIT; 
 

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -1,0 +1,44 @@
+--draft
+
+BEGIN; 
+ALTER TABLE "augur_data"."issue_events" 
+  DROP CONSTRAINT "fk_issue_events_issues_1",
+  ADD CONSTRAINT "fk_issue_events_issues_1" FOREIGN KEY ("issue_id") REFERENCES "augur_data"."issues" ("issue_id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "augur_data"."issue_message_ref" 
+  DROP CONSTRAINT "fk_issue_message_ref_issues_1",
+  ADD CONSTRAINT "fk_issue_message_ref_issues_1" FOREIGN KEY ("issue_id") REFERENCES "augur_data"."issues" ("issue_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+  delete from issues CASCADE where issue_id in (
+  select distinct max(issue_id) as issue_id from issues, (
+  select repo_id,  gh_issue_id, count(*) as counter from issues
+   group by repo_id,  gh_issue_id order by counter desc
+   ) a where a.counter >1 and a.gh_issue_id = issues.gh_issue_id group by a.gh_issue_id );
+ 
+ALTER TABLE "augur_data"."issues" 
+  ADD CONSTRAINT "unique-issue" UNIQUE ("repo_id", "gh_issue_id");
+
+
+---
+
+ALTER TABLE "augur_data"."pull_request_message_ref" 
+  DROP CONSTRAINT "fk_pull_request_message_ref_pull_requests_1",
+  ADD CONSTRAINT "fk_pull_request_message_ref_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE "augur_data"."pull_request_assignees" 
+  DROP CONSTRAINT "fk_pull_request_assignees_pull_requests_1",
+  ADD CONSTRAINT "fk_pull_request_assignees_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+  delete from pull_requests CASCADE where pull_request_id in (
+  select distinct max(pull_request_id) as pull_request_id from pull_requests, (
+  select repo_id,  pr_src_id, count(*) as counter from pull_requests
+   group by repo_id,  pr_src_id order by counter desc
+   ) a where a.counter >1 and a.pr_src_id = pull_requests.pr_src_id group by a.pr_src_id );
+  
+ALTER TABLE "augur_data"."pull_requests" 
+  ADD CONSTRAINT "unique-pr" UNIQUE ("repo_id", "pr_src_id");
+
+update "augur_operations"."augur_settings" set value = 96
+  where setting = 'augur_data_version'; 
+COMMIT; 
+

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -40,7 +40,12 @@ ALTER TABLE "augur_data"."pull_requests"
   DROP CONSTRAINT IF EXISTS "unique-prx",
   ADD CONSTRAINT "unique-prx" UNIQUE ("repo_id", "pr_src_id");
 
-
+  delete from repo_labor CASCADE where repo_labor_id in (
+  select distinct max(repo_labor.repo_labor_id) as repo_labor_id from repo_labor, (
+  select repo_id, repo_labor_id, rl_analysis_date, file_path, file_name, count(*) as counter from repo_labor
+   group by repo_id, repo_labor_id, rl_analysis_date, file_path, file_name order by counter desc
+   ) a where a.counter >1 and a.repo_labor_id = repo_labor.repo_labor_id group by a.repo_labor_id);
+   
 ALTER TABLE "augur_data"."repo_labor" 
   DROP CONSTRAINT IF EXISTS "rl-unique",
   ADD CONSTRAINT "rl-unique" UNIQUE ("repo_id", "rl_analysis_date", "file_path", "file_name") DEFERRABLE INITIALLY DEFERRED;

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -16,6 +16,7 @@ ALTER TABLE "augur_data"."issue_message_ref"
    ) a where a.counter >1 and a.gh_issue_id = issues.gh_issue_id group by a.gh_issue_id );
  
 ALTER TABLE "augur_data"."issues" 
+  DROP CONSTRAINT IF EXISTS "unique-issue",
   ADD CONSTRAINT "unique-issue" UNIQUE ("repo_id", "gh_issue_id");
 
 
@@ -27,7 +28,7 @@ ALTER TABLE "augur_data"."pull_request_message_ref"
 
 ALTER TABLE "augur_data"."pull_request_assignees" 
   DROP CONSTRAINT "fk_pull_request_assignees_pull_requests_1",
-  ADD CONSTRAINT "fk_pull_request_assignees_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE NO ACTION;
+  ADD CONSTRAINT "fk_pull_request_assignees_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE CASCADE;
 
   delete from pull_requests CASCADE where pull_request_id in (
   select distinct max(pull_request_id) as pull_request_id from pull_requests, (
@@ -36,9 +37,15 @@ ALTER TABLE "augur_data"."pull_request_assignees"
    ) a where a.counter >1 and a.pr_src_id = pull_requests.pr_src_id group by a.pr_src_id );
   
 ALTER TABLE "augur_data"."pull_requests" 
-  ADD CONSTRAINT "unique-pr" UNIQUE ("repo_id", "pr_src_id");
+  DROP CONSTRAINT IF EXISTS "unique-prx",
+  ADD CONSTRAINT "unique-prx" UNIQUE ("repo_id", "pr_src_id");
+
+
+ALTER TABLE "augur_data"."repo_labor" 
+  DROP CONSTRAINT IF EXISTS "rl-unique",
+  ADD CONSTRAINT "rl-unique" UNIQUE ("repo_id", "rl_analysis_date", "file_path", "file_name") DEFERRABLE INITIALLY DEFERRED;
+
 
 update "augur_operations"."augur_settings" set value = 97
   where setting = 'augur_data_version'; 
 COMMIT; 
-

--- a/schema/generate/96-schema_update_98.sql
+++ b/schema/generate/96-schema_update_98.sql
@@ -1,7 +1,3 @@
-
-
---draft
-
 BEGIN; 
 -- code added following PR review
 /*
@@ -73,6 +69,6 @@ ALTER TABLE "augur_data"."repo_labor"
 
 
 --
-update "augur_operations"."augur_settings" set value = 97
+update "augur_operations"."augur_settings" set value = 98
   where setting = 'augur_data_version'; 
 COMMIT; 


### PR DESCRIPTION
Specifically, we found 80 duplicate issues in a corpora of 2.8 million, 93 duplicates in a corpora of 3.9 million pull requests, and 7 repo_labor duplicates in a corpora of 7.8 million 

The workers have duplicate protection logic with a rare failure scenario that is prevented by the addition of the unique keys in this schema modification script. 