### PR TITLE
Refresh materialized views collection frequency patch

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -123,6 +123,7 @@ def setup_periodic_tasks(sender, **kwargs):
     Returns
         The tasks so that they are grouped by the module they are defined in
     """
+    from celery.schedules import crontab
     from augur.tasks.start_tasks import augur_collection_monitor
     from augur.tasks.start_tasks import non_repo_domain_tasks
     from augur.tasks.db.refresh_materialized_views import refresh_materialized_views
@@ -142,9 +143,9 @@ def setup_periodic_tasks(sender, **kwargs):
         logger.info(f"Scheduling non-repo-domain collection every {non_domain_collection_interval/60} minutes")
         sender.add_periodic_task(non_domain_collection_interval, non_repo_domain_tasks.s())
 
-        refresh_materialized_views_freq = 36 # hours
-        logger.info(f"Scheduling refresh materialized view every {refresh_materialized_views_freq} hours")
-        sender.add_periodic_task(refresh_materialized_views_freq*60*60, refresh_materialized_views.s())
+        logger.info(f"Scheduling refresh materialized view every night at 1am CDT")
+        sender.add_periodic_task(crontab(hour=1, minute=0), refresh_materialized_views.s())
+        
 
 
 @after_setup_logger.connect

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -125,6 +125,7 @@ def setup_periodic_tasks(sender, **kwargs):
     """
     from augur.tasks.start_tasks import augur_collection_monitor
     from augur.tasks.start_tasks import non_repo_domain_tasks
+    from augur.tasks.db.refresh_materialized_views import refresh_materialized_views
     
     with DatabaseEngine() as engine, DatabaseSession(logger, engine) as session:
 
@@ -140,6 +141,10 @@ def setup_periodic_tasks(sender, **kwargs):
         non_domain_collection_interval = collection_interval * 5
         logger.info(f"Scheduling non-repo-domain collection every {non_domain_collection_interval/60} minutes")
         sender.add_periodic_task(non_domain_collection_interval, non_repo_domain_tasks.s())
+
+        refresh_materialized_views_freq = 36 # hours
+        logger.info(f"Scheduling refresh materialized view every {refresh_materialized_views_freq} hours")
+        sender.add_periodic_task(refresh_materialized_views_freq*60*60, refresh_materialized_views.s())
 
 
 @after_setup_logger.connect

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -269,7 +269,6 @@ def non_repo_domain_tasks():
 
     from augur.tasks.init.celery_app import engine
 
-
     logger = logging.getLogger(non_repo_domain_tasks.__name__)
 
     logger.info("Executing non-repo domain tasks")
@@ -305,7 +304,6 @@ def non_repo_domain_tasks():
 
     tasks = chain(
         *enabled_tasks,
-        refresh_materialized_views.si()
     )
 
     tasks.apply_async()


### PR DESCRIPTION
**Description**
- Gave the `refresh_materialized_views` task its own schedule
- Made the task run once a day at 1am (in whatever timezone the server is in)
- I chose 1am so it doesn't slow down the database so much during regular business hours

**Signed commits**
- [X] Yes, I signed my commits.