### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note that if you open a bug report and your issue does not follow our tem
 ```bash
 $ git clone github.com:your-username/augur.git
 $ cd augur/
-$ git remote add upstream https://github.com/<your username>/augur.git
+$ git remote add upstream https://github.com/chaoss/augur.git
 ```
 
 1. Follow the [development installation instructions](https://oss-augur.readthedocs.io/en/master/development-guide/installation.html).


### PR DESCRIPTION
Signed-off-by: Diana Mukhanova <diananova2508@gmail.com>

Upstream remote should be the central repository, not the user's fork. Per the official Github documentation:
> You must configure a remote that points to the upstream repository in Git to [sync changes you make in a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) with the original repository. This also allows you to sync changes made in the original repository with the fork.

The expected result is this:
```
$ git remote -v
> origin    https://github.com/YOUR_USERNAME/YOUR_FORK.git (fetch)
> origin    https://github.com/YOUR_USERNAME/YOUR_FORK.git (push)
> upstream  https://github.com/ORIGINAL_OWNER/ORIGINAL_REPOSITORY.git (fetch)
> upstream  https://github.com/ORIGINAL_OWNER/ORIGINAL_REPOSITORY.git (push)
```

