### PR TITLE
Add bash in the container

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -10,6 +10,7 @@ RUN set -x \
     && apt-get update \
     && apt-get -y install --no-install-recommends \
         git \
+        bash \
         curl \
         gcc \
         python3-pip \


### PR DESCRIPTION
The entrypoint.sh script use bash, running with podman return

    Jan 09 10:12:24 augur.osci.io podman[2004482]: /usr/bin/env: 'bash': No such file or directory

Signed-off-by: Michael Scherer <misc@redhat.com>

