### PR TITLE
Install only the required nltk data

### DIFF
--- a/scripts/docker/install-workers-deps.sh
+++ b/scripts/docker/install-workers-deps.sh
@@ -10,4 +10,7 @@ do
 done
 
 # install nltk
-/opt/venv/bin/python -m nltk.downloader all
+# taken from ./scripts/install/nltk_dictionaries.sh
+for i in stopwords punkt popular universal_tagset ; do
+	/opt/venv/bin/python -m nltk.downloader $i
+done


### PR DESCRIPTION
Signed-off-by: Michael Scherer <misc@redhat.com>

**Description**
My previous commit downloaded all nltk data. Upon a closer look, it seems we only need a fraction, hence this fix. 

It do not use the existing script, because 1) it is not interactive 2) it doesn't use python in the venv. The duplication is unfortunante, but I fear that fixing it would mean rewriting the whole installation workflow.


**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->