### PR TITLE
Added literal syntax to create the data structure

### DIFF
--- a/workers/deps_libyear_worker/libyear_utils.py
+++ b/workers/deps_libyear_worker/libyear_utils.py
@@ -33,7 +33,7 @@ def find(name, path):
 def get_parsed_deps(path):
 
     deps_file = None
-    dependency_list = list()
+    dependency_list = []
 
     for f in file_list:
         deps_file = find(f, path)

--- a/workers/deps_libyear_worker/npm_parser.py
+++ b/workers/deps_libyear_worker/npm_parser.py
@@ -1,7 +1,7 @@
 import json
 
 def map_dependencies(dict, key, type):
-    deps = list()
+    deps = []
     if not dict:
         return []
     for name, info in dict[key].items():

--- a/workers/deps_libyear_worker/pypi_parser.py
+++ b/workers/deps_libyear_worker/pypi_parser.py
@@ -43,7 +43,7 @@ requirement_regrex = re.compile(REQUIREMENTS_REGEXP)
 def parse_requirement_txt(file_handle):
 
     manifest= file_handle.read()
-    deps=list()
+    deps=[]
     for line in manifest.split('\n'):
         matches = require_regrex.search(line.replace("'",""))
         if not matches:
@@ -65,7 +65,7 @@ def map_dependencies(info):
 
 
 def map_dependencies_pipfile(packages, type):
-    deps = list()
+    deps = []
     if not packages:
         return []
     for name, info in packages.items():
@@ -81,7 +81,7 @@ def parse_pipfile(file_handle):
 
 def parse_pipfile_lock(file_object):
     manifest = json.load(file_object)
-    deps = list()
+    deps = []
     for group,dependencies in manifest.items():
         
         if group == "_meta":
@@ -98,7 +98,7 @@ def parse_pipfile_lock(file_object):
 def parse_setup_py(file_handle):
     manifest= file_handle.read()
 
-    deps = list()
+    deps = []
 
     # for single_line in manifest:
     # matchh = re.match(INSTALL_REGEXP, manifest)
@@ -135,7 +135,7 @@ def parse_poetry(file_handle):
 
 def parse_poetry_lock(file_handle):
     manifest = toml.load(file_handle)
-    deps = list()
+    deps = []
     group = 'runtime'
     for package in manifest['package']:
         req = None

--- a/workers/facade_worker/facade_worker/excel_generators/__init__.py
+++ b/workers/facade_worker/facade_worker/excel_generators/__init__.py
@@ -5,7 +5,7 @@ import glob
 
 files = glob.glob('%s/generate*.py' % os.path.dirname(__file__))
 
-__all__ = list()
+__all__ = []
 
 for f in files:
 	if os.path.isfile(f):


### PR DESCRIPTION
# Pull Request Template

Using the literal syntax can give minor performance bumps compared to using function calls to create dict, list and tuple.

This is because here, the name dict must be looked up in the global scope in case it has been rebound. Same goes for the other two types list() and tuple().