### PR TITLE
Deprecating Facade Affiliations Processing

### DIFF
--- a/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -7,7 +7,6 @@ from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
 from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.application.db.models import ContributorRepo
-from augur.application.db.engine import DatabaseEngine
 
 ### This worker scans all the platform users in Augur, and pulls their platform activity 
 ### logs. Those are then used to analyze what repos each is working in (which will include repos not
@@ -87,8 +86,7 @@ def contributor_breadth_model() -> None:
         WHERE 1 = 1
     """)
 
-    with DatabaseEngine(connection_pool_size=1) as engine:
-        current_event_ids = json.loads(pd.read_sql(dup_query, engine, params={}).to_json(orient="records"))
+    current_event_ids = json.loads(pd.read_sql(dup_query, engine, params={}).to_json(orient="records"))
 
     #Convert list of dictionaries to regular list of 'event_ids'.
     #The only values that the sql query returns are event_ids so

--- a/augur/tasks/data_analysis/discourse_analysis/tasks.py
+++ b/augur/tasks/data_analysis/discourse_analysis/tasks.py
@@ -10,7 +10,6 @@ from collections import Counter
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
 from augur.application.db.models import Repo, DiscourseInsight
-from augur.application.db.engine import DatabaseEngine
 from augur.application.db.util import execute_session_query
 
 #import os, sys, time, requests, json

--- a/augur/tasks/data_analysis/pull_request_analysis_worker/tasks.py
+++ b/augur/tasks/data_analysis/pull_request_analysis_worker/tasks.py
@@ -12,7 +12,6 @@ from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
 from augur.application.config import AugurConfig
 from augur.application.db.models import Repo, PullRequestAnalysis
-from augur.application.db.engine import DatabaseEngine
 from augur.application.db.util import execute_session_query
 
 # from sklearn.metrics import (confusion_matrix, f1_score, precision_score, recall_score)

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -49,8 +49,6 @@ from augur.application.logs import TaskLogConfig
 @celery.task
 def facade_error_handler(request,exc,traceback):
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(facade_error_handler.__name__)
 
     logger.error(f"Task {request.id} raised exception: {exc}! \n {traceback}")
@@ -69,8 +67,6 @@ def facade_error_handler(request,exc,traceback):
 #Predefine facade collection with tasks
 @celery.task
 def facade_analysis_init_facade_task():
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(facade_analysis_init_facade_task.__name__)
     with FacadeSession(logger) as session:
@@ -92,8 +88,6 @@ def grab_comitters(repo_id,platform="github"):
 
 @celery.task
 def trim_commits_facade_task(repo_id):
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(trim_commits_facade_task.__name__)
 
@@ -143,8 +137,6 @@ def trim_commits_facade_task(repo_id):
 
 @celery.task
 def trim_commits_post_analysis_facade_task(repo_id):
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(trim_commits_post_analysis_facade_task.__name__)
     
@@ -232,17 +224,14 @@ def trim_commits_post_analysis_facade_task(repo_id):
 @celery.task
 def facade_analysis_end_facade_task():
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(facade_analysis_end_facade_task.__name__)
-    FacadeSession(logger).log_activity('Info','Running analysis (complete)')
+    with FacadeSession(logger) as session:
+        session.log_activity('Info','Running analysis (complete)')
 
 
 
 @celery.task
 def facade_start_contrib_analysis_task():
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(facade_start_contrib_analysis_task.__name__)
     with FacadeSession(logger) as session:
@@ -255,8 +244,6 @@ def facade_start_contrib_analysis_task():
 def analyze_commits_in_parallel(repo_id, multithreaded: bool)-> None:
     """Take a large list of commit data to analyze and store in the database. Meant to be run in parallel with other instances of this task.
     """
-
-    from augur.tasks.init.celery_app import engine
 
     #create new session for celery thread.
     logger = logging.getLogger(analyze_commits_in_parallel.__name__)
@@ -345,8 +332,6 @@ def analyze_commits_in_parallel(repo_id, multithreaded: bool)-> None:
 @celery.task
 def nuke_affiliations_facade_task():
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(nuke_affiliations_facade_task.__name__)
     
     with FacadeSession(logger) as session:
@@ -355,16 +340,12 @@ def nuke_affiliations_facade_task():
 @celery.task
 def fill_empty_affiliations_facade_task():
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(fill_empty_affiliations_facade_task.__name__)
     with FacadeSession(logger) as session:
         fill_empty_affiliations(session)
 
 @celery.task
 def invalidate_caches_facade_task():
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(invalidate_caches_facade_task.__name__)
 
@@ -374,8 +355,6 @@ def invalidate_caches_facade_task():
 @celery.task
 def rebuild_unknown_affiliation_and_web_caches_facade_task():
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(rebuild_unknown_affiliation_and_web_caches_facade_task.__name__)
     
     with FacadeSession(logger) as session:
@@ -383,8 +362,6 @@ def rebuild_unknown_affiliation_and_web_caches_facade_task():
 
 @celery.task
 def force_repo_analysis_facade_task(repo_git):
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(force_repo_analysis_facade_task.__name__)
 
@@ -394,8 +371,6 @@ def force_repo_analysis_facade_task(repo_git):
 @celery.task
 def git_repo_cleanup_facade_task(repo_git):
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(git_repo_cleanup_facade_task.__name__)
 
     with FacadeSession(logger) as session:
@@ -403,8 +378,6 @@ def git_repo_cleanup_facade_task(repo_git):
 
 @celery.task
 def git_repo_initialize_facade_task(repo_git):
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(git_repo_initialize_facade_task.__name__)
 
@@ -414,8 +387,6 @@ def git_repo_initialize_facade_task(repo_git):
 @celery.task
 def check_for_repo_updates_facade_task(repo_git):
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(check_for_repo_updates_facade_task.__name__)
 
     with FacadeSession(logger) as session:
@@ -424,8 +395,6 @@ def check_for_repo_updates_facade_task(repo_git):
 @celery.task
 def force_repo_updates_facade_task(repo_git):
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(force_repo_updates_facade_task.__name__)
 
     with FacadeSession(logger) as session:
@@ -433,8 +402,6 @@ def force_repo_updates_facade_task(repo_git):
 
 @celery.task
 def git_repo_updates_facade_task(repo_git):
-
-    from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(git_repo_updates_facade_task.__name__)
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -1,3 +1,5 @@
+#SPDX-License-Identifier: MIT
+
 import sys
 import json
 import time

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -599,11 +599,21 @@ def generate_non_repo_domain_facade_tasks(logger):
         facade_sequence = []
 
         if nuke_stored_affiliations:
-            facade_sequence.append(nuke_affiliations_facade_task.si().on_error(facade_error_handler.s()))#nuke_affiliations(session.cfg)
+            #facade_sequence.append(nuke_affiliations_facade_task.si().on_error(facade_error_handler.s()))#nuke_affiliations(session.cfg)
+            logger.info("Nuke stored affiliations is deprecated.")
+            # deprecated because the UI component of facade where affiliations would be 
+            # nuked upon change no longer exists, and this information can easily be derived 
+            # from queries and materialized views in the current version of Augur.
+            # This method is also a major performance bottleneck with little value.
 
         #session.logger.info(session.cfg)
         if not limited_run or (limited_run and fix_affiliations):
-            facade_sequence.append(fill_empty_affiliations_facade_task.si().on_error(facade_error_handler.s()))#fill_empty_affiliations(session)
+            #facade_sequence.append(fill_empty_affiliations_facade_task.si().on_error(facade_error_handler.s()))#fill_empty_affiliations(session)
+            logger.info("Fill empty affiliations is deprecated.")
+            # deprecated because the UI component of facade where affiliations would need 
+            # to be fixed upon change no longer exists, and this information can easily be derived 
+            # from queries and materialized views in the current version of Augur.
+            # This method is also a major performance bottleneck with little value.
 
         if force_invalidate_caches:
             facade_sequence.append(invalidate_caches_facade_task.si().on_error(facade_error_handler.s()))#invalidate_caches(session.cfg)

--- a/augur/tasks/git/util/facade_worker/facade_worker/__init__.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/__init__.py
@@ -1,6 +1,6 @@
 #SPDX-License-Identifier: MIT
 """augur_worker_github - Augur Worker that collects GitHub data"""
 
-__version__ = '1.2.4'
+__version__ = '1.3.0'
 __author__ = 'Augur Team <s@goggins.com>'
 __all__ = []

--- a/augur/tasks/git/util/facade_worker/facade_worker/facade01config.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/facade01config.py
@@ -305,7 +305,7 @@ class FacadeConfig:
             sys.exit(1)
 
         self.tool_source = '\'Facade \''
-        self.tool_version = '\'1.2.4\''
+        self.tool_version = '\'1.3.0\''
         self.data_source = '\'Git Log\''
 
         self.worker_options = worker_options

--- a/augur/tasks/git/util/facade_worker/setup.py
+++ b/augur/tasks/git/util/facade_worker/setup.py
@@ -14,7 +14,7 @@ def read(filename):
 
 setup(
     name="facade_worker",
-    version="1.2.4",
+    version="1.3.0",
     url="https://github.com/chaoss/augur",
     license='MIT',
     author="Augurlabs",

--- a/augur/tasks/github/contributors/tasks.py
+++ b/augur/tasks/github/contributors/tasks.py
@@ -45,7 +45,7 @@ def process_contributors():
 
             url = f"https://api.github.com/users/{contributor_dict['cntrb_login']}" 
 
-            data = retrieve_dict_data(url, session)
+            data = retrieve_dict_data(url, session.oauths, logger)
 
             if data is None:
                 print(f"Unable to get contributor data for: {contributor_dict['cntrb_login']}")
@@ -65,12 +65,12 @@ def process_contributors():
 
 
 
-def retrieve_dict_data(url: str, session):
+def retrieve_dict_data(url: str, key_auth, logger):
 
     num_attempts = 0
     while num_attempts <= 10:
 
-        response = hit_api(session.oauths, url, session.logger)
+        response = hit_api(key_auth, url, logger)
 
         # increment attempts
         if response is None:
@@ -83,14 +83,14 @@ def retrieve_dict_data(url: str, session):
         if "message" in page_data:
 
             if page_data['message'] == "Not Found":
-                session.logger.info(
+                logger.info(
                     "Github repo was not found or does not exist for endpoint: "
                     f"{response.url}\n"
                 )
                 break
 
             elif "You have exceeded a secondary rate limit. Please wait a few minutes before you try again" in page_data['message']:
-                session.logger.info('\n\n\n\nSleeping for 100 seconds due to secondary rate limit issue.\n\n\n\n')
+                logger.info('\n\n\n\nSleeping for 100 seconds due to secondary rate limit issue.\n\n\n\n')
                 time.sleep(100)
                 continue
 

--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -15,10 +15,10 @@ class CollectionState(Enum):
     COLLECTING = "Collecting"
 
 
-def extract_owner_and_repo_from_endpoint(session,url):
-    response_from_gh = hit_api(session.oauths, url, session.logger)
+def extract_owner_and_repo_from_endpoint(key_auth, url, logger):
+    response_from_gh = hit_api(key_auth, url, logger)
 
-    page_data = parse_json_response(session.logger, response_from_gh)
+    page_data = parse_json_response(logger, response_from_gh)
 
     full_repo_name = page_data['full_name']
 
@@ -26,7 +26,7 @@ def extract_owner_and_repo_from_endpoint(session,url):
 
     return splits[0], splits[-1]
 
-def ping_github_for_repo_move(session,repo):
+def ping_github_for_repo_move(session,repo, logger):
 
     owner, name = get_owner_repo(repo.repo_git)
     url = f"https://api.github.com/repos/{owner}/{name}"
@@ -50,7 +50,7 @@ def ping_github_for_repo_move(session,repo):
         session.logger.info(f"Repo found at url: {url}")
         return
     
-    owner, name = extract_owner_and_repo_from_endpoint(session, response_from_gh.headers['location'])
+    owner, name = extract_owner_and_repo_from_endpoint(session, response_from_gh.headers['location'], logger)
 
     current_repo_dict = repo.__dict__
     del current_repo_dict['_sa_instance_state']

--- a/augur/tasks/github/detect_move/tasks.py
+++ b/augur/tasks/github/detect_move/tasks.py
@@ -21,6 +21,6 @@ def detect_github_repo_move(repo_git : str) -> None:
             query = session.query(Repo).filter(Repo.repo_git == repo_git)
             repo = execute_session_query(query, 'one')
             logger.info(f"Pinging repo: {repo_git}")
-            ping_github_for_repo_move(session, repo)
+            ping_github_for_repo_move(session, repo, logger)
         except Exception as e:
             logger.error(f"Could not check repo source for {repo_git}\n Reason: {e} \n Traceback: {''.join(traceback.format_exception(None, e, e.__traceback__))}")

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -23,11 +23,9 @@ def collect_github_messages(repo_git: str) -> None:
 
     from augur.tasks.init.celery_app import engine
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(collect_github_messages.__name__)
 
-    with DatabaseSession(logger, engine) as session:
+    with GithubTaskSession(logger, engine) as session:
         
         try:
             
@@ -35,11 +33,11 @@ def collect_github_messages(repo_git: str) -> None:
                 Repo.repo_git == repo_git).one().repo_id
 
             owner, repo = get_owner_repo(repo_git)
-            message_data = retrieve_all_pr_and_issue_messages(repo_git, logger)
+            message_data = retrieve_all_pr_and_issue_messages(repo_git, logger, session.oauths)
 
             if message_data:
             
-                process_messages(message_data, f"{owner}/{repo}: Message task", repo_id, logger)
+                process_messages(message_data, f"{owner}/{repo}: Message task", repo_id, logger, session)
 
             else:
                 logger.info(f"{owner}/{repo} has no messages")
@@ -48,9 +46,7 @@ def collect_github_messages(repo_git: str) -> None:
 
 
 
-def retrieve_all_pr_and_issue_messages(repo_git: str, logger) -> None:
-
-    from augur.tasks.init.celery_app import engine
+def retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth) -> None:
 
     owner, repo = get_owner_repo(repo_git)
 
@@ -64,10 +60,9 @@ def retrieve_all_pr_and_issue_messages(repo_git: str, logger) -> None:
     url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments"
 
     # define database task session, that also holds authentication keys the GithubPaginator needs
-    with GithubTaskSession(logger, engine) as session:
     
-        # returns an iterable of all issues at this url (this essentially means you can treat the issues variable as a list of the issues)
-        messages = GithubPaginator(url, session.oauths, logger)
+    # returns an iterable of all issues at this url (this essentially means you can treat the issues variable as a list of the issues)
+    messages = GithubPaginator(url, key_auth, logger)
 
     num_pages = messages.get_num_pages()
     all_data = []
@@ -90,9 +85,7 @@ def retrieve_all_pr_and_issue_messages(repo_git: str, logger) -> None:
     return all_data
     
 
-def process_messages(messages, task_name, repo_id, logger):
-
-    from augur.tasks.init.celery_app import engine
+def process_messages(messages, task_name, repo_id, logger, session):
 
     tool_source = "Pr comment task"
     tool_version = "2.0"
@@ -109,120 +102,118 @@ def process_messages(messages, task_name, repo_id, logger):
     if len(messages) == 0:
         logger.info(f"{task_name}: No messages to process")
 
-    with DatabaseSession(logger, engine) as session:
+    for message in messages:
 
-        for message in messages:
+        related_pr_of_issue_found = False
 
-            related_pr_of_issue_found = False
+        # this adds the cntrb_id to the message data
+        # the returned contributor will be added to the contributors list later, if the related issue or pr are found
+        # this logic is used so we don't insert a contributor when the related message isn't inserted
+        message, contributor = process_github_comment_contributors(message, tool_source, tool_version, data_source)
 
-            # this adds the cntrb_id to the message data
-            # the returned contributor will be added to the contributors list later, if the related issue or pr are found
-            # this logic is used so we don't insert a contributor when the related message isn't inserted
-            message, contributor = process_github_comment_contributors(message, tool_source, tool_version, data_source)
+        if is_issue_message(message["html_url"]):
 
-            if is_issue_message(message["html_url"]):
+            try:
+                query = session.query(Issue).filter(Issue.issue_url == message["issue_url"])
+                related_issue = execute_session_query(query, 'one')
+                related_pr_of_issue_found = True
 
-                try:
-                    query = session.query(Issue).filter(Issue.issue_url == message["issue_url"])
-                    related_issue = execute_session_query(query, 'one')
-                    related_pr_of_issue_found = True
-
-                except s.orm.exc.NoResultFound:
-                    logger.info(f"{task_name}: Could not find related pr")
-                    logger.info(
-                        f"{task_name}: We were searching for: {message['id']}")
-                    logger.info(f"{task_name}: Skipping")
-                    continue
-
-                issue_id = related_issue.issue_id
-
-                issue_message_ref_data = extract_needed_issue_message_ref_data(message, issue_id, repo_id, tool_source, tool_version, data_source)
-
-                message_ref_mapping_data.append(
-                    {
-                        "platform_msg_id": message["id"],
-                        "msg_ref_data": issue_message_ref_data,
-                        "is_issue": True
-                    }
-                )
-
-            else:
-
-                try:
-                    query = session.query(PullRequest).filter(PullRequest.pr_issue_url == message["issue_url"])
-                    related_pr = execute_session_query(query, 'one')
-                    related_pr_of_issue_found = True
-
-                except s.orm.exc.NoResultFound:
-                    logger.info(f"{task_name}: Could not find related pr")
-                    logger.info(f"We were searching for: {message['issue_url']}")
-                    logger.info(f"{task_name}: Skipping")
-                    continue
-
-                pull_request_id = related_pr.pull_request_id
-
-                pr_message_ref_data = extract_needed_pr_message_ref_data(message, pull_request_id, repo_id, tool_source, tool_version, data_source)
-
-                message_ref_mapping_data.append(
-                    {
-                        "platform_msg_id": message["id"],
-                        "msg_ref_data": pr_message_ref_data,
-                        "is_issue": False
-                    }
-                )
-            
-            if related_pr_of_issue_found:
-
-                message_dicts.append(
-                                extract_needed_message_data(message, platform_id, repo_id, tool_source, tool_version, data_source)
-                )
-
-                contributors.append(contributor)
-
-        contributors = remove_duplicate_dicts(contributors)
-
-        logger.info(f"{task_name}: Inserting {len(contributors)} contributors")
-
-        session.insert_data(contributors, Contributor, ["cntrb_id"])
-
-        logger.info(f"{task_name}: Inserting {len(message_dicts)} messages")
-        message_natural_keys = ["platform_msg_id"]
-        message_return_columns = ["msg_id", "platform_msg_id"]
-        message_string_fields = ["msg_text"]
-        message_return_data = session.insert_data(message_dicts, Message, message_natural_keys, 
-                                                    return_columns=message_return_columns, string_fields=message_string_fields)
-
-        pr_message_ref_dicts = []
-        issue_message_ref_dicts = []
-        for mapping_data in message_ref_mapping_data:
-
-            value = mapping_data["platform_msg_id"]
-            key = "platform_msg_id"
-
-            issue_or_pr_message = find_dict_in_list_of_dicts(message_return_data, key, value)
-
-            if issue_or_pr_message:
-
-                msg_id = issue_or_pr_message["msg_id"]
-            else:
-                print("Count not find issue or pull request message to map to")
+            except s.orm.exc.NoResultFound:
+                logger.info(f"{task_name}: Could not find related pr")
+                logger.info(
+                    f"{task_name}: We were searching for: {message['id']}")
+                logger.info(f"{task_name}: Skipping")
                 continue
 
-            message_ref_data = mapping_data["msg_ref_data"]
-            message_ref_data["msg_id"] = msg_id 
+            issue_id = related_issue.issue_id
 
-            if mapping_data["is_issue"] is True:
-                issue_message_ref_dicts.append(message_ref_data)
-            else:
-                pr_message_ref_dicts.append(message_ref_data)
+            issue_message_ref_data = extract_needed_issue_message_ref_data(message, issue_id, repo_id, tool_source, tool_version, data_source)
 
-        pr_message_ref_natural_keys = ["pull_request_id", "pr_message_ref_src_comment_id"]
-        session.insert_data(pr_message_ref_dicts, PullRequestMessageRef, pr_message_ref_natural_keys)
+            message_ref_mapping_data.append(
+                {
+                    "platform_msg_id": message["id"],
+                    "msg_ref_data": issue_message_ref_data,
+                    "is_issue": True
+                }
+            )
 
-        issue_message_ref_natural_keys = ["issue_id", "issue_msg_ref_src_comment_id"]
-        session.insert_data(issue_message_ref_dicts, IssueMessageRef, issue_message_ref_natural_keys)
+        else:
 
-        logger.info(f"{task_name}: Inserted {len(message_dicts)} messages. {len(issue_message_ref_dicts)} from issues and {len(pr_message_ref_dicts)} from prs")
+            try:
+                query = session.query(PullRequest).filter(PullRequest.pr_issue_url == message["issue_url"])
+                related_pr = execute_session_query(query, 'one')
+                related_pr_of_issue_found = True
+
+            except s.orm.exc.NoResultFound:
+                logger.info(f"{task_name}: Could not find related pr")
+                logger.info(f"We were searching for: {message['issue_url']}")
+                logger.info(f"{task_name}: Skipping")
+                continue
+
+            pull_request_id = related_pr.pull_request_id
+
+            pr_message_ref_data = extract_needed_pr_message_ref_data(message, pull_request_id, repo_id, tool_source, tool_version, data_source)
+
+            message_ref_mapping_data.append(
+                {
+                    "platform_msg_id": message["id"],
+                    "msg_ref_data": pr_message_ref_data,
+                    "is_issue": False
+                }
+            )
+        
+        if related_pr_of_issue_found:
+
+            message_dicts.append(
+                            extract_needed_message_data(message, platform_id, repo_id, tool_source, tool_version, data_source)
+            )
+
+            contributors.append(contributor)
+
+    contributors = remove_duplicate_dicts(contributors)
+
+    logger.info(f"{task_name}: Inserting {len(contributors)} contributors")
+
+    session.insert_data(contributors, Contributor, ["cntrb_id"])
+
+    logger.info(f"{task_name}: Inserting {len(message_dicts)} messages")
+    message_natural_keys = ["platform_msg_id"]
+    message_return_columns = ["msg_id", "platform_msg_id"]
+    message_string_fields = ["msg_text"]
+    message_return_data = session.insert_data(message_dicts, Message, message_natural_keys, 
+                                                return_columns=message_return_columns, string_fields=message_string_fields)
+
+    pr_message_ref_dicts = []
+    issue_message_ref_dicts = []
+    for mapping_data in message_ref_mapping_data:
+
+        value = mapping_data["platform_msg_id"]
+        key = "platform_msg_id"
+
+        issue_or_pr_message = find_dict_in_list_of_dicts(message_return_data, key, value)
+
+        if issue_or_pr_message:
+
+            msg_id = issue_or_pr_message["msg_id"]
+        else:
+            print("Count not find issue or pull request message to map to")
+            continue
+
+        message_ref_data = mapping_data["msg_ref_data"]
+        message_ref_data["msg_id"] = msg_id 
+
+        if mapping_data["is_issue"] is True:
+            issue_message_ref_dicts.append(message_ref_data)
+        else:
+            pr_message_ref_dicts.append(message_ref_data)
+
+    pr_message_ref_natural_keys = ["pull_request_id", "pr_message_ref_src_comment_id"]
+    session.insert_data(pr_message_ref_dicts, PullRequestMessageRef, pr_message_ref_natural_keys)
+
+    issue_message_ref_natural_keys = ["issue_id", "issue_msg_ref_src_comment_id"]
+    session.insert_data(issue_message_ref_dicts, IssueMessageRef, issue_message_ref_natural_keys)
+
+    logger.info(f"{task_name}: Inserted {len(message_dicts)} messages. {len(issue_message_ref_dicts)} from issues and {len(pr_message_ref_dicts)} from prs")
 
 
 def is_issue_message(html_url):

--- a/augur/tasks/github/pull_requests/commits_model/core.py
+++ b/augur/tasks/github/pull_requests/commits_model/core.py
@@ -11,9 +11,7 @@ from augur.tasks.github.util.util import get_owner_repo
 from augur.application.db.util import execute_session_query
 
 
-def pull_request_commits_model(repo_id,logger):
-
-    from augur.tasks.init.celery_app import engine
+def pull_request_commits_model(repo_id,logger, session):
     
     # query existing PRs and the respective url we will append the commits url to
     pr_url_sql = s.sql.text("""
