### PR TITLE
PR template added in .github directory

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,20 @@
-# Pull Request Template
+**Description**
+- Please include a summary of the change.
+
+This PR fixes #
+
+**Notes for Reviewers**
+
+**Signed commits**
+- [ ] Yes, I signed my commits.
+
+<!--
+Thank you for contributing to CHAOSS projects! 
+
+Contributing Conventions:
+1. Include descriptive PR titles with [<component-name>] prepended.
+2. Build and test your changes before submitting a PR. 
+3. Sign your commits
+
+By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
+-->


### PR DESCRIPTION
Signed-off-by: Priya Srivastava <shivikapriya730@gmail.com>
**Current behaviour:**
The changes made in the [PR](https://github.com/chaoss/augur/pull/1745) are not functional because of the missing content in the `pr_request_template.md`in the `.github` directory. 

**Solution:**
For the pull request template to work it needs to updated in the .github directory as well. This PR updates the same.
