### PR TITLE
Make detect_repo_move and collect_repo_info execute in a group

### DIFF
--- a/augur/tasks/github/detect_move/tasks.py
+++ b/augur/tasks/github/detect_move/tasks.py
@@ -4,11 +4,9 @@ from augur.tasks.init.celery_app import celery_app as celery
 
 
 @celery.task
-def detect_github_repo_move():
+def detect_github_repo_move(repo_git: str) -> None:
     logger = logging.getLogger(detect_github_repo_move.__name__)
 
     with GithubTaskSession(logger) as session:
-        repos = session.query(Repo).all()
-
-        for repo in repos:
-            ping_github_for_repo_move(session, repo)
+        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+        ping_github_for_repo_move(session, repo)

--- a/augur/tasks/github/repo_info/tasks.py
+++ b/augur/tasks/github/repo_info/tasks.py
@@ -4,15 +4,13 @@ from augur.tasks.init.celery_app import celery_app as celery, engine
 
 
 @celery.task
-def collect_repo_info():
+def collect_repo_info(repo_git: str):
 
     logger = logging.getLogger(collect_repo_info.__name__)
 
     with GithubTaskSession(logger, engine) as session:
-        repos = session.query(Repo).all()
-
-        for repo in repos:
-            try:
-                repo_info_model(session, repo)
-            except Exception as e:
-                session.logger.error(f"Could not add repo info for repo {repo.repo_id}\n Error: {e}")
+        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+        try:
+            repo_info_model(session, repo)
+        except Exception as e:
+            session.logger.error(f"Could not add repo info for repo {repo.repo_id}\n Error: {e}")

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -42,24 +42,28 @@ def prelim_phase(logger):
     return preliminary_tasks
 
 def repo_collect_phase(logger):
-    #store all tasks that taks a repo as an argument 
-    tasks_with_repo_domain = []
+    #Here the term issues also includes prs. This list is a bunch of chains that run in parallel to process issue data.
+    issue_dependent_tasks = []
+    #repo_info should run in a group
+    repo_info_tasks = []
     #A chain is needed for each repo.
     with DatabaseSession(logger) as session:
         repos = session.query(Repo).all()
+        #Just use list comprehension for simple group
+        repo_info_tasks = [collect_repo_info.si(repo.repo_git) for repo in repos]
 
         for repo in repos:
             first_tasks_repo = group(collect_issues.si(repo.repo_git),collect_pull_requests.si(repo.repo_git))
             second_tasks_repo = group(collect_events.si(repo.repo_git),collect_github_messages.si(repo.repo_git))
 
             repo_chain = chain(first_tasks_repo,second_tasks_repo)
-            tasks_with_repo_domain.append(repo_chain)
+            issue_dependent_tasks.append(repo_chain)
     
     return group(
-            chain(group(*tasks_with_repo_domain),process_contributors.si()),
+            *repo_info_tasks,
+            chain(group(*issue_dependent_tasks),process_contributors.si()),
             facade_commits_model.si(),
-            collect_releases.si(),
-            collect_repo_info.si()
+            collect_releases.si()
         )
 
 

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -28,8 +28,17 @@ pr_numbers = [70, 106, 170, 190, 192, 208, 213, 215, 216, 218, 223, 224, 226, 23
 #Predefine phases. For new phases edit this and the config to reflect.
 #The domain of tasks ran should be very explicit.
 def prelim_phase(logger):
-    preliminary_task_list = [detect_github_repo_move.si()]
-    preliminary_tasks = group(preliminary_task_list)
+
+    tasks_with_repo_domain = []
+
+    with DatabaseSession(logger) as session:
+        repos = session.query(Repo).all()
+
+        for repo in repos:
+            tasks_with_repo_domain.append(detect_github_repo_move.si(repo.repo_git))
+
+    #preliminary_task_list = [detect_github_repo_move.si()]
+    preliminary_tasks = group(*tasks_with_repo_domain)
     return preliminary_tasks
 
 def repo_collect_phase(logger):


### PR DESCRIPTION
**Description**
- Patch detect_github_repo_move to be called on a per-repo basis and is now executed parallel in a group
- Patch with same effect for collect_repo_info to address it lagging really far behind other tasks