### PR TITLE
Hardcode bash

### DIFF
--- a/docker/backend/entrypoint.sh
+++ b/docker/backend/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #SPDX-License-Identifier: MIT
 set -e
 


### PR DESCRIPTION
**Description**

It seems that for a reason I can't understand (and to be fair, I am not that motivated to go deeply in that rabbit hole), the shebang do not work on podman. Removing /usr/bin/env make it work fine, and since there is almost no reason to see bash move anywhere out of /usr, I think that's safe to just remove env and directly use bash.

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->