### PR TITLE
Fix:Removed duplicate dictionary keys

### DIFF
--- a/augur/config.py
+++ b/augur/config.py
@@ -342,25 +342,7 @@ default_config = {
                     "insight_days": 30,
                     "models_dir": "message_models"
                 },
-                "pull_request_analysis_worker": {
-                    "port": pull_request_analysis_worker_p,
-                    "switch": 0,
-                    "workers": 1,
-                    "insight_days": 30
-                },
-                "discourse_analysis_worker":{
-                    "port" : discourse_analysis_worker_p,
-                    "switch": 0,
-                    "workers": 1
-                },
-                "message_insights_worker": {
-                    "port": message_insights_worker_p,
-                    "switch": 0,
-                    "workers": 1,
-                    "insight_days": 30,
-                    "models_dir": "message_models"
-                },
-                "pull_request_analysis_worker": {
+                "pull_request_analysis_worker": {                   
                     "port": pull_request_analysis_worker_p,
                     "switch": 0,
                     "workers": 1,

--- a/workers/insight_worker/insight_worker.py
+++ b/workers/insight_worker/insight_worker.py
@@ -676,10 +676,8 @@ class InsightWorker(WorkerGitInterfaceable):
                 "cm_defined": True if metric['is_defined'] == 'true' else False,
                 "cm_api_endpoint_repo": metric['endpoint'],
                 "cm_api_endpoint_rg": None,
-                // cm info key is being used twice
                 "cm_info": metric['display_name'],
                 "cm_working_group": metric['group'],
-                // 
                 "cm_info": metric['tag'],
                 "tool_source": self.tool_source,
                 "tool_version": self.tool_version,

--- a/workers/insight_worker/insight_worker.py
+++ b/workers/insight_worker/insight_worker.py
@@ -676,8 +676,10 @@ class InsightWorker(WorkerGitInterfaceable):
                 "cm_defined": True if metric['is_defined'] == 'true' else False,
                 "cm_api_endpoint_repo": metric['endpoint'],
                 "cm_api_endpoint_rg": None,
+                // cm info key is being used twice
                 "cm_info": metric['display_name'],
                 "cm_working_group": metric['group'],
+                // 
                 "cm_info": metric['tag'],
                 "tool_source": self.tool_source,
                 "tool_version": self.tool_version,


### PR DESCRIPTION
Signed-off-by: Biki-das <bikid475@gmail.com>

# Pull Request Template

Dictionary expression binds the same key multiple times. This may lead to unintentional behaviour as the key will always map the last value provided to it. It is recommended to have unique keys.