### PR TITLE
Reduce Db connections

### DIFF
--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -20,11 +20,13 @@ from flask_cors import CORS
 import pandas as pd
 from beaker.util import parse_cache_config_options
 from beaker.cache import CacheManager, Cache
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
 
-
-from augur.application.db.session import DatabaseSession
 from augur.application.logs import AugurLogger
 from augur.application.config import AugurConfig
+from augur.application.db.session import DatabaseSession
+from augur.application.db.engine import get_database_string
 from metadata import __version__ as augur_code_version
 
 # from augur.api.routes import AUGUR_API_VERSION
@@ -319,12 +321,11 @@ def get_server_cache(config, cache_manager) -> Cache:
     return server_cache
 
 
-
-
 logger = AugurLogger("server").get_logger()
-db_session = DatabaseSession(logger)
+url = get_database_string()
+engine = create_engine(url, poolclass=StaticPool)
+db_session = DatabaseSession(logger, engine)
 augur_config = AugurConfig(logger, db_session)
-engine = db_session.engine
 
 template_dir = str(Path(__file__).parent.parent / "templates")
 static_dir = str(Path(__file__).parent.parent / "static")

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -162,8 +162,9 @@ def init_worker(**kwargs):
     global engine
 
     from augur.application.db.engine import DatabaseEngine
+    from sqlalchemy.pool import NullPool, StaticPool
 
-    engine = DatabaseEngine(pool_size=5, max_overflow=10).engine
+    engine = DatabaseEngine(poolclass=StaticPool).engine
 
 
 @worker_process_shutdown.connect


### PR DESCRIPTION
**Description**
- Changed workers from using a QueuePool for connections to a StaticPool. The QueuePool contained multiple connections, but this was no longer needed since each process now has its own pool. Therefore I switched each process to use a StaticPool so that each process only has one connection. Now running Augur with default configuration should use about 60 connections. There are still improvements to be made, but I decided to open a pr now since this is a solid improvement

**Signed commits**
- [X] Yes, I signed my commits.
