### PR TITLE
Python module imports detection patch

### DIFF
--- a/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
@@ -2,17 +2,32 @@ import sys
 import re
 from pathlib import Path
 import codecs
+import ast
+
 
 def get_files(path):
-	#copied from example on https://docs.python.org/3/library/pathlib.html
-	dir = path
-	p = Path(dir)
-	files = list(p.glob('**/*.py'))
-	return files
-	
-def get_deps_for_file(path):
-	f = open(path, 'r',encoding="utf-8")
+    # copied from example on https://docs.python.org/3/library/pathlib.html
+    dir = path
+    p = Path(dir)
+    files = list(p.glob("**/*.py"))
+    return files
 
-	matches = re.findall("import\s*(\w*)", f.read())
-	f.close()
-	return matches
+
+def get_deps_for_file(path):
+
+    with open(path, "r", encoding="utf-8") as f:
+
+        imports = set()
+
+        # parse abstract syntax tree (ast)
+        tree = ast.parse(f.read())
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for name in node.names:
+                    imports.add(name.name)
+            elif isinstance(node, ast.ImportFrom):
+                module_name = node.module
+                if module_name:
+                    imports.add(module_name)
+    return imports


### PR DESCRIPTION
Uses abstract syntax tree (AST module) of Python file instead of regex to identify python imports.

also detects submodules.

**Signed commits**
- [x] Yes, I signed my commits.