### PR TITLE
Pr commits and files optimization

### DIFF
--- a/augur/tasks/github/util/gh_graphql_entities.py
+++ b/augur/tasks/github/util/gh_graphql_entities.py
@@ -45,7 +45,7 @@ def hit_api_graphql(keyAuth,url,logger,query,variables={},timeout=40):
             
             #print(json.dumps(json_dict))
             response = client.post(
-                url=url,auth=keyAuth,json=json_dict
+                url=url,auth=keyAuth,json=json_dict, timeout=timeout
                 )
         
         except TimeoutError:


### PR DESCRIPTION
**Description**
- Pr commits was doing a upsert on a per pr basis, now it does 1 bulk upsert for the whole repo. This sped up Augur collection by around 15 seconds which isn't much, but the goal of this change was to reduce the number of database transactions
- Pr files ran into a read timeout exception 16 times during Augur's collection, which added 160 seconds to the 800 second task. I thought this was a bit strange so I looked into it and found that the timeout value of 40 seconds was not being passed to the request so the default timeout of 5 seconds was being used. After changing this there were no more timeouts, which saved 160 seconds on Augur's pr file collection. 

**Signed commits**
- [X] Yes, I signed my commits.