### PR TITLE
Document MacOS issue during installation

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -155,6 +155,8 @@ your installation of Python 3: on most systems, this is ``python3``, but yours m
 
 If you think something went wrong, check the log files in ``logs/``. If you want to try again, you can use ``make clean`` to delete any build files before running ``make install`` again.
 
+MacOS users: if your build fails and in gunicorn.log you see this error: ``Connection in use: ('0.0.0.0', 5000)``, that means port 5000 is being used by another process. To solve this issue, go to System Preferences -> Sharing -> Disable Airplay Receiver.
+
 If you want to test new code you have written, you can rebuild Augur using: 
 
 .. code-block:: bash


### PR DESCRIPTION
Signed-off-by: Diana Mukhanova <diananova2508@gmail.com>

I want to document an issue that I experienced on my MacOS during installation that I think others will find helpful as well. After running `make install`, my build failed and I found this error in gunicorn.log:

```
[ERROR] Connection in use: ('0.0.0.0', 5000) 
```
The problem is that port 5000 is being used by another process. I tried the common commands for killing the process:
```
sudo lsof -i :<PortNumber>
kill -9 <PID>
```
This didn't work and after searching a bit online I found a[ solution ](https://medium.com/pythonistas/port-5000-already-in-use-macos-monterey-issue-d86b02edd36c). Turns out MacOS uses 5000 port for Airplay Receiver, so I had to manually change the settings.