@@ -24,48 +22,45 @@ def pull_request_commits_model(repo_id,logger):
     pr_urls = []
     #pd.read_sql(pr_number_sql, self.db, params={})
 
-    with DatabaseSession(logger, engine) as session:
-        pr_urls = session.fetchall_data_from_sql_text(pr_url_sql)#session.execute_sql(pr_number_sql).fetchall()
-        
-        query = session.query(Repo).filter(Repo.repo_id == repo_id)
-        repo = execute_session_query(query, 'one')
+    pr_urls = session.fetchall_data_from_sql_text(pr_url_sql)#session.execute_sql(pr_number_sql).fetchall()
+    
+    query = session.query(Repo).filter(Repo.repo_id == repo_id)
+    repo = execute_session_query(query, 'one')
 
     owner, name = get_owner_repo(repo.repo_git)
 
     logger.info(f"Getting pull request commits for repo: {repo.repo_git}")
-
-    with GithubTaskSession(logger, engine) as session:
         
-        for index,pr_info in enumerate(pr_urls):
-            logger.info(f'Querying commits for pull request #{index + 1} of {len(pr_urls)}')
+    for index,pr_info in enumerate(pr_urls):
+        logger.info(f'Querying commits for pull request #{index + 1} of {len(pr_urls)}')
 
