### PR TITLE
Hardcode the vega version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "shards-ui": "^3.0.0",
     "shards-vue": "^1.0.4",
     "svgsaver": "^0.9.0",
-    "vega": "^5.22.1",
+    "vega": "5.20.2",
     "vega-embed": "^4.2.5",
     "vega-lite": "^3.4.0",
     "vue": "^2.6.11",


### PR DESCRIPTION
For some reason (likely due to the complex web of dependencies),
newer version are failling with a typescript error. Since part of the
stack can't be update (vue-vega is 5 years old), I suspect we can't
really count on a fix there.

So in order to build the application (and containers), it has to be
fixed on the exact version for now.

**Signed commits**
- [X] Yes, I signed my commits.
