### PR TITLE
Fixed bugs in messages and pr review comments

### DIFF
--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -215,7 +215,7 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
 
 def is_issue_message(html_url):
 
-    return 'pull' not in html_url
+    return '/pull/' not in html_url
 
 
 def process_github_comment_contributors(message, tool_source, tool_version, data_source):

--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -177,7 +177,7 @@ def process_pull_request_review_contributor(pr_review: dict, tool_source: str, t
 
     # get contributor data and set pr cntrb_id
     user = pr_review["user"]
-    if user["id"] is None:
+    if user is None:
         return None
     
     pr_review_cntrb = extract_needed_contributor_data(user, tool_source, tool_version, data_source)


### PR DESCRIPTION
This PR fixes #
- Bug in github messages when the word `pull` in org or repo name
- Pr review comments was trying to process pr review comments that did not contain a pr review id. It didn't produce errors, but they shouldn't be processed at all


**Signed commits**
- [X] Yes, I signed my commits.
