### PR TITLE
Make logs get the log level and directory from config rather than using defaults

### DIFF
--- a/augur/api/gunicorn_conf.py
+++ b/augur/api/gunicorn_conf.py
@@ -19,9 +19,11 @@ with DatabaseSession(logger) as session:
     workers = multiprocessing.cpu_count() * 2 + 1
     umask = 0o007
     reload = True
-    #logging
-    accesslog = "logs/gunicorn.log"
-    errorlog = "logs/gunicorn.log"
+
+    # set the log location for gunicorn    
+    logs_directory = session.config.get_value('Logging', 'logs_directory')
+    accesslog = f"{logs_directory}/gunicorn.log"
+    errorlog = f"{logs_directory}/gunicorn.log"
 
     ssl_bool = session.config.get_value('Server', 'ssl')
 

--- a/augur/application/cli/config.py
+++ b/augur/application/cli/config.py
@@ -20,7 +20,7 @@ from augur.application.cli import test_connection, test_db_connection
 
 from augur.application.cli import test_connection, test_db_connection
 
-ROOT_AUGUR_DIRECTORY = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+ROOT_AUGUR_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
 
 logger = logging.getLogger(__name__)
 

--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -41,9 +41,6 @@ default_config = {
             "Logging": {
                 "logs_directory": "",
                 "log_level": "INFO",
-                "verbose": 0,
-                "quiet": 0,
-                "debug": 0
             },
             "Celery": {
                 "concurrency": 12

--- a/augur/application/logs.py
+++ b/augur/application/logs.py
@@ -101,7 +101,13 @@ def get_log_config():
 
 #TODO dynamically define loggers for every task names.
 class TaskLogConfig():
-    def __init__(self, all_tasks, disable_log_files=False,reset_logfiles=False,base_log_dir=ROOT_AUGUR_DIRECTORY + "/logs/",logLevel=logging.INFO):
+    def __init__(self, all_tasks, disable_log_files=False,reset_logfiles=False,base_log_dir=ROOT_AUGUR_DIRECTORY + "/logs/"):
+        
+        log_config = get_log_config()
+
+        if log_config["logs_directory"] != "":
+            base_log_dir=log_config["logs_directory"]
+
         if reset_logfiles is True:
             try:
                 print("(tasks) Reseting log files")
@@ -109,9 +115,10 @@ class TaskLogConfig():
             except FileNotFoundError as e:
                 pass
 
-        self.log_confg = get_log_config()
-
-        self.logLevel = logLevel
+        if log_config["log_level"].lower() == "debug":
+            self.logLevel = logging.DEBUG
+        else:
+            self.logLevel = logging.INFO
 
         self.base_log_dir = Path(base_log_dir)
 
@@ -165,7 +172,13 @@ class TaskLogConfig():
 
 
 class AugurLogger():
-    def __init__(self, logger_name, disable_log_files=False,reset_logfiles=False,base_log_dir=ROOT_AUGUR_DIRECTORY + "/logs/",logLevel=logging.INFO):
+    def __init__(self, logger_name, disable_log_files=False,reset_logfiles=False,base_log_dir=ROOT_AUGUR_DIRECTORY + "/logs/"):
+        
+        log_config = get_log_config()
+        
+        if log_config["logs_directory"] != "":
+            base_log_dir=log_config["logs_directory"]
+
         if reset_logfiles is True:
             try:
                 print("(augur) Reseting log files")
@@ -173,7 +186,10 @@ class AugurLogger():
             except FileNotFoundError as e:
                 pass
 
-        self.logLevel = logLevel
+        if log_config["log_level"].lower() == "debug":
+            self.logLevel = logging.DEBUG
+        else:
+            self.logLevel = logging.INFO
 
         self.base_log_dir = Path(base_log_dir)
 


### PR DESCRIPTION
1. Log level comes from config now, rather than using a default
2. Log directory comes from config now, rather than using a default
3. Removed old log settings that are not currently used. They may be added back in the future, but for now they are removed so they do not confuse users.