### PR TITLE
Viz fix

### DIFF
--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -9,8 +9,8 @@ from ..server import app, db_session
 @app.route('/cache/file/<path:file>')
 def cache(file=None):
     if file is None:
-        return redirect(url_for('static', path="cache/"))
-    return redirect(url_for('static', path="cache/" + toCacheFilename(file)))
+        return redirect(url_for('static', filename="cache"))
+    return redirect(url_for('static', filename="cache/" + toCacheFilename(file)))
 
 @app.route('/account/repos/add', methods = ['POST'])
 @login_required

--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -10,7 +10,7 @@ from ..server import app, db_session
 def cache(file=None):
     if file is None:
         return redirect(url_for('static', filename="cache"))
-    return redirect(url_for('static', filename="cache/" + toCacheFilename(file)))
+    return redirect(url_for('static', filename="cache/" + toCacheFilename(file, False)))
 
 @app.route('/account/repos/add', methods = ['POST'])
 @login_required

--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -9,8 +9,8 @@ from ..server import app, db_session
 @app.route('/cache/file/<path:file>')
 def cache(file=None):
     if file is None:
-        return redirect(url_for('root', path=getSetting('caching')))
-    return redirect(url_for('root', path=toCacheFilepath(file)))
+        return redirect(url_for('static', path="cache/"))
+    return redirect(url_for('static', path="cache/" + toCacheFilename(file)))
 
 @app.route('/account/repos/add', methods = ['POST'])
 @login_required

--- a/augur/api/view/utils.py
+++ b/augur/api/view/utils.py
@@ -106,7 +106,7 @@ def loadSettings():
     # # Ensure that the cache directory exists and is valid
     # cachePath = Path(settings["caching"])
 
-    cachePath = Path(url_for("static")) / "cache"
+    cachePath = Path.cwd() / "augur" / "static" / "cache"
 
     if not cachePath.is_dir():
         if cachePath.is_file():

--- a/augur/api/view/utils.py
+++ b/augur/api/view/utils.py
@@ -102,9 +102,12 @@ def loadSettings():
     else:
         with open(configFilePath) as file:
             settings = yaml.load(file, Loader=yaml.FullLoader)
+    
+    # # Ensure that the cache directory exists and is valid
+    # cachePath = Path(settings["caching"])
 
-    # Ensure that the cache directory exists and is valid
-    cachePath = Path(settings["caching"])
+    cachePath = Path(url_for("static")) / "cache"
+
     if not cachePath.is_dir():
         if cachePath.is_file():
             raise Exception(f"Cannot initialize caching: cache path [{cachePath}] is a file")
@@ -291,7 +294,7 @@ def download(url, cmanager, filename, image_cache, image_id, repo_id = None):
         image_cache[image_id]['exists'] = True
         try:
             with open(filename, 'wb') as f:
-                logger.info("Writing image: " + filename)
+                logger.info("Writing image: " + str(filename))
                 f.write(response.data)
         except Exception as err:
             logger.error("An exception occurred writing a cache file to disk")

--- a/augur/api/view/utils.py
+++ b/augur/api/view/utils.py
@@ -200,11 +200,11 @@ def stripStatic(url):
 
 """ ----------------------------------------------------------------
 """
-def toCacheFilename(endpoint):
-    return endpoint.replace("/", ".").replace("?", "_").replace("=", "_") + '.agcache'
+def toCacheFilename(endpoint, append = True):
+    return endpoint.replace("/", ".").replace("?", "_").replace("=", "_") + ('.agcache' if append else "")
 
-def toCacheFilepath(endpoint):
-    return getSetting('caching').joinpath(toCacheFilename(endpoint))
+def toCacheFilepath(endpoint, append = True):
+    return getSetting('caching').joinpath(toCacheFilename(endpoint), append)
 
 def toCacheURL(endpoint):
     return getSetting('approot') + str(toCacheFilepath(endpoint))
@@ -275,7 +275,7 @@ def requestPNG(endpoint):
 def download(url, cmanager, filename, image_cache, image_id, repo_id = None):
     image_cache[image_id] = {}
     image_cache[image_id]['filename'] = filename
-    filename = toCacheFilepath(filename)
+    filename = toCacheFilepath(filename, False)
     if cacheFileExists(filename):
         image_cache[image_id]['exists'] = True
         return

--- a/augur/api/view/utils.py
+++ b/augur/api/view/utils.py
@@ -204,7 +204,7 @@ def toCacheFilename(endpoint, append = True):
     return endpoint.replace("/", ".").replace("?", "_").replace("=", "_") + ('.agcache' if append else "")
 
 def toCacheFilepath(endpoint, append = True):
-    return getSetting('caching').joinpath(toCacheFilename(endpoint), append)
+    return getSetting('caching').joinpath(toCacheFilename(endpoint, append))
 
 def toCacheURL(endpoint):
     return getSetting('approot') + str(toCacheFilepath(endpoint))


### PR DESCRIPTION
**Description**
- Fixes visualizations broken since augur view merger into chaoss/augur

The merger of these two applications made the choice of an external cache directory impossible, so the application must now cache files in a directory relative to the root of the gunicorn server. The `static` directory is used for convenience.

- Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->