### PR TITLE
Small changes to process_dict_response

### DIFF
--- a/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
+++ b/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
@@ -62,7 +62,7 @@ def request_dict_from_endpoint(session, url, timeout_wait=10):
 
             
             #If we get an error message that's not None
-            if err and err != GithubApiResult.NEW_RESULT:
+            if err and err != GithubApiResult.SUCCESS:
                 attempts += 1
                 session.logger.info(f"err: {err}")
                 continue
@@ -88,7 +88,7 @@ def request_dict_from_endpoint(session, url, timeout_wait=10):
                     err = process_dict_response(session.logger,response,response_data)
 
                     #If we get an error message that's not None
-                    if err and err != GithubApiResult.NEW_RESULT:
+                    if err and err != GithubApiResult.SUCCESS:
                         continue
                     
                     success = True

--- a/augur/tasks/github/util/github_paginator.py
+++ b/augur/tasks/github/util/github_paginator.py
@@ -62,7 +62,7 @@ def process_dict_response(logger: logging.Logger, response: httpx.Response, page
     #logger.info("Request returned a dict: {}\n".format(page_data))
 
     if 'message' not in page_data.keys():
-        return GithubApiResult.NEW_RESULT
+        return GithubApiResult.SUCCESS
 
     if page_data['message'] == "Not Found":
         logger.error(

--- a/augur/tasks/github/util/github_paginator.py
+++ b/augur/tasks/github/util/github_paginator.py
@@ -96,14 +96,17 @@ def process_dict_response(logger: logging.Logger, response: httpx.Response, page
         time.sleep(key_reset_time)
 
         return GithubApiResult.RATE_LIMIT_EXCEEDED
-        # return "do_not_increase_attempts"
 
     if "You have triggered an abuse detection mechanism." in page_data['message']:
         # self.update_rate_limit(response, temporarily_disable=True,platform=platform)
-        logger.info("Abuse mechanism detected sleeping for 10 seconds")
+        
+
+        # sleeps for the specified amount of time that github says to retry after
+        retry_after = int(response.headers["Retry-After"])
+        logger.info(f"Abuse mechanism detected sleeping for {retry_after} seconds")
+        time.sleep(retry_after)
 
         return GithubApiResult.ABUSE_MECHANISM_TRIGGERED
-        # return "decrease_attempts"
 
     if page_data['message'] == "Bad credentials":
         logger.error("\n\n\n\n\n\n\n Bad Token Detected \n\n\n\n\n\n\n")


### PR DESCRIPTION
The `process_dict_response` function now returns `SUCCESS` if the dict does not contain the key `message`.

This is to handle additional cases where the GitHub API is intended to return a dict and not a list. 
For example when `https://api.github.com/users/ABrain7710` returns a dict when it succeeds not a list.

The function will still process error responses fine though because all Github errors include the `message` key.

Additionally, when GitHub returns an error indicating that an abuse mechanism has been detected we now sleep for the amount of time specified in the `Retry-After` header