### PR TITLE
Define function to get absolute repo path

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -26,6 +26,7 @@ import sqlalchemy as s
 
 
 from augur.tasks.git.util.facade_worker.facade_worker.facade02utilitymethods import update_repo_log, trim_commit, store_working_author, trim_author
+from augur.tasks.git.util.facade_worker.facade_worker.facade02utilitymethods import get_absolute_repo_path
 from augur.tasks.git.util.facade_worker.facade_worker.facade03analyzecommit import analyze_commit
 from augur.tasks.github.facade_github.tasks import *
 
@@ -167,7 +168,8 @@ def trim_commits_post_analysis_facade_task(repo_id):
         repo = execute_session_query(query, 'one')
 
         #Get the huge list of commits to process.
-        repo_loc = (f"{session.repo_base_directory}{repo.repo_group_id}/{repo.repo_path}{repo.repo_name}/.git")
+        absoulte_path = get_absolute_repo_path(session.repo_base_directory, repo.repo_group_id, repo.repo_path, repo.repo_name)
+        repo_loc = (f"{absoulte_path}/.git")
         # Grab the parents of HEAD
 
         parents = subprocess.Popen(["git --git-dir %s log --ignore-missing "
@@ -260,7 +262,8 @@ def analyze_commits_in_parallel(repo_id, multithreaded: bool)-> None:
         repo = execute_session_query(query, 'one')
 
         #Get the huge list of commits to process.
-        repo_loc = (f"{session.repo_base_directory}{repo.repo_group_id}/{repo.repo_path}{repo.repo_name}/.git")
+        absoulte_path = get_absolute_repo_path(session.repo_base_directory, repo.repo_group_id, repo.repo_path, repo.repo_name)
+        repo_loc = (f"{absoulte_path}/.git")
         # Grab the parents of HEAD
 
         parents = subprocess.Popen(["git --git-dir %s log --ignore-missing "
@@ -323,10 +326,10 @@ def analyze_commits_in_parallel(repo_id, multithreaded: bool)-> None:
             repo = execute_session_query(query,'one')
 
         logger.info(f"Got to analysis!")
+        absoulte_path = get_absolute_repo_path(session.repo_base_directory, repo.repo_group_id, repo.repo_path, repo.repo_name)
+        repo_loc = (f"{absoulte_path}/.git")
         
         for count, commitTuple in enumerate(queue):
-
-            repo_loc = (f"{session.repo_base_directory}{repo.repo_group_id}/{repo.repo_path}{repo.repo_name}/.git")    
 
             analyze_commit(session, repo_id, repo_loc, commitTuple)
 

--- a/augur/tasks/git/util/facade_worker/facade_worker/facade02utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/facade02utilitymethods.py
@@ -110,3 +110,7 @@ def trim_author(session, email):
 
 	session.log_activity('Debug',f"Trimmed working author: {email}")
 
+def get_absolute_repo_path(repo_base_dir, repo_group_id, repo_path, repo_name):
+	
+	return f"{repo_base_dir}{repo_group_id}/{repo_path}{repo_name}"
+

--- a/augur/tasks/git/util/facade_worker/facade_worker/facade04postanalysiscleanup.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/facade04postanalysiscleanup.py
@@ -38,6 +38,7 @@ import xlsxwriter
 import configparser
 import sqlalchemy as s
 from augur.application.db.util import execute_session_query
+from augur.tasks.git.util.facade_worker.facade_worker.facade02utilitymethods import get_absolute_repo_path
 from augur.application.db.models import *
 
 #Will delete repos passed and cleanup associated commit data.
@@ -59,8 +60,10 @@ def git_repo_cleanup(session,repo_git):
 
 		# Remove the files on disk
 
-		cmd = ("rm -rf %s%s/%s%s"
-			% (session.repo_base_directory,row.repo_group_id,row.repo_path,row.repo_name))
+		absolute_path = get_absolute_repo_path(session.repo_base_directory, row.repo_group_id, row.repo_path, row.repo_name)
+
+		cmd = ("rm -rf %s"
+			% (absolute_path))
 
 		return_code = subprocess.Popen([cmd],shell=True).wait()
 


### PR DESCRIPTION
**Description**
- Defined a function called `get_absolute_repo_path` that takes the repo base dir, repo_group_id, repo_path, and repo_name and returns the absolute repo path
- This reduces the chance of defining the repo path wrong throughout the code, since everywhere should use this function to get the path

**Signed commits**
- [X] Yes, I signed my commits.
