### PR TITLE
Remove Uses of Celery.result

### DIFF
--- a/augur/tasks/data_analysis/__init__.py
+++ b/augur/tasks/data_analysis/__init__.py
@@ -40,4 +40,4 @@ def machine_learning_phase():
         
     task_chain = chain(*ml_tasks)
 
-    return task_chain
+    task_chain.apply_async()

--- a/augur/tasks/data_analysis/__init__.py
+++ b/augur/tasks/data_analysis/__init__.py
@@ -8,8 +8,12 @@ from augur.application.db.session import DatabaseSession
 from augur.application.db.models import Repo 
 from augur.application.db.util import execute_session_query
 from celery import group, chain, chord, signature
+from augur.tasks.init.celery_app import celery_app as celery
 
-def machine_learning_phase(logger):
+@celery.task
+def machine_learning_phase():
+
+    logger = logging.getLogger(machine_learning_phase.__name__)
 
     with DatabaseSession(logger) as session:
         query = session.query(Repo)

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -16,7 +16,8 @@ from augur.tasks.init import get_redis_conn_values
 
 logger = logging.getLogger(__name__)
 
-start_tasks = ['augur.tasks.start_tasks']
+start_tasks = ['augur.tasks.start_tasks',
+                'augur.tasks.data_analysis']
 
 github_tasks = ['augur.tasks.github.contributors.tasks',
                 'augur.tasks.github.issues.tasks',

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -135,25 +135,12 @@ class AugurTaskRoutine:
         augur_collection_sequence = []
         for phaseName, job in self.jobs_dict.items():
             self.logger.info(f"Queuing phase {phaseName}")
-            #Call the function stored in the dict to return the object to call apply_async on
-            #try:
-            #    tasks = job(self.logger)
-            #    phaseResult = tasks.apply_async() 
-
-                # if the job is a group of tasks then join the group
-            #    if isinstance(tasks, CELERY_GROUP_TYPE): 
-            #        with allow_join_result():
-            #            phaseResult.join()
-
-            #except Exception as e:
-            #    #Log full traceback if a phase fails.
-            #    self.logger.error(
-            #    ''.join(traceback.format_exception(None, e, e.__traceback__)))
-            #    self.logger.error(
-            #        f"Phase {phaseName} has failed during augur collection. Error: {e}")
-            #    raise e
+            
+            #Add the phase to the sequence in order as a celery task.
+            #The preliminary task creates the larger task chain 
             augur_collection_sequence.append(job.si())
         
+        #Link all phases in a chain and send to celery
         augur_collection_chain = chain(*augur_collection_sequence)
         augur_collection_chain.apply_async()
 

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -51,7 +51,7 @@ def prelim_phase():
 
     #preliminary_task_list = [detect_github_repo_move.si()]
     preliminary_tasks = group(*tasks_with_repo_domain)
-    return preliminary_tasks
+    preliminary_tasks.apply_async()
 
 @celery.task
 def repo_collect_phase():
@@ -83,7 +83,7 @@ def repo_collect_phase():
             collect_releases.si()
         )
     
-    return chain(repo_task_group, refresh_materialized_views.si())
+    chain(repo_task_group, refresh_materialized_views.si()).apply_async()
 
 
 DEFINED_COLLECTION_PHASES = [prelim_phase, repo_collect_phase]

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -6,7 +6,7 @@ import json
 import os
 from enum import Enum
 
-from celery.result import AsyncResult
+#from celery.result import AsyncResult
 from celery import signature
 from celery import group, chain, chord, signature
 
@@ -35,7 +35,10 @@ CELERY_CHAIN_TYPE = type(chain())
 
 #Predefine phases. For new phases edit this and the config to reflect.
 #The domain of tasks ran should be very explicit.
-def prelim_phase(logger):
+@celery.task
+def prelim_phase():
+
+    logger = logging.getLogger(prelim_phase.__name__)
 
     tasks_with_repo_domain = []
 
@@ -50,7 +53,10 @@ def prelim_phase(logger):
     preliminary_tasks = group(*tasks_with_repo_domain)
     return preliminary_tasks
 
-def repo_collect_phase(logger):
+@celery.task
+def repo_collect_phase():
+    logger = logging.getLogger(repo_collect_phase.__name__)
+
     #Here the term issues also includes prs. This list is a bunch of chains that run in parallel to process issue data.
     issue_dependent_tasks = []
     #repo_info should run in a group
@@ -125,29 +131,31 @@ class AugurTaskRoutine:
 
         self.logger.info(f"Enabled phases: {list(self.jobs_dict.keys())}")
         augur_collection_list = []
-        for phaseName, job in self.jobs_dict.items():
-            self.logger.info(f"Starting phase {phaseName}")
-            #Call the function stored in the dict to return the object to call apply_async on
 
-            try:
-                tasks = job(self.logger)
-                phaseResult = tasks.apply_async() 
+        augur_collection_sequence = []
+        for phaseName, job in self.jobs_dict.items():
+            self.logger.info(f"Queuing phase {phaseName}")
+            #Call the function stored in the dict to return the object to call apply_async on
+            #try:
+            #    tasks = job(self.logger)
+            #    phaseResult = tasks.apply_async() 
 
                 # if the job is a group of tasks then join the group
-                if isinstance(tasks, CELERY_GROUP_TYPE): 
-                    with allow_join_result():
-                        phaseResult.join()
+            #    if isinstance(tasks, CELERY_GROUP_TYPE): 
+            #        with allow_join_result():
+            #            phaseResult.join()
 
-            except Exception as e:
-                #Log full traceback if a phase fails.
-                self.logger.error(
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
-                self.logger.error(
-                    f"Phase {phaseName} has failed during augur collection. Error: {e}")
-                raise e
-
-
-            #self.logger.info(f"Result of {phaseName} phase: {phaseResult.status}")
+            #except Exception as e:
+            #    #Log full traceback if a phase fails.
+            #    self.logger.error(
+            #    ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            #    self.logger.error(
+            #        f"Phase {phaseName} has failed during augur collection. Error: {e}")
+            #    raise e
+            augur_collection_sequence.append(job.si())
+        
+        augur_collection_chain = chain(*augur_collection_sequence)
+        augur_collection_chain.apply_async()
 
 
 @celery.task
@@ -168,6 +176,7 @@ def start_task():
     augur_collection = AugurTaskRoutine(collection_phases=enabled_phases)
 
     augur_collection.start_data_collection()
+
 
 
 

--- a/augur/tasks/util/worker_util.py
+++ b/augur/tasks/util/worker_util.py
@@ -56,7 +56,7 @@ def remove_duplicates_by_uniques(data, uniques):
 
     #Deal with null data being passed. 
     if not uniques:
-        return unique_data
+        return data
 
     for x in data:
 

--- a/augur/tasks/util/worker_util.py
+++ b/augur/tasks/util/worker_util.py
@@ -53,6 +53,11 @@ def remove_duplicates_by_uniques(data, uniques):
     unique_values = {}
 
     unique_data = []
+
+    #Deal with null data being passed. 
+    if not uniques:
+        return unique_data
+
     for x in data:
 
         # creates a key out of the uniques


### PR DESCRIPTION
**Description**
- Remove all use of Celery's result module to match the recent changes to Celery's settings in augur to ignore task results
- Make the task phases make more sense and be scheduled as celery tasks


**Signed commits**
- [x ] Yes, I signed my commits.
