### PR TITLE
Github Message Task Optimization

### DIFF
--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -141,19 +141,10 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
 
             issue_message_ref_data = extract_needed_issue_message_ref_data(message, issue_id, repo_id, tool_source, tool_version, data_source)
 
-            logger.info(f"MSG ID: {message['id']}. Type: {type(message['id'])}")
             message_ref_mapping_data[message["id"]] = {
                 "msg_ref_data": issue_message_ref_data,
                 "is_issue": True
             }
-
-            # message_ref_mapping_data.append(
-            #     {
-            #         "platform_msg_id": message["id"],
-            #         "msg_ref_data": issue_message_ref_data,
-            #         "is_issue": True
-            #     }
-            # )
 
         else:
 
@@ -169,20 +160,11 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
             pr_message_ref_data = extract_needed_pr_message_ref_data(message, pull_request_id, repo_id, tool_source, tool_version, data_source)
 
 
-            logger.info(f"MSG ID: {message['id']}. Type: {type(message['id'])}")
             message_ref_mapping_data[message["id"]] = {
                 "msg_ref_data": pr_message_ref_data,
                 "is_issue": False
             }
 
-            # message_ref_mapping_data.append(
-            #     {
-            #         "platform_msg_id": message["id"],
-            #         "msg_ref_data": pr_message_ref_data,
-            #         "is_issue": False
-            #     }
-            # )
-        
         if related_pr_or_issue_found:
 
             message_dicts.append(
@@ -203,6 +185,7 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
     message_return_data = augur_db.insert_data(message_dicts, Message, message_natural_keys, 
                                                 return_columns=message_return_columns, string_fields=message_string_fields)
     
+    
     pr_message_ref_dicts = []
     issue_message_ref_dicts = []
     for data in message_return_data:
@@ -218,31 +201,6 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
             issue_message_ref_dicts.append(message_ref_data)
         else:
             pr_message_ref_dicts.append(message_ref_data)
-
-
-    # pr_message_ref_dicts = []
-    # issue_message_ref_dicts = []
-    # for mapping_data in message_ref_mapping_data:
-
-    #     value = mapping_data["platform_msg_id"]
-    #     key = "platform_msg_id"
-
-    #     issue_or_pr_message = find_dict_in_list_of_dicts(message_return_data, key, value)
-
-    #     if issue_or_pr_message:
-
-    #         msg_id = issue_or_pr_message["msg_id"]
-    #     else:
-    #         logger.info(f"{task_name}: Count not find issue or pull request message to map to")
-    #         continue
-
-    #     message_ref_data = mapping_data["msg_ref_data"]
-    #     message_ref_data["msg_id"] = msg_id 
-
-    #     if mapping_data["is_issue"] is True:
-    #         issue_message_ref_dicts.append(message_ref_data)
-    #     else:
-    #         pr_message_ref_dicts.append(message_ref_data)
 
     logger.info(f"{task_name}: Inserting {len(pr_message_ref_dicts)} pr messages ref rows")
     pr_message_ref_natural_keys = ["pull_request_id", "pr_message_ref_src_comment_id"]

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -26,27 +26,24 @@ def collect_github_messages(repo_git: str) -> None:
     with GithubTaskManifest(logger) as manifest:
 
         augur_db = manifest.augur_db
+            
+        repo_id = augur_db.session.query(Repo).filter(
+            Repo.repo_git == repo_git).one().repo_id
+
+        owner, repo = get_owner_repo(repo_git)
+        task_name = f"{owner}/{repo}: Message Task"
+        message_data = retrieve_all_pr_and_issue_messages(repo_git, logger, manifest.key_auth, task_name)
         
-        try:
-            
-            repo_id = augur_db.session.query(Repo).filter(
-                Repo.repo_git == repo_git).one().repo_id
+        if message_data:
+        
+            process_messages(message_data, task_name, repo_id, logger, augur_db)
 
-            owner, repo = get_owner_repo(repo_git)
-            message_data = retrieve_all_pr_and_issue_messages(repo_git, logger, manifest.key_auth)
-
-            if message_data:
-            
-                process_messages(message_data, f"{owner}/{repo}: Message task", repo_id, logger, augur_db)
-
-            else:
-                logger.info(f"{owner}/{repo} has no messages")
-        except Exception as e:
-            logger.error(f"Could not collect github messages for {repo_git}\n Reason: {e} \n Traceback: {''.join(traceback.format_exception(None, e, e.__traceback__))}")
+        else:
+            logger.info(f"{owner}/{repo} has no messages")
 
 
 
-def retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth) -> None:
+def retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth, task_name) -> None:
 
     owner, repo = get_owner_repo(repo_git)
 
@@ -74,10 +71,10 @@ def retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth) -> None:
         elif len(page_data) == 0:
             logger.debug(f"{repo.capitalize()} Messages Page {page} contains no data...returning")
             logger.info(
-                f"{owner}/{repo}: Github Messages Page {page} of {num_pages}")
+                f"{task_name}: Page {page} of {num_pages}")
             return all_data
 