-            commits_url = pr_info['pr_url'] + '/commits?state=all'
+        commits_url = pr_info['pr_url'] + '/commits?state=all'
 
-            #Paginate through the pr commits
-            pr_commits = GithubPaginator(commits_url, session.oauths, logger)
+        #Paginate through the pr commits
+        pr_commits = GithubPaginator(commits_url, session.oauths, logger)
 
-            all_data = []
-            for page_data in pr_commits:
-                logger.info(f"Processing pr commit with hash {page_data['sha']}")
-                pr_commit_row = {
-                    'pull_request_id': pr_info['pull_request_id'],
-                    'pr_cmt_sha': page_data['sha'],
-                    'pr_cmt_node_id': page_data['node_id'],
-                    'pr_cmt_message': page_data['commit']['message'],
-                    # 'pr_cmt_comments_url': pr_commit['comments_url'],
-                    'tool_source': 'pull_request_commits_model',
-                    'tool_version': '0.41',
-                    'data_source': 'GitHub API',
-                    'repo_id': repo_id,
-                }
+        all_data = []
+        for page_data in pr_commits:
+            logger.info(f"Processing pr commit with hash {page_data['sha']}")
+            pr_commit_row = {
+                'pull_request_id': pr_info['pull_request_id'],
+                'pr_cmt_sha': page_data['sha'],
+                'pr_cmt_node_id': page_data['node_id'],
+                'pr_cmt_message': page_data['commit']['message'],
+                # 'pr_cmt_comments_url': pr_commit['comments_url'],
+                'tool_source': 'pull_request_commits_model',
+                'tool_version': '0.41',
+                'data_source': 'GitHub API',
+                'repo_id': repo_id,
+            }
 
