### PR TITLE
Add https support to augurface

### DIFF
--- a/augurface/src/store/UtilModule.js
+++ b/augurface/src/store/UtilModule.js
@@ -8,7 +8,7 @@ export default {
   state: {
     host: configObject["Frontend"].host,
     port: configObject["Frontend"].port,
-    baseEndpointUrl: `http://${configObject["Frontend"].host}:${configObject["Frontend"].port}/api/unstable`,
+    baseEndpointUrl: `http${configObject["Frontend"].ssl ? "s" : ""}://${configObject["Frontend"].host}:${configObject["Frontend"].port}/api/unstable`,
     // baseEndpointUrl: 'http://localhost:5000/api/unstable',
     crudKey: sessionStorage.getItem("__augursessionstorage__crudkey") !== null ? sessionStorage.getItem("__augursessionstorage__crudkey") : '',
     availableEndpoints: [


### PR DESCRIPTION
The patch un-hardcode the use of http, that was found while working on augurface deployment for augur.osci.io. 
