### PR TITLE
Fixes to adding repos from CLI

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -968,17 +968,16 @@ class Repo(Base):
 
         if not RepoGroup.is_valid_repo_group_id(session, repo_group_id):
             return None
-
-        result = re.search(r"https:\/\/(github\.com\/[A-Za-z0-9 \- _]+\/)([A-Za-z0-9 \- _ .]+)$", url)
-        if not result:
+        
+        owner, repo = Repo.parse_github_repo_url(url)
+        if not owner or not repo:
             return None
 
-        split_repo_git = result.groups()        
         repo_data = {
             "repo_group_id": repo_group_id,
             "repo_git": url,
-            "repo_path": split_repo_git[0],
-            "repo_name": split_repo_git[1],
+            "repo_path": f"github.com/{owner}/",
+            "repo_name": repo,
             "tool_source": tool_source,
             "tool_version": "1.0",
             "data_source": "Git"
@@ -990,15 +989,6 @@ class Repo(Base):
 
         if not result:
             return None
-
-        if repo_group_id != DEFAULT_REPO_GROUP_ID:
-            # update the repo group id
-            query = session.query(Repo).filter(Repo.repo_git == url)
-            repo = execute_session_query(query, 'one')
-
-            if not repo.repo_group_id == repo_group_id:
-                repo.repo_group_id = repo_group_id
-                session.commit()
 
         return result[0]["repo_id"]
 

--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -30,7 +30,7 @@ def parse_repo_url(url: str) -> tuple:
         Tuple of owner and repo. Or a tuple of None and None if the url is invalid.
     """
 
-    if url.endswith(".github") or url.endswith(".github.io") or url.endswith(".js"):
+    if url.endswith(".github") or url.endswith(".io") or url.endswith(".js"):
 
         result = re.search(r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$", url)
     else:


### PR DESCRIPTION
**Description**
- Repo Group ID is no longer updated when adding a repo already exists
- Add support for repos that end with `.io`
- Change Repo.insert() method to use `parse_github_repo_url` to get the repo_path and name

**Signed commits**
- [X] Yes, I signed my commits.