### PR TITLE
updated CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ $ cd augur/
 $ git remote add upstream https://github.com/chaoss/augur.git
 ```
 
-2. Follow the [development installation instructions](https://oss-augur.readthedocs.io/en/main/development-guide/installation.html).
+2. Follow the [development installation instructions](https://github.com/chaoss/augur/blob/main/docs/new-install.md).
 
 3. Create a new branch
 ```bash


### PR DESCRIPTION
Signed-off-by: WhiteWolf47 <bhandari2003anurag@gmail.com>

**Description**
Updated CONTRIBUTING.md by adding the link to the new installation guide

This PR fixes #

The official augur docs still shows "make install-dev" for developers but since the new augur release and according to the new installation guide, we are now using "make install" even for devs. So this PR replaces the official augur link in the CONTRIBUTING.md file by the new installation guide i.e https://github.com/chaoss/augur/blob/main/docs/new-install.md .

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->