-                all_data.append(pr_commit_row)
-        
-            if len(all_data) > 0:
-                #Execute bulk upsert
-                pr_commits_natural_keys = [	"pull_request_id", "repo_id", "pr_cmt_sha"]
-                session.insert_data(all_data,PullRequestCommit,pr_commits_natural_keys)
-                
+            all_data.append(pr_commit_row)
+    
+        if len(all_data) > 0:
+            #Execute bulk upsert
+            pr_commits_natural_keys = [	"pull_request_id", "repo_id", "pr_cmt_sha"]
+            session.insert_data(all_data,PullRequestCommit,pr_commits_natural_keys)
+            
 
 
 

--- a/augur/tasks/github/pull_requests/commits_model/tasks.py
+++ b/augur/tasks/github/pull_requests/commits_model/tasks.py
@@ -13,12 +13,12 @@ def process_pull_request_commits(repo_git: str) -> None:
 
     logger = logging.getLogger(process_pull_request_commits.__name__)
 
-    with DatabaseSession(logger, engine) as session:
+    with GithubTaskSession(logger, engine) as session:
 
         query = session.query(Repo).filter(Repo.repo_git == repo_git)
         repo = execute_session_query(query, 'one')
         try:
-            pull_request_commits_model(repo.repo_id, logger)
+            pull_request_commits_model(repo.repo_id, logger, session)
         except Exception as e:
             logger.error(f"Could not complete pull_request_commits_model!\n Reason: {e} \n Traceback: {''.join(traceback.format_exception(None, e, e.__traceback__))}")
             raise e