-        logger.info(f"{owner}/{repo}: Github Messages Page {page} of {num_pages}")
+        logger.info(f"{task_name}: Page {page} of {num_pages}")
 
         all_data += page_data
         
@@ -92,7 +89,7 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
     data_source = "Github API"
 
     message_dicts = []
-    message_ref_mapping_data = []
+    message_ref_mapping_data = {}
     contributors = []
 
     if messages is None:
@@ -102,9 +99,29 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
     if len(messages) == 0:
         logger.info(f"{task_name}: No messages to process")
 
-    for message in messages:
+    # create mapping from issue url to issue id of current issues
+    issue_url_to_id_map = {}
+    issues = augur_db.session.query(Issue).filter(Issue.repo_id == repo_id).all()
+    for issue in issues:
+        issue_url_to_id_map[issue.issue_url] = issue.issue_id
 
-        related_pr_of_issue_found = False
+    # create mapping from pr url to pr id of current pull requests
+    pr_issue_url_to_id_map = {}
+    prs = augur_db.session.query(PullRequest).filter(PullRequest.repo_id == repo_id).all()
+    for pr in prs:
+        pr_issue_url_to_id_map[pr.pr_issue_url] = pr.pull_request_id
+
+
+    message_len = len(messages)
+    for index, message in enumerate(messages):
+
+        if index % 1000 == 0:
+            if message_len > 1000:
+                logger.info(f"{task_name}: Processing 1000 messages")
+            else:
+                logger.info(f"{task_name}: Processing {message_len-index} messages")
+
+        related_pr_or_issue_found = False
 
         # this adds the cntrb_id to the message data
         # the returned contributor will be added to the contributors list later, if the related issue or pr are found
@@ -114,55 +131,59 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
         if is_issue_message(message["html_url"]):
 
             try:
-                query = augur_db.session.query(Issue).filter(Issue.issue_url == message["issue_url"])
-                related_issue = execute_session_query(query, 'one')
-                related_pr_of_issue_found = True
-
-            except s.orm.exc.NoResultFound:
+                issue_id = issue_url_to_id_map[message["issue_url"]]
+                related_pr_or_issue_found = True
+            except KeyError:
                 logger.info(f"{task_name}: Could not find related pr")
-                logger.info(
-                    f"{task_name}: We were searching for: {message['id']}")
+                logger.info(f"{task_name}: We were searching for: {message['id']}")
                 logger.info(f"{task_name}: Skipping")
                 continue
 
-            issue_id = related_issue.issue_id
-
             issue_message_ref_data = extract_needed_issue_message_ref_data(message, issue_id, repo_id, tool_source, tool_version, data_source)
 
-            message_ref_mapping_data.append(
-                {
-                    "platform_msg_id": message["id"],
-                    "msg_ref_data": issue_message_ref_data,
-                    "is_issue": True
-                }
-            )
+            logger.info(f"MSG ID: {message['id']}. Type: {type(message['id'])}")
+            message_ref_mapping_data[message["id"]] = {
+                "msg_ref_data": issue_message_ref_data,
+                "is_issue": True
+            }
+
+            # message_ref_mapping_data.append(
+            #     {
+            #         "platform_msg_id": message["id"],
+            #         "msg_ref_data": issue_message_ref_data,
+            #         "is_issue": True
+            #     }
+            # )
 
         else:
 
             try:
-                query = augur_db.session.query(PullRequest).filter(PullRequest.pr_issue_url == message["issue_url"])
-                related_pr = execute_session_query(query, 'one')
-                related_pr_of_issue_found = True
-
-            except s.orm.exc.NoResultFound:
+                pull_request_id = pr_issue_url_to_id_map[message["issue_url"]]
+                related_pr_or_issue_found = True
+            except KeyError:
                 logger.info(f"{task_name}: Could not find related pr")
-                logger.info(f"We were searching for: {message['issue_url']}")
+                logger.info(f"{task_name}: We were searching for: {message['issue_url']}")
                 logger.info(f"{task_name}: Skipping")
                 continue
 
-            pull_request_id = related_pr.pull_request_id
-
             pr_message_ref_data = extract_needed_pr_message_ref_data(message, pull_request_id, repo_id, tool_source, tool_version, data_source)
 
-            message_ref_mapping_data.append(
-                {
-                    "platform_msg_id": message["id"],
-                    "msg_ref_data": pr_message_ref_data,
-                    "is_issue": False
-                }
-            )
+
+            logger.info(f"MSG ID: {message['id']}. Type: {type(message['id'])}")
+            message_ref_mapping_data[message["id"]] = {
+                "msg_ref_data": pr_message_ref_data,
+                "is_issue": False
+            }
+
+            # message_ref_mapping_data.append(
+            #     {
+            #         "platform_msg_id": message["id"],
+            #         "msg_ref_data": pr_message_ref_data,
+            #         "is_issue": False
+            #     }
+            # )
         
