### PR TITLE
Automation Schema Change - Added Schema Explicitly

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -5,8 +5,8 @@ __url__ = "https://github.com/chaoss/augur"
 
 __short_description__ = "Python 3 package for free/libre and open-source software community metrics, models & data collection"
 
-__version__ = "0.25.11"
-__release__ = "v0.25.11"
+__version__ = "0.25.12"
+__release__ = "v0.25.12"
 
 __license__ = "MIT"
 __copyright__ = "University of Missouri, University of Nebraska-Omaha, CHAOSS, & Augurlabs 2022"

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -49,7 +49,7 @@ ALTER TABLE "augur_data"."pull_request_assignees"
   ADD CONSTRAINT "fk_pull_request_assignees_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE CASCADE;
 
   delete from "augur_data"."pull_requests" CASCADE where pull_request_id in (
-  select distinct max(pull_request_id) as pull_request_id from pull_requests, (
+  select distinct max(pull_request_id) as pull_request_id from "augur_data"."pull_requests", (
   select repo_id,  pr_src_id, count(*) as counter from "augur_data"."pull_requests"
    group by repo_id,  pr_src_id order by counter desc
    ) a where a.counter >1 and a.pr_src_id = pull_requests.pr_src_id group by a.pr_src_id );
@@ -60,9 +60,9 @@ ALTER TABLE "augur_data"."pull_requests"
 
   delete from "augur_data"."repo_labor" CASCADE where repo_labor_id in (
   select distinct max(repo_labor.repo_labor_id) as repo_labor_id from "augur_data"."repo_labor", (
-  select repo_id, repo_labor_id, rl_analysis_date, file_path, file_name, count(*) as counter from repo_labor
+  select repo_id, repo_labor_id, rl_analysis_date, file_path, file_name, count(*) as counter from "augur_data"."repo_labor"
    group by repo_id, repo_labor_id, rl_analysis_date, file_path, file_name order by counter desc
-   ) a where a.counter >1 and a.repo_labor_id = repo_labor.repo_labor_id group by a.repo_labor_id);
+   ) a where a.counter >1 and a.repo_labor_id = "augur_data"."repo_labor".repo_labor_id group by a.repo_labor_id);
    
 ALTER TABLE "augur_data"."repo_labor" 
   DROP CONSTRAINT IF EXISTS "rl-unique",

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -26,8 +26,8 @@ ALTER TABLE "augur_data"."issue_message_ref"
   ADD CONSTRAINT "fk_issue_message_ref_issues_1" FOREIGN KEY ("issue_id") REFERENCES "augur_data"."issues" ("issue_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
   delete from "augur_data"."issues" CASCADE where issue_id in (
-  select distinct max(issue_id) as issue_id from issues, (
-  select repo_id,  gh_issue_id, count(*) as counter from issues
+  select distinct max(issue_id) as issue_id from "augur_data"."issues", (
+  select repo_id,  gh_issue_id, count(*) as counter from "augur_data"."issues"
    group by repo_id,  gh_issue_id order by counter desc
    ) a where a.counter >1 and a.gh_issue_id = issues.gh_issue_id group by a.gh_issue_id );
  
@@ -48,9 +48,9 @@ ALTER TABLE "augur_data"."pull_request_assignees"
   DROP CONSTRAINT "fk_pull_request_assignees_pull_requests_1",
   ADD CONSTRAINT "fk_pull_request_assignees_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE CASCADE;
 
-  delete from pull_requests CASCADE where pull_request_id in (
+  delete from "augur_data"."pull_requests" CASCADE where pull_request_id in (
   select distinct max(pull_request_id) as pull_request_id from pull_requests, (
-  select repo_id,  pr_src_id, count(*) as counter from pull_requests
+  select repo_id,  pr_src_id, count(*) as counter from "augur_data"."pull_requests"
    group by repo_id,  pr_src_id order by counter desc
    ) a where a.counter >1 and a.pr_src_id = pull_requests.pr_src_id group by a.pr_src_id );
   
@@ -58,8 +58,8 @@ ALTER TABLE "augur_data"."pull_requests"
   DROP CONSTRAINT IF EXISTS "unique-prx",
   ADD CONSTRAINT "unique-prx" UNIQUE ("repo_id", "pr_src_id");
 
-  delete from repo_labor CASCADE where repo_labor_id in (
-  select distinct max(repo_labor.repo_labor_id) as repo_labor_id from repo_labor, (
+  delete from "augur_data"."repo_labor" CASCADE where repo_labor_id in (
+  select distinct max(repo_labor.repo_labor_id) as repo_labor_id from "augur_data"."repo_labor", (
   select repo_id, repo_labor_id, rl_analysis_date, file_path, file_name, count(*) as counter from repo_labor
    group by repo_id, repo_labor_id, rl_analysis_date, file_path, file_name order by counter desc
    ) a where a.counter >1 and a.repo_labor_id = repo_labor.repo_labor_id group by a.repo_labor_id);

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -10,8 +10,6 @@ The foreign key from the pull_request_reviews table to the pull_requests table s
 The foreign key from the issue_labels table to the issues table still has on delete restrict on it, which I believe needs to be on delete cascade
 */
 
-ALTER TABLE "augur_data"."pull_request_reviews"
-
 
 ALTER TABLE "augur_data"."issue_labels" 
   DROP CONSTRAINT IF EXISTS "fk_issue_labels_issues_1",

--- a/schema/generate/95-schema_update_97.sql
+++ b/schema/generate/95-schema_update_97.sql
@@ -25,7 +25,7 @@ ALTER TABLE "augur_data"."issue_message_ref"
   DROP CONSTRAINT "fk_issue_message_ref_issues_1",
   ADD CONSTRAINT "fk_issue_message_ref_issues_1" FOREIGN KEY ("issue_id") REFERENCES "augur_data"."issues" ("issue_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-  delete from issues CASCADE where issue_id in (
+  delete from "augur_data"."issues" CASCADE where issue_id in (
   select distinct max(issue_id) as issue_id from issues, (
   select repo_id,  gh_issue_id, count(*) as counter from issues
    group by repo_id,  gh_issue_id order by counter desc

--- a/schema/generate/96-schema_update_98.sql
+++ b/schema/generate/96-schema_update_98.sql
@@ -6,8 +6,6 @@ The foreign key from the pull_request_reviews table to the pull_requests table s
 The foreign key from the issue_labels table to the issues table still has on delete restrict on it, which I believe needs to be on delete cascade
 */
 
-ALTER TABLE "augur_data"."pull_request_reviews"
-
 
 ALTER TABLE "augur_data"."issue_labels" 
   DROP CONSTRAINT IF EXISTS "fk_issue_labels_issues_1",

--- a/schema/generate/96-schema_update_98.sql
+++ b/schema/generate/96-schema_update_98.sql
@@ -71,6 +71,6 @@ ALTER TABLE "augur_data"."repo_labor"
 
 
 --
-update "augur_operations"."augur_settings" set value = 97
+update "augur_operations"."augur_settings" set value = 98
   where setting = 'augur_data_version'; 
 COMMIT; 

--- a/schema/generate/96-schema_update_98.sql
+++ b/schema/generate/96-schema_update_98.sql
@@ -1,3 +1,7 @@
+
+
+--draft
+
 BEGIN; 
 -- code added following PR review
 /*
@@ -21,7 +25,7 @@ ALTER TABLE "augur_data"."issue_message_ref"
   DROP CONSTRAINT "fk_issue_message_ref_issues_1",
   ADD CONSTRAINT "fk_issue_message_ref_issues_1" FOREIGN KEY ("issue_id") REFERENCES "augur_data"."issues" ("issue_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
-  delete from issues CASCADE where issue_id in (
+  delete from "augur_data"."issues" CASCADE where issue_id in (
   select distinct max(issue_id) as issue_id from issues, (
   select repo_id,  gh_issue_id, count(*) as counter from issues
    group by repo_id,  gh_issue_id order by counter desc
@@ -67,6 +71,6 @@ ALTER TABLE "augur_data"."repo_labor"
 
 
 --
-update "augur_operations"."augur_settings" set value = 98
+update "augur_operations"."augur_settings" set value = 97
   where setting = 'augur_data_version'; 
 COMMIT; 

--- a/schema/generate/96-schema_update_98.sql
+++ b/schema/generate/96-schema_update_98.sql
@@ -49,7 +49,7 @@ ALTER TABLE "augur_data"."pull_request_assignees"
   ADD CONSTRAINT "fk_pull_request_assignees_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE CASCADE;
 
   delete from "augur_data"."pull_requests" CASCADE where pull_request_id in (
-  select distinct max(pull_request_id) as pull_request_id from pull_requests, (
+  select distinct max(pull_request_id) as pull_request_id from "augur_data"."pull_requests", (
   select repo_id,  pr_src_id, count(*) as counter from "augur_data"."pull_requests"
    group by repo_id,  pr_src_id order by counter desc
    ) a where a.counter >1 and a.pr_src_id = pull_requests.pr_src_id group by a.pr_src_id );
@@ -60,9 +60,9 @@ ALTER TABLE "augur_data"."pull_requests"
 
   delete from "augur_data"."repo_labor" CASCADE where repo_labor_id in (
   select distinct max(repo_labor.repo_labor_id) as repo_labor_id from "augur_data"."repo_labor", (
-  select repo_id, repo_labor_id, rl_analysis_date, file_path, file_name, count(*) as counter from repo_labor
+  select repo_id, repo_labor_id, rl_analysis_date, file_path, file_name, count(*) as counter from "augur_data"."repo_labor"
    group by repo_id, repo_labor_id, rl_analysis_date, file_path, file_name order by counter desc
-   ) a where a.counter >1 and a.repo_labor_id = repo_labor.repo_labor_id group by a.repo_labor_id);
+   ) a where a.counter >1 and a.repo_labor_id = "augur_data"."repo_labor".repo_labor_id group by a.repo_labor_id);
    
 ALTER TABLE "augur_data"."repo_labor" 
   DROP CONSTRAINT IF EXISTS "rl-unique",

--- a/schema/generate/96-schema_update_98.sql
+++ b/schema/generate/96-schema_update_98.sql
@@ -26,8 +26,8 @@ ALTER TABLE "augur_data"."issue_message_ref"
   ADD CONSTRAINT "fk_issue_message_ref_issues_1" FOREIGN KEY ("issue_id") REFERENCES "augur_data"."issues" ("issue_id") ON DELETE CASCADE ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
 
   delete from "augur_data"."issues" CASCADE where issue_id in (
-  select distinct max(issue_id) as issue_id from issues, (
-  select repo_id,  gh_issue_id, count(*) as counter from issues
+  select distinct max(issue_id) as issue_id from "augur_data"."issues", (
+  select repo_id,  gh_issue_id, count(*) as counter from "augur_data"."issues"
    group by repo_id,  gh_issue_id order by counter desc
    ) a where a.counter >1 and a.gh_issue_id = issues.gh_issue_id group by a.gh_issue_id );
  
@@ -48,9 +48,9 @@ ALTER TABLE "augur_data"."pull_request_assignees"
   DROP CONSTRAINT "fk_pull_request_assignees_pull_requests_1",
   ADD CONSTRAINT "fk_pull_request_assignees_pull_requests_1" FOREIGN KEY ("pull_request_id") REFERENCES "augur_data"."pull_requests" ("pull_request_id") ON DELETE CASCADE ON UPDATE CASCADE;
 
-  delete from pull_requests CASCADE where pull_request_id in (
+  delete from "augur_data"."pull_requests" CASCADE where pull_request_id in (
   select distinct max(pull_request_id) as pull_request_id from pull_requests, (
-  select repo_id,  pr_src_id, count(*) as counter from pull_requests
+  select repo_id,  pr_src_id, count(*) as counter from "augur_data"."pull_requests"
    group by repo_id,  pr_src_id order by counter desc
    ) a where a.counter >1 and a.pr_src_id = pull_requests.pr_src_id group by a.pr_src_id );
   
@@ -58,8 +58,8 @@ ALTER TABLE "augur_data"."pull_requests"
   DROP CONSTRAINT IF EXISTS "unique-prx",
   ADD CONSTRAINT "unique-prx" UNIQUE ("repo_id", "pr_src_id");
 
-  delete from repo_labor CASCADE where repo_labor_id in (
-  select distinct max(repo_labor.repo_labor_id) as repo_labor_id from repo_labor, (
+  delete from "augur_data"."repo_labor" CASCADE where repo_labor_id in (
+  select distinct max(repo_labor.repo_labor_id) as repo_labor_id from "augur_data"."repo_labor", (
   select repo_id, repo_labor_id, rl_analysis_date, file_path, file_name, count(*) as counter from repo_labor
    group by repo_id, repo_labor_id, rl_analysis_date, file_path, file_name order by counter desc
    ) a where a.counter >1 and a.repo_labor_id = repo_labor.repo_labor_id group by a.repo_labor_id);


### PR DESCRIPTION
Depending on the postgres deployment, schema update's 97 and 98 were not deploying without error. This patch fixes the error on postgres deployments where they were failing. 