--- a/augur/tasks/github/pull_requests/core.py
+++ b/augur/tasks/github/pull_requests/core.py
@@ -131,7 +131,7 @@ def extract_data_from_pr_list(pull_requests: List[dict],
     return pr_dicts, pr_mapping_data, pr_numbers, contributors
 
 
-def insert_pr_contributors(contributors: List[dict], session: GithubTaskSession, task_name: str) -> None:
+def insert_pr_contributors(contributors: List[dict], session: DatabaseSession, task_name: str) -> None:
     """Insert pr contributors
     
     Args:
@@ -148,7 +148,7 @@ def insert_pr_contributors(contributors: List[dict], session: GithubTaskSession,
     session.insert_data(contributors, Contributor, ["cntrb_id"])
 
 
-def insert_prs(pr_dicts: List[dict], session: GithubTaskSession, task_name: str) -> Optional[List[dict]]:
+def insert_prs(pr_dicts: List[dict], session: DatabaseSession, task_name: str) -> Optional[List[dict]]:
     """Insert pull requests
     
     Args:
@@ -213,7 +213,7 @@ def map_other_pr_data_to_pr(
     return pr_label_dicts, pr_assignee_dicts, pr_reviewer_dicts, pr_metadata_dicts 
 
 
-def insert_pr_labels(labels: List[dict], logger: logging.Logger) -> None:
+def insert_pr_labels(labels: List[dict], logger: logging.Logger, session) -> None:
     """Insert pull request labels
 
     Note:
@@ -223,16 +223,12 @@ def insert_pr_labels(labels: List[dict], logger: logging.Logger) -> None:
         labels: list of labels to insert
         logger: handles logging
     """
-    from augur.tasks.init.celery_app import engine
-
-    with DatabaseSession(logger, engine) as session:
-
-        # we are using pr_src_id and pull_request_id to determine if the label is already in the database.
-        pr_label_natural_keys = ['pr_src_id', 'pull_request_id']
-        session.insert_data(labels, PullRequestLabel, pr_label_natural_keys)
+    # we are using pr_src_id and pull_request_id to determine if the label is already in the database.
+    pr_label_natural_keys = ['pr_src_id', 'pull_request_id']
+    session.insert_data(labels, PullRequestLabel, pr_label_natural_keys)
 
 
-def insert_pr_assignees(assignees: List[dict], logger: logging.Logger) -> None:
+def insert_pr_assignees(assignees: List[dict], logger: logging.Logger, session) -> None:
     """Insert pull request assignees
 
     Note:
@@ -242,16 +238,12 @@ def insert_pr_assignees(assignees: List[dict], logger: logging.Logger) -> None:
         assignees: list of assignees to insert
         logger: handles logging
     """
-    from augur.tasks.init.celery_app import engine
-
-    with DatabaseSession(logger, engine) as session:
-
-        # we are using pr_assignee_src_id and pull_request_id to determine if the label is already in the database.
-        pr_assignee_natural_keys = ['pr_assignee_src_id', 'pull_request_id']
-        session.insert_data(assignees, PullRequestAssignee, pr_assignee_natural_keys)
+    # we are using pr_assignee_src_id and pull_request_id to determine if the label is already in the database.
+    pr_assignee_natural_keys = ['pr_assignee_src_id', 'pull_request_id']
+    session.insert_data(assignees, PullRequestAssignee, pr_assignee_natural_keys)
 
 
-def insert_pr_reviewers(reviewers: List[dict], logger: logging.Logger) -> None:
+def insert_pr_reviewers(reviewers: List[dict], logger: logging.Logger, session) -> None:
     """Insert pull request reviewers
 
     Note:
@@ -261,16 +253,12 @@ def insert_pr_reviewers(reviewers: List[dict], logger: logging.Logger) -> None:
         reviewers: list of reviewers to insert
         logger: handles logging
     """
-    from augur.tasks.init.celery_app import engine
-
-    with DatabaseSession(logger, engine) as session:
-
-        # we are using pr_src_id and pull_request_id to determine if the label is already in the database.
-        pr_reviewer_natural_keys = ["pull_request_id", "pr_reviewer_src_id"]
-        session.insert_data(reviewers, PullRequestReviewer, pr_reviewer_natural_keys)
+    # we are using pr_src_id and pull_request_id to determine if the label is already in the database.
+    pr_reviewer_natural_keys = ["pull_request_id", "pr_reviewer_src_id"]
+    session.insert_data(reviewers, PullRequestReviewer, pr_reviewer_natural_keys)
 
 
-def insert_pr_metadata(metadata: List[dict], logger: logging.Logger) -> None:
+def insert_pr_metadata(metadata: List[dict], logger: logging.Logger, session) -> None:
     """Insert pull request metadata
 
     Note:
@@ -280,14 +268,10 @@ def insert_pr_metadata(metadata: List[dict], logger: logging.Logger) -> None:
         metadata: list of metadata to insert
         logger: handles logging
     """
-    from augur.tasks.init.celery_app import engine
-
-    with DatabaseSession(logger, engine) as session:
-
-        # inserting pr metadata
-        # we are using pull_request_id, pr_head_or_base, and pr_sha to determine if the label is already in the database.
-        pr_metadata_natural_keys = ['pull_request_id', 'pr_head_or_base', 'pr_sha']
-        session.insert_data(metadata, PullRequestMeta, pr_metadata_natural_keys)
+    # inserting pr metadata
+    # we are using pull_request_id, pr_head_or_base, and pr_sha to determine if the label is already in the database.
+    pr_metadata_natural_keys = ['pull_request_id', 'pr_head_or_base', 'pr_sha']
+    session.insert_data(metadata, PullRequestMeta, pr_metadata_natural_keys)
 
 
 

--- a/augur/tasks/github/pull_requests/files_model/core.py
+++ b/augur/tasks/github/pull_requests/files_model/core.py
@@ -11,7 +11,7 @@ from augur.application.db.models import *
 from augur.tasks.github.util.util import get_owner_repo
 from augur.application.db.util import execute_session_query
 
-def pull_request_files_model(repo_id,logger):
+def pull_request_files_model(repo_id,logger, session):
     
     from augur.tasks.init.celery_app import engine
 
@@ -24,69 +24,68 @@ def pull_request_files_model(repo_id,logger):
     pr_numbers = []
     #pd.read_sql(pr_number_sql, self.db, params={})
 
-    with GithubTaskSession(logger, engine) as session:
-        result = session.execute_sql(pr_number_sql).fetchall()
-        pr_numbers = [dict(zip(row.keys(), row)) for row in result]
+    result = session.execute_sql(pr_number_sql).fetchall()
+    pr_numbers = [dict(zip(row.keys(), row)) for row in result]
 
-        query = session.query(Repo).filter(Repo.repo_id == repo_id)
-        repo = execute_session_query(query, 'one')
+    query = session.query(Repo).filter(Repo.repo_id == repo_id)
+    repo = execute_session_query(query, 'one')
 
-        owner, name = get_owner_repo(repo.repo_git)
+    owner, name = get_owner_repo(repo.repo_git)
 
-        pr_file_rows = []
-        logger.info(f"Getting pull request files for repo: {repo.repo_git}")
-        for index,pr_info in enumerate(pr_numbers):
+    pr_file_rows = []
+    logger.info(f"Getting pull request files for repo: {repo.repo_git}")
+    for index,pr_info in enumerate(pr_numbers):
 
-            logger.info(f'Querying files for pull request #{index + 1} of {len(pr_numbers)}')
-            
-            query = """
+        logger.info(f'Querying files for pull request #{index + 1} of {len(pr_numbers)}')
+        
+        query = """
 
-                query($repo: String!, $owner: String!,$pr_number: Int!, $numRecords: Int!, $cursor: String) {
-                    repository(name: $repo, owner: $owner) {
-                        pullRequest(number: $pr_number) {
-                            files ( first: $numRecords, after: $cursor)
-                            {
-                                edges {
-                                    node {
-                                        additions
-                                        deletions
-                                        path
-                                    }
+            query($repo: String!, $owner: String!,$pr_number: Int!, $numRecords: Int!, $cursor: String) {
+                repository(name: $repo, owner: $owner) {
+                    pullRequest(number: $pr_number) {
+                        files ( first: $numRecords, after: $cursor)
+                        {
+                            edges {
+                                node {
+                                    additions
+                                    deletions
+                                    path
                                 }
-                                totalCount
-                                pageInfo {
-                                    hasNextPage
-                                    endCursor
-                                }
+                            }
+                            totalCount
+                            pageInfo {
+                                hasNextPage
+                                endCursor
                             }
                         }
                     }
                 }
-            """
-            
-            values = ("repository","pullRequest","files")
-            params = {
-                'owner' : owner,
-                'repo'  : name,
-                'pr_number' : pr_info['pr_src_number'],
-                'values' : values
             }
+        """
+        
+        values = ("repository","pullRequest","files")
+        params = {
+            'owner' : owner,
+            'repo'  : name,
+            'pr_number' : pr_info['pr_src_number'],
+            'values' : values
+        }
 
-            try:
-                file_collection = GraphQlPageCollection(query, session.oauths, session.logger,bind=params)
+        try:
+            file_collection = GraphQlPageCollection(query, session.oauths, session.logger,bind=params)
 
-                pr_file_rows += [{
-                    'pull_request_id': pr_info['pull_request_id'],
-                    'pr_file_additions': pr_file['additions'] if 'additions' in pr_file else None,
-                    'pr_file_deletions': pr_file['deletions'] if 'deletions' in pr_file else None,
-                    'pr_file_path': pr_file['path'],
-                    'data_source': 'GitHub API',
-                    'repo_id': repo_id, 
-                    } for pr_file in file_collection if pr_file and 'path' in pr_file]
-            except Exception as e:
-                logger.error(f"Ran into error with pull request #{index + 1} in repo {repo_id}")
-                logger.error(
-                ''.join(traceback.format_exception(None, e, e.__traceback__)))
+            pr_file_rows += [{
+                'pull_request_id': pr_info['pull_request_id'],
+                'pr_file_additions': pr_file['additions'] if 'additions' in pr_file else None,
+                'pr_file_deletions': pr_file['deletions'] if 'deletions' in pr_file else None,
+                'pr_file_path': pr_file['path'],
+                'data_source': 'GitHub API',
+                'repo_id': repo_id, 
+                } for pr_file in file_collection if pr_file and 'path' in pr_file]
+        except Exception as e:
+            logger.error(f"Ran into error with pull request #{index + 1} in repo {repo_id}")
+            logger.error(
+            ''.join(traceback.format_exception(None, e, e.__traceback__)))
 
 
 

--- a/augur/tasks/github/pull_requests/files_model/tasks.py
+++ b/augur/tasks/github/pull_requests/files_model/tasks.py
@@ -12,11 +12,11 @@ def process_pull_request_files(repo_git: str) -> None:
 
     logger = logging.getLogger(process_pull_request_files.__name__)
 
-    with DatabaseSession(logger, engine) as session:
+    with GithubTaskSession(logger, engine) as session:
         query = session.query(Repo).filter(Repo.repo_git == repo_git)
         repo = execute_session_query(query, 'one')
         try:
-            pull_request_files_model(repo.repo_id, logger)
+            pull_request_files_model(repo.repo_id, logger, session)
         except Exception as e:
             logger.error(f"Could not complete pull_request_files_model!\n Reason: {e} \n Traceback: {''.join(traceback.format_exception(None, e, e.__traceback__))}")
             #raise e

--- a/augur/tasks/github/releases/core.py
+++ b/augur/tasks/github/releases/core.py
@@ -14,7 +14,7 @@ from augur.tasks.github.util.gh_graphql_entities import hit_api_graphql, request
 from augur.application.db.util import execute_session_query
 
 
-def get_release_inf(session, repo_id, release, tag_only):
+def get_release_inf(repo_id, release, tag_only):
     if not tag_only:
 
         if release['author'] is None:
@@ -81,7 +81,7 @@ def insert_release(session, repo_id, owner, release, tag_only = False):
 
     # Put all data together in format of the table
     session.logger.info(f'Inserting release for repo with id:{repo_id}, owner:{owner}, release name:{release["name"]}\n')
-    release_inf = get_release_inf(session, repo_id, release, tag_only)
+    release_inf = get_release_inf(repo_id, release, tag_only)
 
     #Do an upsert
     session.insert_data(release_inf,Release,['release_id'])

--- a/augur/tasks/github/releases/tasks.py
+++ b/augur/tasks/github/releases/tasks.py
@@ -9,8 +9,6 @@ def collect_releases(repo_git):
 
     from augur.tasks.init.celery_app import engine
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(collect_releases.__name__)
     with GithubTaskSession(logger, engine) as session:
 

--- a/augur/tasks/github/repo_info/core.py
+++ b/augur/tasks/github/repo_info/core.py
@@ -100,8 +100,8 @@ def grab_repo_info_from_graphql_endpoint(session,query):
     return data
     
 
-def repo_info_model(session, repo_orm_obj):
-    session.logger.info("Beginning filling the repo_info model for repo: " + repo_orm_obj.repo_git + "\n")
+def repo_info_model(session, repo_orm_obj, logger):
+    logger.info("Beginning filling the repo_info model for repo: " + repo_orm_obj.repo_git + "\n")
 
     owner, repo = get_owner_repo(repo_orm_obj.repo_git)
 
@@ -220,7 +220,7 @@ def repo_info_model(session, repo_orm_obj):
     try:
         data = grab_repo_info_from_graphql_endpoint(session, query)
     except Exception as e:
-        session.logger.error(f"Could not grab info for repo {repo_orm_obj.repo_id}")
+        logger.error(f"Could not grab info for repo {repo_orm_obj.repo_id}")
         raise e
         return
 
@@ -235,7 +235,7 @@ def repo_info_model(session, repo_orm_obj):
     committers_count = query_committers_count(session, owner, repo)
 
     # Put all data together in format of the table
-    session.logger.info(f'Inserting repo info for repo with id:{repo_orm_obj.repo_id}, owner:{owner}, name:{repo}\n')
+    logger.info(f'Inserting repo info for repo with id:{repo_orm_obj.repo_id}, owner:{owner}, name:{repo}\n')
     rep_inf = {
         'repo_id': repo_orm_obj.repo_id,
         'last_updated': data['updatedAt'] if 'updatedAt' in data else None,
@@ -301,6 +301,6 @@ def repo_info_model(session, repo_orm_obj):
     update_repo_data = s.sql.text("""UPDATE repo SET forked_from=:forked, repo_archived=:archived, repo_archived_date_collected=:archived_date_collected WHERE repo_id=:repo_id""").bindparams(forked=forked, archived=archived, archived_date_collected=archived_date_collected, repo_id=repo_orm_obj.repo_id)
     session.execute_sql(update_repo_data)
 
-    session.logger.info(f"Inserted info for {owner}/{repo}\n")
+    logger.info(f"Inserted info for {owner}/{repo}\n")
 
 

--- a/augur/tasks/github/repo_info/tasks.py
+++ b/augur/tasks/github/repo_info/tasks.py
@@ -10,15 +10,13 @@ def collect_repo_info(repo_git: str):
 
     from augur.tasks.init.celery_app import engine
 
-    from augur.tasks.init.celery_app import engine
-
     logger = logging.getLogger(collect_repo_info.__name__)
 
     with GithubTaskSession(logger, engine) as session:
         query = session.query(Repo).filter(Repo.repo_git == repo_git)
         repo = execute_session_query(query, 'one')
         try:
-            repo_info_model(session, repo)
+            repo_info_model(session, repo, logger)
         except Exception as e:
             session.logger.error(f"Could not add repo info for repo {repo.repo_id}\n Error: {e}")
             session.logger.error(

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -161,7 +161,7 @@ def init_worker(**kwargs):
 
     from augur.application.db.engine import DatabaseEngine
 
-    engine = DatabaseEngine(pool_size=5, max_overflow=10, pool_timeout=240).engine
+    engine = DatabaseEngine(pool_size=5, max_overflow=10).engine
 
 
 @worker_process_shutdown.connect

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -30,7 +30,6 @@ from celery.result import allow_join_result
 from augur.application.logs import AugurLogger
 from augur.application.config import AugurConfig
 from augur.application.db.session import DatabaseSession
-from augur.application.db.engine import DatabaseEngine
 from augur.application.db.util import execute_session_query
 from logging import Logger
 from enum import Enum

--- a/scripts/docker/install-workers-deps.sh
+++ b/scripts/docker/install-workers-deps.sh
@@ -10,4 +10,7 @@ do
 done
 
 # install nltk
-/opt/venv/bin/python -m nltk.downloader all
+# taken from ./scripts/install/nltk_dictionaries.sh
+for i in stopwords punkt popular universal_tagset ; do
+	/opt/venv/bin/python -m nltk.downloader $i
+done


### PR DESCRIPTION
**Description**
- The Facade task, which is used for commit counting in Augur, previously had two functions for "nuking" and "rebuilding" affiliation data inside the commit table. This is a feature no longer required, as it can be replaced with simpler logic, queries, and materialized views if needed. These were also computationally expensive tasks that added limited value. 
- Facade task version bumped to 1.3.0
