### PR TITLE
check to not subscript null value for relase info in get_release_inf

### DIFF
--- a/augur/tasks/github/releases/core.py
+++ b/augur/tasks/github/releases/core.py
@@ -16,9 +16,17 @@ from augur.application.db.util import execute_session_query
 
 def get_release_inf(session, repo_id, release, tag_only):
     if not tag_only:
-        name = "" if release['author']['name'] is None else release['author']['name']
-        company = "" if release['author']['company'] is None else release['author']['company']
-        author = name + '_' + company
+
+        if release['author'] is None:
+            author = 'No Author Available.'
+            name = "N/A"
+            company = "N/A"
+        else:
+            name = "" if release['author']['name'] is None else release['author']['name']
+            company = "" if release['author']['company'] is None else release['author']['company']
+            author = name + '_' + company
+
+
         release_inf = {
             'release_id': release['id'],
             'repo_id': repo_id,


### PR DESCRIPTION
Signed-off-by: Isaac Milarsky <imilarsky@gmail.com>

**Description**
Checks for the author field when collecting release info to avoid accessing a null value. Also recorded in the data when the author info is completely null. 

This PR fixes #2038

**Signed commits**
- [X ] Yes, I signed my commits.
