### PR TITLE
use a fully qualified name for the container

### DIFF
--- a/util/docker/frontend/Dockerfile
+++ b/util/docker/frontend/Dockerfile
@@ -23,7 +23,7 @@ RUN npm run build
 # COPY augurface/ .
 # RUN npm run build
 
-FROM nginx as production-stage
+FROM docker.io/library/nginx as production-stage
 COPY --from=core-ui /augur/frontend/dist /usr/share/nginx/core
 # COPY --from=augurface /augur/augurface/dist /usr/share/nginx/augurface
 COPY ./util/docker/frontend/nginx.conf /etc/nginx/nginx.conf

--- a/util/docker/frontend/Dockerfile
+++ b/util/docker/frontend/Dockerfile
@@ -9,7 +9,8 @@ COPY ./util/docker/frontend/frontend.docker.config.json frontend.config.json
 # RUN cp frontend.docker.config.json frontend.config.json
 
 FROM build-stage as core-ui
-COPY frontend/package.json .
+COPY frontend/package.json . 
+COPY frontend/package-lock.json .
 RUN npm install
 RUN npm install @vue/cli
 COPY frontend/ .


### PR DESCRIPTION
While this work to build with docker, podman/buildah stop the
build to ask which image to use, preventing a build in a script.



**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->