### PR TITLE
Fix Server has no engine error

### DIFF
--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -49,7 +49,9 @@ class Server():
         """Initialize the Server class."""
 
         self.logger = AugurLogger("server").get_logger()
-
+        self.session = DatabaseSession(self.logger)
+        self.config = AugurConfig(self.logger, self.session)
+        self.engine = self.session.engine
 
         self.cache_manager = self.create_cache_manager()
         self.server_cache = self.get_server_cache()
@@ -435,12 +437,9 @@ class Server():
             server cache
         """
 
-        with DatabaseSession(self.logger) as session:
-            config = AugurConfig(self.logger, session)
-
-            expire = int(config.get_value('Server', 'cache_expire'))
-            server_cache = self.cache_manager.get_cache('server', expire=expire)
-            server_cache.clear()
+        expire = int(self.config.get_value('Server', 'cache_expire'))
+        server_cache = self.cache_manager.get_cache('server', expire=expire)
+        server_cache.clear()
 
         return server_cache
 


### PR DESCRIPTION
This fixes this error:
```
Traceback (most recent call last):
  File "/home/andrew/virtualenvs/augur_env/lib/python3.8/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/andrew/virtualenvs/augur_env/lib/python3.8/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/andrew/virtualenvs/augur_env/lib/python3.8/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/andrew/virtualenvs/augur_env/lib/python3.8/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/andrew/virtualenvs/augur_env/lib/python3.8/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/home/andrew/augur/augur/api/routes/util.py", line 62, in get_all_repos
    results = pd.read_sql(get_all_repos_sql,  server.engine)
AttributeError: 'Server' object has no attribute 'engine'
```