-        if related_pr_of_issue_found:
+        if related_pr_or_issue_found:
 
             message_dicts.append(
                             extract_needed_message_data(message, platform_id, repo_id, tool_source, tool_version, data_source)
@@ -173,7 +194,6 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
     contributors = remove_duplicate_dicts(contributors)
 
     logger.info(f"{task_name}: Inserting {len(contributors)} contributors")
-
     augur_db.insert_data(contributors, Contributor, ["cntrb_id"])
 
     logger.info(f"{task_name}: Inserting {len(message_dicts)} messages")
@@ -182,34 +202,53 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
     message_string_fields = ["msg_text"]
     message_return_data = augur_db.insert_data(message_dicts, Message, message_natural_keys, 
                                                 return_columns=message_return_columns, string_fields=message_string_fields)
-
+    
     pr_message_ref_dicts = []
     issue_message_ref_dicts = []
-    for mapping_data in message_ref_mapping_data:
+    for data in message_return_data:
 
-        value = mapping_data["platform_msg_id"]
-        key = "platform_msg_id"
+        augur_msg_id = data["msg_id"]
+        platform_message_id = data["platform_msg_id"]
 
-        issue_or_pr_message = find_dict_in_list_of_dicts(message_return_data, key, value)
+        ref = message_ref_mapping_data[platform_message_id]
+        message_ref_data = ref["msg_ref_data"]
+        message_ref_data = ref["msg_id"] = augur_msg_id
 
-        if issue_or_pr_message:
-
-            msg_id = issue_or_pr_message["msg_id"]
-        else:
-            print("Count not find issue or pull request message to map to")
-            continue
-
-        message_ref_data = mapping_data["msg_ref_data"]
-        message_ref_data["msg_id"] = msg_id 
-
-        if mapping_data["is_issue"] is True:
+        if ref["is_issue"] is True:
             issue_message_ref_dicts.append(message_ref_data)
         else:
             pr_message_ref_dicts.append(message_ref_data)
 
+
+    # pr_message_ref_dicts = []
+    # issue_message_ref_dicts = []
+    # for mapping_data in message_ref_mapping_data:
+
+    #     value = mapping_data["platform_msg_id"]
+    #     key = "platform_msg_id"
+
+    #     issue_or_pr_message = find_dict_in_list_of_dicts(message_return_data, key, value)
+
+    #     if issue_or_pr_message:
+
+    #         msg_id = issue_or_pr_message["msg_id"]
+    #     else:
+    #         logger.info(f"{task_name}: Count not find issue or pull request message to map to")
+    #         continue
+
+    #     message_ref_data = mapping_data["msg_ref_data"]
+    #     message_ref_data["msg_id"] = msg_id 
+
+    #     if mapping_data["is_issue"] is True:
+    #         issue_message_ref_dicts.append(message_ref_data)
+    #     else:
+    #         pr_message_ref_dicts.append(message_ref_data)
+
+    logger.info(f"{task_name}: Inserting {len(pr_message_ref_dicts)} pr messages ref rows")
     pr_message_ref_natural_keys = ["pull_request_id", "pr_message_ref_src_comment_id"]
     augur_db.insert_data(pr_message_ref_dicts, PullRequestMessageRef, pr_message_ref_natural_keys)
 
+    logger.info(f"{task_name}: Inserting {len(pr_message_ref_dicts)} issue messages ref rows")
     issue_message_ref_natural_keys = ["issue_id", "issue_msg_ref_src_comment_id"]
     augur_db.insert_data(issue_message_ref_dicts, IssueMessageRef, issue_message_ref_natural_keys)
 

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -185,7 +185,7 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
     message_return_data = augur_db.insert_data(message_dicts, Message, message_natural_keys, 
                                                 return_columns=message_return_columns, string_fields=message_string_fields)
     
-    
+
     pr_message_ref_dicts = []
     issue_message_ref_dicts = []
     for data in message_return_data:
@@ -206,7 +206,7 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
     pr_message_ref_natural_keys = ["pull_request_id", "pr_message_ref_src_comment_id"]
     augur_db.insert_data(pr_message_ref_dicts, PullRequestMessageRef, pr_message_ref_natural_keys)
 
-    logger.info(f"{task_name}: Inserting {len(pr_message_ref_dicts)} issue messages ref rows")
+    logger.info(f"{task_name}: Inserting {len(issue_message_ref_dicts)} issue messages ref rows")
     issue_message_ref_natural_keys = ["issue_id", "issue_msg_ref_src_comment_id"]
     augur_db.insert_data(issue_message_ref_dicts, IssueMessageRef, issue_message_ref_natural_keys)
 


### PR DESCRIPTION
**Description**
- Optimize gh messages collection
- It not makes 1 query to the db when processing the messages rather than 1 query per message
- It also stores the mapping data as a dictionary instead of a list so the pull_request_id or issue_id can be determined in O(1) rather than O(n) time 
- Added more logs when processing the messages

Results: Tested on a repo with 300 pages of messages and the new changes completed messages collection in 341 seconds while dev finished in 520 seconds.

**Signed commits**
- [X] Yes, I signed my commits.
