### PR TITLE
Changes working towards quantifying repos by their metrics to not overwhelm collection

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -221,7 +221,7 @@ def clean_collection_status(session):
         WHERE facade_status LIKE '%Collecting%';
         UPDATE augur_operations.collection_status
         SET facade_status='Pending'
-        WHERE facade_status='Failed Clone';
+        WHERE facade_status='Failed Clone' OR facade_status='Initializing';
     """))
     #TODO: write timestamp for currently running repos.
 
@@ -261,7 +261,7 @@ def repo_reset(augur_app):
         WHERE facade_status='Collecting' OR facade_status='Success' OR facade_status='Error';
         UPDATE augur_operations.collection_status
         SET facade_status='Pending'
-        WHERE facade_status='Failed Clone';
+        WHERE facade_status='Failed Clone' OR facade_status='Initializing';
         TRUNCATE augur_data.commits CASCADE;
         """))
 

--- a/augur/tasks/git/dependency_tasks/core.py
+++ b/augur/tasks/git/dependency_tasks/core.py
@@ -26,7 +26,7 @@ def generate_deps_data(session, repo_id, path):
 
         
 
-        deps = dep_calc.get_deps(path)
+        deps = dep_calc.get_deps(path,session.logger)
         
         for dep in deps:
             repo_deps = {

--- a/augur/tasks/git/util/facade_worker/facade_worker/facade05repofetch.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/facade05repofetch.py
@@ -137,12 +137,6 @@ def git_repo_initialize(session, repo_git):
 
         session.execute_sql(query)
 
-        query = s.sql.text("""UPDATE augur_operations.collection_status
-            SET facade_status='Collecting (Initializing)'
-            WHERE repo_id=:idParam""").bindparams(idParam=row.repo_id)
-
-        session.execute_sql(query)
-
         session.log_activity('Verbose',f"Cloning: {git}")
 
         cmd = f"git -C {repo_path} clone '{git}' {repo_name}"
@@ -152,12 +146,6 @@ def git_repo_initialize(session, repo_git):
             # If cloning succeeded, repo is ready for analysis
             # Mark the entire project for an update, so that under normal
             # circumstances caches are rebuilt only once per waiting period.
-
-            update_project_status = s.sql.text("""UPDATE augur_operations.collection_status
-                SET facade_status='Update' WHERE 
-                repo_id=:repo_id""").bindparams(repo_id=row.repo_id)
-            session.execute_sql(update_project_status)
-
             update_repo_log(session, row.repo_id,'Up-to-date')
             session.log_activity('Info',f"Cloned {git}")
 

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -56,7 +56,7 @@ def process_commit_metadata(session,contributorQueue,repo_id):
         contributors_with_matching_name = execute_session_query(query, 'first')
 
         if not contributors_with_matching_name:
-            session.logger.debug(f"Failed local login lookup with error: {e}")
+            session.logger.debug("Failed local login lookup")
         else:
             login = contributors_with_matching_name.gh_login
         

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -51,14 +51,14 @@ def process_commit_metadata(session,contributorQueue,repo_id):
         login = None
     
         #Check the contributors table for a login for the given name
-        try:
-            query = session.query(Contributor).filter_by(cntrb_full_name=name)
-            contributors_with_matching_name = execute_session_query(query, 'first')
 
-            login = contributors_with_matching_name.gh_login
+        query = session.query(Contributor).filter_by(cntrb_full_name=name)
+        contributors_with_matching_name = execute_session_query(query, 'first')
 
-        except NoResultFound as e:
+        if not contributors_with_matching_name:
             session.logger.debug(f"Failed local login lookup with error: {e}")
+        else:
+            login = contributors_with_matching_name.gh_login
         
 
         # Try to get the login from the commit sha

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -53,7 +53,7 @@ def process_commit_metadata(session,contributorQueue,repo_id):
         #Check the contributors table for a login for the given name
         try:
             query = session.query(Contributor).filter_by(cntrb_full_name=name)
-            contributors_with_matching_name = execute_session_query(query, 'one')
+            contributors_with_matching_name = execute_session_query(query, 'first')
 
             login = contributors_with_matching_name.gh_login
 

--- a/augur/tasks/github/issues/tasks.py
+++ b/augur/tasks/github/issues/tasks.py
@@ -16,7 +16,7 @@ from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
 from augur.application.config import get_development_flag
 from augur.application.db.util import execute_session_query
-from augur.application.db.session import DatabaseSession
+
 development = get_development_flag()
 
 @celery.task()

--- a/augur/tasks/github/issues/tasks.py
+++ b/augur/tasks/github/issues/tasks.py
@@ -16,6 +16,7 @@ from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
 from augur.application.config import get_development_flag
 from augur.application.db.util import execute_session_query
+from augur.application.db.session import DatabaseSession
 development = get_development_flag()
 
 @celery.task()

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -63,6 +63,7 @@ celery_app = Celery('tasks', broker=BROKER_URL, backend=BACKEND_URL, include=tas
 # define the queues that tasks will be put in (by default tasks are put in celery queue)
 celery_app.conf.task_routes = {
     'augur.tasks.start_tasks.*': {'queue': 'scheduling'},
+    'augur.tasks.util.collection_util.*': {'queue': 'scheduling'},
     'augur.tasks.github.pull_requests.commits_model.tasks.*': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.files_model.tasks.*': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.tasks.collect_pull_request_reviews': {'queue': 'secondary'},

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -20,7 +20,8 @@ from augur.application.db.models import CollectionStatus
 logger = logging.getLogger(__name__)
 
 start_tasks = ['augur.tasks.start_tasks',
-                'augur.tasks.data_analysis']
+                'augur.tasks.data_analysis',
+                'augur.tasks.util.collection_util']
 
 github_tasks = ['augur.tasks.github.contributors.tasks',
                 'augur.tasks.github.issues.tasks',

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -158,10 +158,10 @@ def start_primary_collection(session,max_repo,days):
         primary_enabled_phases.append(primary_repo_collect_phase)
 
     #task success is scheduled no matter what the config says.
-    def core_task_success_gen(repo_git):
-        return core_task_success.si(repo_git)
+    def core_task_success_util_gen(repo_git):
+        return core_task_success_util.si(repo_git)
     
-    primary_enabled_phases.append(core_task_success_gen)
+    primary_enabled_phases.append(core_task_success_util_gen)
     
     active_repo_count = len(session.query(CollectionStatus).filter(CollectionStatus.core_status == CollectionState.COLLECTING.value).all())
 
@@ -210,10 +210,10 @@ def start_secondary_collection(session,max_repo,days):
     if secondary_repo_collect_phase.__name__ in enabled_phase_names:
         secondary_enabled_phases.append(secondary_repo_collect_phase)
 
-    def secondary_task_success_gen(repo_git):
-        return secondary_task_success.si(repo_git)
+    def secondary_task_success_util_gen(repo_git):
+        return secondary_task_success_util.si(repo_git)
 
-    secondary_enabled_phases.append(secondary_task_success_gen)
+    secondary_enabled_phases.append(secondary_task_success_util_gen)
 
     active_repo_count = len(session.query(CollectionStatus).filter(CollectionStatus.secondary_status == CollectionState.COLLECTING.value).all())
 
@@ -252,10 +252,10 @@ def start_facade_clone_update(session,max_repo,days):
 
     facade_enabled_phases.append(facade_clone_update_phase)
 
-    def facade_clone_update_success_gen(repo_git):
-        return facade_clone_update_success.si(repo_git)
+    def facade_clone_update_success_util_gen(repo_git):
+        return facade_clone_update_success_util.si(repo_git)
     
-    facade_enabled_phases.append(facade_clone_update_success_gen)
+    facade_enabled_phases.append(facade_clone_update_success_util_gen)
 
     active_repo_count = len(session.query(CollectionStatus).filter(CollectionStatus.facade_status == CollectionState.INITIALIZING.value).all())
 
@@ -298,10 +298,10 @@ def start_facade_collection(session,max_repo,days):
     
     facade_enabled_phases.append(facade_phase)
 
-    def facade_task_success_gen(repo_git):
-        return facade_task_success.si(repo_git)
+    def facade_task_success_util_gen(repo_git):
+        return facade_task_success_util.si(repo_git)
 
-    facade_enabled_phases.append(facade_task_success_gen)
+    facade_enabled_phases.append(facade_task_success_util_gen)
 
     active_repo_count = len(session.query(CollectionStatus).filter(CollectionStatus.facade_status == CollectionState.COLLECTING.value).all())
 

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -27,7 +27,6 @@ from augur.tasks.git.facade_tasks import *
 from augur.tasks.db.refresh_materialized_views import *
 # from augur.tasks.data_analysis import *
 from augur.tasks.init.celery_app import celery_app as celery
-from augur.application.config import AugurConfig
 from augur.application.db.session import DatabaseSession
 from logging import Logger
 from enum import Enum

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -356,8 +356,8 @@ def augur_collection_monitor():
         start_secondary_collection(session, max_repo=30, days=30)
 
         if facade_phase.__name__ in enabled_phase_names:
-            start_facade_clone_update(session,max_repo=15,days=30)
             start_facade_collection(session, max_repo=30, days=30)
+            start_facade_clone_update(session,max_repo=15,days=30)
 
 
 

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -264,7 +264,7 @@ def start_facade_clone_update(session,max_repo,days):
     not_failed_clone = CollectionStatus.facade_status != str(CollectionState.FAILED_CLONE.value)
     not_collecting = CollectionStatus.facade_status != str(CollectionState.COLLECTING.value)
     not_initializing = CollectionStatus.facade_status != str(CollectionState.INITIALIZING.value)
-    never_collected = CollectionStatus.facade_data_last_collected == None
+    never_collected = CollectionStatus.facade_status == CollectionState.PENDING.value
     old_collection = CollectionStatus.facade_data_last_collected <= cutoff_date
 
     limit = max_repo-active_repo_count

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -27,160 +27,17 @@ from augur.tasks.git.facade_tasks import *
 from augur.tasks.db.refresh_materialized_views import *
 # from augur.tasks.data_analysis import *
 from augur.tasks.init.celery_app import celery_app as celery
-from celery.result import allow_join_result
-from augur.application.logs import AugurLogger
 from augur.application.config import AugurConfig
 from augur.application.db.session import DatabaseSession
-from augur.application.db.util import execute_session_query
 from logging import Logger
 from enum import Enum
 from augur.tasks.util.redis_list import RedisList
 from augur.application.db.models import CollectionStatus, Repo
+from augur.tasks.util.collection_util import *
 
 CELERY_GROUP_TYPE = type(group())
 CELERY_CHAIN_TYPE = type(chain())
 
-
-# class syntax
-class CollectionState(Enum):
-    SUCCESS = "Success"
-    PENDING = "Pending"
-    ERROR = "Error"
-    COLLECTING = "Collecting"
-    UPDATE = "Update"
-    FAILED_CLONE = "Failed Clone"
-
-"""
-@celery.task(bind=True)
-def collection_task_wrapper(self,*args,**kwargs):
-    task = kwargs.pop('task')
-
-    task(*args,**kwargs)
-
-    return self.request.id
-"""
-
-@celery.task
-def core_task_success(repo_git):
-
-    from augur.tasks.init.celery_app import engine
-
-    logger = logging.getLogger(core_task_success.__name__)
-
-    logger.info(f"Repo '{repo_git}' succeeded through core collection")
-
-    with DatabaseSession(logger, engine) as session:
-
-        repo = Repo.get_by_repo_git(session, repo_git)
-        if not repo:
-            raise Exception(f"Task with repo_git of {repo_git} but could not be found in Repo table")
-
-        collection_status = repo.collection_status[0]
-
-        collection_status.core_status = CollectionState.SUCCESS.value
-        collection_status.core_data_last_collected = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        collection_status.core_task_id = None
-
-        session.commit()
-
-@celery.task
-def secondary_task_success(repo_git):
-
-    from augur.tasks.init.celery_app import engine
-
-    logger = logging.getLogger(secondary_task_success.__name__)
-
-    logger.info(f"Repo '{repo_git}' succeeded through secondary collection")
-
-    with DatabaseSession(logger, engine) as session:
-
-        repo = Repo.get_by_repo_git(session, repo_git)
-        if not repo:
-            raise Exception(f"Task with repo_git of {repo_git} but could not be found in Repo table")
-
-        collection_status = repo.collection_status[0]
-
-        collection_status.secondary_status = CollectionState.SUCCESS.value
-        collection_status.secondary_data_last_collected	 = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        collection_status.secondary_task_id = None
-
-        session.commit()
-
-@celery.task
-def facade_task_success(repo_git):
-
-    from augur.tasks.init.celery_app import engine
-
-    logger = logging.getLogger(facade_task_success.__name__)
-
-    logger.info(f"Repo '{repo_git}' succeeded through facade task collection")
-
-    with DatabaseSession(logger, engine) as session:
-
-        repo = Repo.get_by_repo_git(session, repo_git)
-        if not repo:
-            raise Exception(f"Task with repo_git of {repo_git} but could not be found in Repo table")
-
-        collection_status = repo.collection_status[0]
-
-        collection_status.facade_status = CollectionState.SUCCESS.value
-        collection_status.facade_data_last_collected = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        collection_status.facade_task_id = None
-
-        session.commit()
-
-@celery.task
-def task_failed(request,exc,traceback):
-
-    from augur.tasks.init.celery_app import engine
-
-    logger = logging.getLogger(task_failed.__name__)
-
-    # log traceback to error file
-    logger.error(f"Task {request.id} raised exception: {exc}\n{traceback}")
-    
-    with DatabaseSession(logger,engine) as session:
-        core_id_match = CollectionStatus.core_task_id == request.id
-        secondary_id_match = CollectionStatus.secondary_task_id == request.id
-        facade_id_match = CollectionStatus.facade_task_id == request.id
-
-        query = session.query(CollectionStatus).filter(or_(core_id_match,secondary_id_match,facade_id_match))
-
-        print(f"chain: {request.chain}")
-        #Make sure any further execution of tasks dependent on this one stops.
-        try:
-            #Replace the tasks queued ahead of this one in a chain with None.
-            request.chain = None
-        except AttributeError:
-            pass #Task is not part of a chain. Normal so don't log.
-        except Exception as e:
-            logger.error(f"Could not mutate request chain! \n Error: {e}")
-        
-        try:
-            collectionRecord = execute_session_query(query,'one')
-        except:
-            #Exit if we can't find the record.
-            return
-        
-        if collectionRecord.core_task_id == request.id:
-            # set status to Error in db
-            collectionRecord.core_status = CollectionStatus.ERROR.value
-            collectionRecord.core_task_id = None
-        
-
-        if collectionRecord.secondary_task_id == request.id:
-            # set status to Error in db
-            collectionRecord.secondary_status = CollectionStatus.ERROR.value
-            collectionRecord.secondary_task_id = None
-            
-        
-        if collectionRecord.facade_task_id == request.id:
-            collectionRecord.facade_status = CollectionStatus.ERROR.value
-            collectionRecord.facade_task_id = None
-        
-        session.commit()
-    
-    
 
 
 #Predefine phases. For new phases edit this and the config to reflect.
@@ -243,81 +100,6 @@ def secondary_repo_collect_phase(repo_git):
     return repo_task_group
 
 
-class AugurTaskRoutine:
-    """class to keep track of various groups of collection tasks as well as how they relate to one another.
-    Accessible like a dict, each dict item represents a 'phase' of augur collection executed more or less in parallel.
-
-    Attributes:
-        logger (Logger): Get logger from AugurLogger
-        jobs_dict (dict): Dict of data collection phases to run
-        repos (List[str]): List of repo_ids to run collection on.
-        collection_phases (List[str]): List of phases to run in augur collection.
-        session: Database session to use
-    """
-    def __init__(self,session,repos: List[str]=[],collection_phases: List[str]=[]):
-        self.logger = AugurLogger("data_collection_jobs").get_logger()
-        #self.session = TaskSession(self.logger)
-        self.jobs_dict = {}
-        self.collection_phases = collection_phases
-        #self.disabled_collection_tasks = disabled_collection_tasks
-        self.repos = repos
-        self.session = session
-
-        #Assemble default phases
-        #These will then be able to be overridden through the config.
-        for phase in collection_phases:
-            self.jobs_dict[phase.__name__] = phase
-
-    #Get and set dict values that correspond to phases of collection
-    def __getitem__(self,key: str) -> dict:
-        """Return the collection group with the specified key.
-        """
-        return self.jobs_dict[key]
-    
-    def __setitem__(self,key: str,newJobs):
-        """Create a new collection job group with the name of the key specified.
-        """
-        self.collection_phases.append(newJobs)
-        self.jobs_dict[key] = newJobs
-
-    def start_data_collection(self):
-        """Start all task items and return.
-        """
-        augur_collection_list = []
-        
-        for repo_git in self.repos:
-
-            repo = self.session.query(Repo).filter(Repo.repo_git == repo_git).one()
-            repo_id = repo.repo_id
-
-            augur_collection_sequence = []
-            for phaseName, job in self.jobs_dict.items():
-                self.logger.info(f"Queuing phase {phaseName} for repo {repo_git}")
-                
-                #Add the phase to the sequence in order as a celery task.
-                #The preliminary task creates the larger task chain 
-                augur_collection_sequence.append(job(repo_git))
-
-            #augur_collection_sequence.append(core_task_success.si(repo_git))
-            #Link all phases in a chain and send to celery
-            augur_collection_chain = chain(*augur_collection_sequence)
-            task_id = augur_collection_chain.apply_async(link_error=task_failed.s()).task_id
-
-            self.logger.info(f"Setting repo_id {repo_id} to collecting for repo: {repo_git}")
-
-            #yield the value of the task_id to the calling method so that the proper collectionStatus field can be updated
-            yield repo_git, task_id
-
-def get_enabled_phase_names_from_config(logger, session):
-
-    config = AugurConfig(logger, session)
-    phase_options = config.get_section("Task_Routine")
-
-    #Get list of enabled phases 
-    enabled_phase_names = [name for name, phase in phase_options.items() if phase == 1]
-
-    return enabled_phase_names
-
 
 
 @celery.task
@@ -344,16 +126,6 @@ def non_repo_domain_tasks():
 
         session.execute_sql(query)
 
-        #Disable augur from running these tasks more than once unless requested
-        query = s.sql.text("""
-            UPDATE augur_operations.config
-            SET value=0
-            WHERE section_name='Task_Routine'
-            AND setting_name='machine_learning_phase'
-        """)
-
-        session.execute_sql(query)
-
     enabled_tasks = []
 
     enabled_tasks.extend(generate_non_repo_domain_facade_tasks(logger))
@@ -369,12 +141,6 @@ def non_repo_domain_tasks():
     tasks.apply_async()
 
 
-#Query db for CollectionStatus records that fit the desired condition.
-#Used to get CollectionStatus for differant collection hooks
-def get_collection_status_repo_git_from_filter(session,filter_condition,limit):
-    repo_status_list = session.query(CollectionStatus).filter(filter_condition).limit(limit).all()
-
-    return [status.repo.repo_git for status in repo_status_list]
 
 
 def start_primary_collection(session,max_repo,days):

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -15,6 +15,7 @@ from augur.application.logs import AugurLogger
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.models import CollectionStatus, Repo
 from augur.application.db.util import execute_session_query
+from augur.application.config import AugurConfig
 
 
 # class syntax

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -53,11 +53,11 @@ def get_collection_status_repo_git_from_filter(session,filter_condition,limit):
 
 
 @celery.task
-def task_failed(request,exc,traceback):
+def task_failed_util(request,exc,traceback):
 
     from augur.tasks.init.celery_app import engine
 
-    logger = logging.getLogger(task_failed.__name__)
+    logger = logging.getLogger(task_failed_util.__name__)
 
     # log traceback to error file
     logger.error(f"Task {request.id} raised exception: {exc}\n{traceback}")
@@ -108,11 +108,11 @@ def task_failed(request,exc,traceback):
     
     
 @celery.task
-def core_task_success(repo_git):
+def core_task_success_util(repo_git):
 
     from augur.tasks.init.celery_app import engine
 
-    logger = logging.getLogger(core_task_success.__name__)
+    logger = logging.getLogger(core_task_success_util.__name__)
 
     logger.info(f"Repo '{repo_git}' succeeded through core collection")
 
@@ -131,11 +131,11 @@ def core_task_success(repo_git):
         session.commit()
 
 @celery.task
-def secondary_task_success(repo_git):
+def secondary_task_success_util(repo_git):
 
     from augur.tasks.init.celery_app import engine
 
-    logger = logging.getLogger(secondary_task_success.__name__)
+    logger = logging.getLogger(secondary_task_success_util.__name__)
 
     logger.info(f"Repo '{repo_git}' succeeded through secondary collection")
 
@@ -171,11 +171,11 @@ def get_repo_weight_by_issue(logger,repo_git,days_since_last_collection):
 
 
 @celery.task
-def facade_task_success(repo_git):
+def facade_task_success_util(repo_git):
 
     from augur.tasks.init.celery_app import engine
 
-    logger = logging.getLogger(facade_task_success.__name__)
+    logger = logging.getLogger(facade_task_success_util.__name__)
 
     logger.info(f"Repo '{repo_git}' succeeded through facade task collection")
 
@@ -194,11 +194,11 @@ def facade_task_success(repo_git):
         session.commit()
 
 @celery.task
-def facade_clone_update_success(repo_git):
+def facade_clone_update_success_util(repo_git):
 
     from augur.tasks.init.celery_app import engine
 
-    logger = logging.getLogger(facade_clone_update_success.__name__)
+    logger = logging.getLogger(facade_clone_update_success_util.__name__)
 
     logger.info(f"Repo '{repo_git}' succeeded through facade update/clone")
 
@@ -274,10 +274,10 @@ class AugurTaskRoutine:
                 #The preliminary task creates the larger task chain 
                 augur_collection_sequence.append(job(repo_git))
 
-            #augur_collection_sequence.append(core_task_success.si(repo_git))
+            #augur_collection_sequence.append(core_task_success_util.si(repo_git))
             #Link all phases in a chain and send to celery
             augur_collection_chain = chain(*augur_collection_sequence)
-            task_id = augur_collection_chain.apply_async(link_error=task_failed.s()).task_id
+            task_id = augur_collection_chain.apply_async(link_error=task_failed_util.s()).task_id
 
             self.logger.info(f"Setting repo_id {repo_id} to collecting for repo: {repo_git}")
 

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -99,7 +99,7 @@ def task_failed_util(request,exc,traceback):
         
         if collectionRecord.facade_task_id == request.id:
             #Failed clone is differant than an error in collection.
-            if collectionRecord.facade_status != CollectionStatus.FAILED_CLONE.value:
+            if collectionRecord.facade_status != CollectionStatus.FAILED_CLONE.value or collectionRecord.facade_status != CollectionStatus.UPDATE.value:
                 collectionRecord.facade_status = CollectionStatus.ERROR.value
 
             collectionRecord.facade_task_id = None

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+from typing import List
+import time
+import logging
+import json
+import os
+from enum import Enum
+import math
+import numpy as np
+#from celery.result import AsyncResult
+from celery import signature
+from celery import group, chain, chord, signature
+from sqlalchemy import or_, and_
+from augur.application.logs import AugurLogger
+from augur.tasks.init.celery_app import celery_app as celery
+from augur.application.db.models import CollectionStatus, Repo
+from augur.application.db.util import execute_session_query
+
+
+# class syntax
+class CollectionState(Enum):
+    SUCCESS = "Success"
+    PENDING = "Pending"
+    ERROR = "Error"
+    COLLECTING = "Collecting"
+    UPDATE = "Update"
+    FAILED_CLONE = "Failed Clone"
+
+def get_enabled_phase_names_from_config(logger, session):
+
+    config = AugurConfig(logger, session)
+    phase_options = config.get_section("Task_Routine")
+
+    #Get list of enabled phases 
+    enabled_phase_names = [name for name, phase in phase_options.items() if phase == 1]
+
+    return enabled_phase_names
+
+#Query db for CollectionStatus records that fit the desired condition.
+#Used to get CollectionStatus for differant collection hooks
+def get_collection_status_repo_git_from_filter(session,filter_condition,limit):
+    repo_status_list = session.query(CollectionStatus).filter(filter_condition).limit(limit).all()
+
+    return [status.repo.repo_git for status in repo_status_list]
+
+
+
+@celery.task
+def task_failed(request,exc,traceback):
+
+    from augur.tasks.init.celery_app import engine
+
+    logger = logging.getLogger(task_failed.__name__)
+
+    # log traceback to error file
+    logger.error(f"Task {request.id} raised exception: {exc}\n{traceback}")
+    
+    with DatabaseSession(logger,engine) as session:
+        core_id_match = CollectionStatus.core_task_id == request.id
+        secondary_id_match = CollectionStatus.secondary_task_id == request.id
+        facade_id_match = CollectionStatus.facade_task_id == request.id
+
+        query = session.query(CollectionStatus).filter(or_(core_id_match,secondary_id_match,facade_id_match))
+
+        print(f"chain: {request.chain}")
+        #Make sure any further execution of tasks dependent on this one stops.
+        try:
+            #Replace the tasks queued ahead of this one in a chain with None.
+            request.chain = None
+        except AttributeError:
+            pass #Task is not part of a chain. Normal so don't log.
+        except Exception as e:
+            logger.error(f"Could not mutate request chain! \n Error: {e}")
+        
+        try:
+            collectionRecord = execute_session_query(query,'one')
+        except:
+            #Exit if we can't find the record.
+            return
+        
+        if collectionRecord.core_task_id == request.id:
+            # set status to Error in db
+            collectionRecord.core_status = CollectionStatus.ERROR.value
+            collectionRecord.core_task_id = None
+        
+
+        if collectionRecord.secondary_task_id == request.id:
+            # set status to Error in db
+            collectionRecord.secondary_status = CollectionStatus.ERROR.value
+            collectionRecord.secondary_task_id = None
+            
+        
+        if collectionRecord.facade_task_id == request.id:
+            collectionRecord.facade_status = CollectionStatus.ERROR.value
+            collectionRecord.facade_task_id = None
+        
+        session.commit()
+    
+    
+@celery.task
+def core_task_success(repo_git):
+
+    from augur.tasks.init.celery_app import engine
+
+    logger = logging.getLogger(core_task_success.__name__)
+
+    logger.info(f"Repo '{repo_git}' succeeded through core collection")
+
+    with DatabaseSession(logger, engine) as session:
+
+        repo = Repo.get_by_repo_git(session, repo_git)
+        if not repo:
+            raise Exception(f"Task with repo_git of {repo_git} but could not be found in Repo table")
+
+        collection_status = repo.collection_status[0]
+
+        collection_status.core_status = CollectionState.SUCCESS.value
+        collection_status.core_data_last_collected = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        collection_status.core_task_id = None
+
+        session.commit()
+
+@celery.task
+def secondary_task_success(repo_git):
+
+    from augur.tasks.init.celery_app import engine
+
+    logger = logging.getLogger(secondary_task_success.__name__)
+
+    logger.info(f"Repo '{repo_git}' succeeded through secondary collection")
+
+    with DatabaseSession(logger, engine) as session:
+
+        repo = Repo.get_by_repo_git(session, repo_git)
+        if not repo:
+            raise Exception(f"Task with repo_git of {repo_git} but could not be found in Repo table")
+
+        collection_status = repo.collection_status[0]
+
+        collection_status.secondary_status = CollectionState.SUCCESS.value
+        collection_status.secondary_data_last_collected	 = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        collection_status.secondary_task_id = None
+
+        session.commit()
+
+@celery.task
+def facade_task_success(repo_git):
+
+    from augur.tasks.init.celery_app import engine
+
+    logger = logging.getLogger(facade_task_success.__name__)
+
+    logger.info(f"Repo '{repo_git}' succeeded through facade task collection")
+
+    with DatabaseSession(logger, engine) as session:
+
+        repo = Repo.get_by_repo_git(session, repo_git)
+        if not repo:
+            raise Exception(f"Task with repo_git of {repo_git} but could not be found in Repo table")
+
+        collection_status = repo.collection_status[0]
+
+        collection_status.facade_status = CollectionState.SUCCESS.value
+        collection_status.facade_data_last_collected = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        collection_status.facade_task_id = None
+
+        session.commit()
+
+
+class AugurTaskRoutine:
+    """class to keep track of various groups of collection tasks as well as how they relate to one another.
+    Accessible like a dict, each dict item represents a 'phase' of augur collection executed more or less in parallel.
+
+    Attributes:
+        logger (Logger): Get logger from AugurLogger
+        jobs_dict (dict): Dict of data collection phases to run
+        repos (List[str]): List of repo_ids to run collection on.
+        collection_phases (List[str]): List of phases to run in augur collection.
+        session: Database session to use
+    """
+    def __init__(self,session,repos: List[str]=[],collection_phases: List[str]=[]):
+        self.logger = AugurLogger("data_collection_jobs").get_logger()
+        #self.session = TaskSession(self.logger)
+        self.jobs_dict = {}
+        self.collection_phases = collection_phases
+        #self.disabled_collection_tasks = disabled_collection_tasks
+        self.repos = repos
+        self.session = session
+
+        #Assemble default phases
+        #These will then be able to be overridden through the config.
+        for phase in collection_phases:
+            self.jobs_dict[phase.__name__] = phase
+
+    #Get and set dict values that correspond to phases of collection
+    def __getitem__(self,key: str) -> dict:
+        """Return the collection group with the specified key.
+        """
+        return self.jobs_dict[key]
+    
+    def __setitem__(self,key: str,newJobs):
+        """Create a new collection job group with the name of the key specified.
+        """
+        self.collection_phases.append(newJobs)
+        self.jobs_dict[key] = newJobs
+
+    def start_data_collection(self):
+        """Start all task items and return.
+        """
+        augur_collection_list = []
+        
+        for repo_git in self.repos:
+
+            repo = self.session.query(Repo).filter(Repo.repo_git == repo_git).one()
+            repo_id = repo.repo_id
+
+            augur_collection_sequence = []
+            for phaseName, job in self.jobs_dict.items():
+                self.logger.info(f"Queuing phase {phaseName} for repo {repo_git}")
+                
+                #Add the phase to the sequence in order as a celery task.
+                #The preliminary task creates the larger task chain 
+                augur_collection_sequence.append(job(repo_git))
+
+            #augur_collection_sequence.append(core_task_success.si(repo_git))
+            #Link all phases in a chain and send to celery
+            augur_collection_chain = chain(*augur_collection_sequence)
+            task_id = augur_collection_chain.apply_async(link_error=task_failed.s()).task_id
+
+            self.logger.info(f"Setting repo_id {repo_id} to collecting for repo: {repo_git}")
+
+            #yield the value of the task_id to the calling method so that the proper collectionStatus field can be updated
+            yield repo_git, task_id

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -21,6 +21,7 @@ from augur.tasks.github.util.util import get_owner_repo
 from augur.tasks.github.util.gh_graphql_entities import GitHubRepo as GitHubRepoGraphql
 from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
+from augur.application.db.session import DatabaseSession
 
 # class syntax
 class CollectionState(Enum):

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -152,7 +152,7 @@ def date_weight_factor(days_since_last_collection):
     return (days_since_last_collection ** 3) / 25
 
 
-def get_repo_weight_by_issue(logger,repo_git):
+def get_repo_weight_by_issue(logger,repo_git,days_since_last_collection):
 
 
     owner,name = get_owner_repo(repo_git)
@@ -161,7 +161,7 @@ def get_repo_weight_by_issue(logger,repo_git):
         repo_graphql = GitHubRepoGraphql(logger, manifest.key_auth, owner, name)
         number_of_issues_and_prs = len(repo_graphql.get_issues_collection()) + len(repo_graphql.get_pull_requests_collection())
     
-    return number_of_issues_and_prs
+    return number_of_issues_and_prs - date_weight_factor(days_since_last_collection)
 
 
 
@@ -187,6 +187,9 @@ def facade_task_success(repo_git):
         collection_status.facade_task_id = None
 
         session.commit()
+
+def get_repo_weight_by_commit(logger,repo_git,days_since_last_collection):
+    pass
 
 
 class AugurTaskRoutine:


### PR DESCRIPTION
**Description**
- Work towards being able to schedule a predefined load of collection by repo sizes rather than raw repo amount
- Add functions to see how large a repo is respective of its pull_requests and issues
- Split start_tasks.py into two to make it less overwhelming
- Split facade collection into two hooks. One to clone/update, one to collect data. This is done so that in the future similar metrics to the pr/issue metrics to see how large a repo is respective of its commits
- Fix issues with logic when handling dependency errors
- Add new status for facade when it is cloning and updating called 'Initializing'
- Change celery settings to work with newly split start_tasks.py
- Fix issue with sqlalchemy where 'one' was used instead of 'first'.


**Signed commits**
- [x] Yes, I signed my commits.
