### PR TITLE
Remove more null string data from github data

### DIFF
--- a/augur/tasks/github/issues/tasks.py
+++ b/augur/tasks/github/issues/tasks.py
@@ -168,7 +168,9 @@ def process_issues(issues, task_name, repo_id, logger) -> None:
         # inserting issue labels
         # we are using label_src_id and issue_id to determine if the label is already in the database.
         issue_label_natural_keys = ['label_src_id', 'issue_id']
-        session.insert_data(issue_label_dicts, IssueLabel, issue_label_natural_keys)
+        issue_label_string_fields = ["label_text", "label_description"]
+        session.insert_data(issue_label_dicts, IssueLabel,
+                            issue_label_natural_keys, string_fields=issue_label_string_fields)
     
         # inserting issue assignees
         # we are using issue_assignee_src_id and issue_id to determine if the label is already in the database.

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -169,7 +169,9 @@ def process_messages(messages, task_name, repo_id, logger):
         logger.info(f"{task_name}: Inserting {len(message_dicts)} messages")
         message_natural_keys = ["platform_msg_id"]
         message_return_columns = ["msg_id", "platform_msg_id"]
-        message_return_data = session.insert_data(message_dicts, Message, message_natural_keys, message_return_columns)
+        message_string_fields = ["msg_text"]
+        message_return_data = session.insert_data(message_dicts, Message, message_natural_keys, 
+                                                    return_columns=message_return_columns, string_fields=message_string_fields)
 
         pr_message_ref_dicts = []
         issue_message_ref_dicts = []

--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -94,7 +94,9 @@ def process_pull_requests(pull_requests, task_name, repo_id, logger):
         logger.info(f"{task_name}: Inserting prs of length: {len(pr_dicts)}")
         pr_natural_keys = ["pr_url"]
         pr_return_columns = ["pull_request_id", "pr_url"]
-        pr_return_data = session.insert_data(pr_dicts, PullRequest, pr_natural_keys, return_columns=pr_return_columns)
+        pr_string_fields = ["pr_src_title", "pr_body"]
+        pr_return_data = session.insert_data(pr_dicts, PullRequest, pr_natural_keys, 
+                                return_columns=pr_return_columns, string_fields=pr_string_fields)
 
         if pr_return_data is None:
             return
@@ -131,7 +133,8 @@ def process_pull_requests(pull_requests, task_name, repo_id, logger):
         # inserting pr labels
         # we are using pr_src_id and pull_request_id to determine if the label is already in the database.
         pr_label_natural_keys = ['pr_src_id', 'pull_request_id']
-        session.insert_data(pr_label_dicts, PullRequestLabel, pr_label_natural_keys)
+        pr_label_string_fields = ["pr_src_description"]
+        session.insert_data(pr_label_dicts, PullRequestLabel, pr_label_natural_keys, string_fields=pr_label_string_fields)
     
         # inserting pr assignees
         # we are using pr_assignee_src_id and pull_request_id to determine if the label is already in the database.
@@ -139,7 +142,7 @@ def process_pull_requests(pull_requests, task_name, repo_id, logger):
         session.insert_data(pr_assignee_dicts, PullRequestAssignee, pr_assignee_natural_keys)
 
     
-        # inserting pr assignees
+        # inserting pr requested reviewers
         # we are using pr_src_id and pull_request_id to determine if the label is already in the database.
         pr_reviewer_natural_keys = ["pull_request_id", "pr_reviewer_src_id"]
         session.insert_data(pr_reviewer_dicts, PullRequestReviewer, pr_reviewer_natural_keys)
@@ -147,7 +150,9 @@ def process_pull_requests(pull_requests, task_name, repo_id, logger):
         # inserting pr metadata
         # we are using pull_request_id, pr_head_or_base, and pr_sha to determine if the label is already in the database.
         pr_metadata_natural_keys = ['pull_request_id', 'pr_head_or_base', 'pr_sha']
-        session.insert_data(pr_metadata_dicts, PullRequestMeta, pr_metadata_natural_keys)
+        pr_metadata_string_fields = ["pr_src_meta_label"]
+        session.insert_data(pr_metadata_dicts, PullRequestMeta,
+                            pr_metadata_natural_keys, string_fields=pr_metadata_string_fields)
 
 
 


### PR DESCRIPTION
**Description**
Went through all the GitHub data and found all the user-controlled string fields, and used the null string data removal function to ensure that we are cleaning all user-controlled string fields or null string data.

This PR fixes #
This error which is thrown whenever there is a string with null data
ValueError('A string literal cannot contain NUL (0x00) characters.')

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.