### PR TITLE
Syntax Errors in Alembic Script

### DIFF
--- a/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
+++ b/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
@@ -36,7 +36,7 @@ def upgrade():
                 UPDATE "repo"
                 SET repo_path=:path,repo_name=:name
                 WHERE repo_git=:repo_git
-                """).bindparams(repo_path=repo_path,repo_name=repo_name,repo_git=row.repo_git))
+                """).bindparams(path=repo_path,repo_name=repo_name,repo_git=row.repo_git))
     # ### end Alembic commands ###
 
 

--- a/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
+++ b/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
@@ -36,7 +36,7 @@ def upgrade():
                 UPDATE "repo"
                 SET repo_path=:path,repo_name=:name
                 WHERE repo_git=:repo_git
-                """).bindparams(path=repo_path,repo_name=repo_name,repo_git=row.repo_git))
+                """).bindparams(path=repo_path,name=repo_name,repo_git=row.repo_git))
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
**Description**
- Fix issue with alembic script having the wrong bind variable name for update statements
- Issue was not caught because it only happens when existing repos have null repo_path or repo_name when upgrading via alembic. 


**Signed commits**
- [x] Yes, I signed my commits.
