### PR TITLE
fix: `Exeption` is not defined

### DIFF
--- a/augur/application/db/util.py
+++ b/augur/application/db/util.py
@@ -19,7 +19,7 @@ def catch_operational_error(func):
 
         attempts += 1
 
-    raise Exeption("Unable to Resolve Operational Error")
+    raise Exception("Unable to Resolve Operational Error")
 
 
 def execute_session_query(query, query_type="all"):


### PR DESCRIPTION
**Description**

The change fixes a spelling error were `raise Exeption` was used instead of `raise Exception`

This PR fixes #

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->