### PR TITLE
Fix celery error handling to set repo's collection status to error when error encountered

### DIFF
--- a/augur/tasks/git/dependency_libyear_tasks/tasks.py
+++ b/augur/tasks/git/dependency_libyear_tasks/tasks.py
@@ -3,9 +3,10 @@ import traceback
 from augur.application.db.session import DatabaseSession
 from augur.tasks.git.dependency_libyear_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask
 from augur.application.db.util import execute_session_query
 
-@celery.task
+@celery.task(base=AugurFacadeRepoCollectionTask)
 def process_libyear_dependency_metrics(repo_git):
     #raise NotImplementedError
 

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -3,11 +3,11 @@ import traceback
 from augur.application.db.session import DatabaseSession
 from augur.tasks.git.dependency_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
-from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
+from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask, AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
 
 
-@celery.task(base=AugurCoreRepoCollectionTask)
+@celery.task(base=AugurFacadeRepoCollectionTask)
 def process_dependency_metrics(repo_git):
     #raise NotImplementedError
 

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -3,10 +3,11 @@ import traceback
 from augur.application.db.session import DatabaseSession
 from augur.tasks.git.dependency_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
 
 
-@celery.task
+@celery.task(base=AugurCoreRepoCollectionTask)
 def process_dependency_metrics(repo_git):
     #raise NotImplementedError
 
@@ -23,7 +24,7 @@ def process_dependency_metrics(repo_git):
         deps_model(session, repo.repo_id,repo_git,repo.repo_group_id)
 
 
-@celery.task
+@celery.task(base=AugurCoreRepoCollectionTask)
 def process_ossf_scorecard_metrics(repo_git):
     from augur.tasks.init.celery_app import engine
     

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -33,6 +33,7 @@ from augur.tasks.github.facade_github.tasks import *
 from augur.tasks.util.worker_util import create_grouped_task_load
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask
 
 
 from augur.application.db import data_parse
@@ -69,7 +70,7 @@ def facade_error_handler(request,exc,traceback):
 
 
 #Predefine facade collection with tasks
-@celery.task
+@celery.task(base=AugurFacadeRepoCollectionTask)
 def facade_analysis_init_facade_task(repo_git):
 
     logger = logging.getLogger(facade_analysis_init_facade_task.__name__)
@@ -86,12 +87,16 @@ def facade_analysis_init_facade_task(repo_git):
             repo_id=:repo_id""").bindparams(repo_id=repo_id)
         session.execute_sql(update_project_status)
 
-@celery.task
-def grab_comitters(repo_id,platform="github"):
+@celery.task(base=AugurFacadeRepoCollectionTask)
+def grab_comitters(repo_git,platform="github"):
 
     from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(grab_comitters.__name__)
+    with FacadeSession(logger) as session:
+
+        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+        repo_id = repo.repo_id
 
     try:
         grab_committer_list(GithubTaskSession(logger, engine), repo_id,platform)
@@ -99,12 +104,15 @@ def grab_comitters(repo_id,platform="github"):
         logger.error(f"Could not grab committers from github endpoint!\n Reason: {e} \n Traceback: {''.join(traceback.format_exception(None, e, e.__traceback__))}")
 
 
-@celery.task
-def trim_commits_facade_task(repo_id):
+@celery.task(base=AugurFacadeRepoCollectionTask)
+def trim_commits_facade_task(repo_git):
 
     logger = logging.getLogger(trim_commits_facade_task.__name__)
 
     with FacadeSession(logger) as session:
+
+        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+        repo_id = repo.repo_id
 
         def update_analysis_log(repos_id,status):
 
@@ -148,13 +156,16 @@ def trim_commits_facade_task(repo_id):
         update_analysis_log(repo_id,'Collecting data')
         logger.info(f"Got past repo {repo_id}")
 
-@celery.task
-def trim_commits_post_analysis_facade_task(repo_id):
+@celery.task(base=AugurFacadeRepoCollectionTask)
+def trim_commits_post_analysis_facade_task(repo_git):
 
     logger = logging.getLogger(trim_commits_post_analysis_facade_task.__name__)
     
 
     with FacadeSession(logger) as session:
+        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+        repo_id = repo.repo_id
+
         start_date = session.get_setting('start_date')
         def update_analysis_log(repos_id,status):
 
@@ -228,14 +239,18 @@ def facade_start_contrib_analysis_task():
 
 
 #enable celery multithreading
-@celery.task
-def analyze_commits_in_parallel(repo_id, multithreaded: bool)-> None:
+@celery.task(base=AugurFacadeRepoCollectionTask)
+def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
     """Take a large list of commit data to analyze and store in the database. Meant to be run in parallel with other instances of this task.
     """
 
     #create new session for celery thread.
     logger = logging.getLogger(analyze_commits_in_parallel.__name__)
     with FacadeSession(logger) as session:
+        
+        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+        repo_id = repo.repo_id
+
         start_date = session.get_setting('start_date')
 
         session.logger.info(f"Generating sequence for repo {repo_id}")
@@ -390,13 +405,13 @@ def generate_analysis_sequence(logger,repo_git, session):
 
     analysis_sequence.append(facade_analysis_init_facade_task.si(repo_git))
 
-    analysis_sequence.append(grab_comitters.si(repo_id))
+    analysis_sequence.append(grab_comitters.si(repo_git))
 
-    analysis_sequence.append(trim_commits_facade_task.si(repo_id))
+    analysis_sequence.append(trim_commits_facade_task.si(repo_git))
 
-    analysis_sequence.append(analyze_commits_in_parallel.si(repo_id,True))
+    analysis_sequence.append(analyze_commits_in_parallel.si(repo_git,True))
 
-    analysis_sequence.append(trim_commits_post_analysis_facade_task.si(repo_id))
+    analysis_sequence.append(trim_commits_post_analysis_facade_task.si(repo_git))
 
     
     analysis_sequence.append(facade_analysis_end_facade_task.si())

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -70,10 +70,14 @@ def facade_error_handler(request,exc,traceback):
 
 #Predefine facade collection with tasks
 @celery.task
-def facade_analysis_init_facade_task(repo_id):
+def facade_analysis_init_facade_task(repo_git):
 
     logger = logging.getLogger(facade_analysis_init_facade_task.__name__)
     with FacadeSession(logger) as session:
+
+        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+        repo_id = repo.repo_id
+
         session.update_status('Running analysis')
         session.log_activity('Info',f"Beginning analysis.")
 
@@ -384,11 +388,7 @@ def generate_analysis_sequence(logger,repo_git, session):
 
     repo_id = repo_ids.pop(0)
 
-    #determine amount of celery tasks to run at once in each grouped task load
-    concurrentTasks = int((-1 * (15/(len(repo_ids)+1))) + 15)
-    logger.info(f"Scheduling concurrent layers {concurrentTasks} tasks at a time.")
-
-    analysis_sequence.append(facade_analysis_init_facade_task.si(repo_id))
+    analysis_sequence.append(facade_analysis_init_facade_task.si(repo_git))
 
     analysis_sequence.append(grab_comitters.si(repo_id))
 

--- a/augur/tasks/github/detect_move/tasks.py
+++ b/augur/tasks/github/detect_move/tasks.py
@@ -1,12 +1,13 @@
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.github.detect_move.core import *
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
 import traceback
 
 
 
-@celery.task()
+@celery.task(base=AugurCoreRepoCollectionTask)
 def detect_github_repo_move_core(repo_git : str) -> None:
 
     logger = logging.getLogger(detect_github_repo_move_core.__name__)
@@ -22,7 +23,7 @@ def detect_github_repo_move_core(repo_git : str) -> None:
         ping_github_for_repo_move(augur_db, manifest.key_auth, repo, logger)
 
 
-@celery.task()
+@celery.task(base=AugurCoreRepoCollectionTask)
 def detect_github_repo_move_secondary(repo_git : str) -> None:
 
     logger = logging.getLogger(detect_github_repo_move_secondary.__name__)

--- a/augur/tasks/github/events/tasks.py
+++ b/augur/tasks/github/events/tasks.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
@@ -14,7 +15,7 @@ from augur.application.db.util import execute_session_query
 
 platform_id = 1
 
-@celery.task()
+@celery.task(base=AugurCoreRepoCollectionTask)
 def collect_events(repo_git: str):
 
     logger = logging.getLogger(collect_events.__name__)

--- a/augur/tasks/github/issues/tasks.py
+++ b/augur/tasks/github/issues/tasks.py
@@ -24,8 +24,7 @@ development = get_development_flag()
 def collect_issues(repo_git : str) -> None:
 
 
-    logger = logging.getLogger(collect_issues.__name__)
-    raise Exception()    
+    logger = logging.getLogger(collect_issues.__name__) 
     with GithubTaskManifest(logger) as manifest:
 
         augur_db = manifest.augur_db

--- a/augur/tasks/github/issues/tasks.py
+++ b/augur/tasks/github/issues/tasks.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
@@ -19,12 +20,12 @@ from augur.application.db.util import execute_session_query
 
 development = get_development_flag()
 
-@celery.task()
+@celery.task(base=AugurCoreRepoCollectionTask)
 def collect_issues(repo_git : str) -> None:
 
 
     logger = logging.getLogger(collect_issues.__name__)
-    
+    raise Exception()    
     with GithubTaskManifest(logger) as manifest:
 
         augur_db = manifest.augur_db

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -4,6 +4,7 @@ import logging
 import traceback
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
@@ -18,7 +19,7 @@ from augur.application.db.util import execute_session_query
 platform_id = 1
 
 
-@celery.task()
+@celery.task(base=AugurCoreRepoCollectionTask)
 def collect_github_messages(repo_git: str) -> None:
 
     logger = logging.getLogger(collect_github_messages.__name__)

--- a/augur/tasks/github/pull_requests/commits_model/tasks.py
+++ b/augur/tasks/github/pull_requests/commits_model/tasks.py
@@ -3,11 +3,12 @@ import traceback
 from augur.application.db.session import DatabaseSession
 from augur.tasks.github.pull_requests.commits_model.core import *
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurSecondaryRepoCollectionTask
 from augur.application.db.util import execute_session_query
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 
 
-@celery.task()
+@celery.task(base=AugurSecondaryRepoCollectionTask)
 def process_pull_request_commits(repo_git: str) -> None:
 
     logger = logging.getLogger(process_pull_request_commits.__name__)

--- a/augur/tasks/github/pull_requests/files_model/tasks.py
+++ b/augur/tasks/github/pull_requests/files_model/tasks.py
@@ -4,9 +4,10 @@ from augur.application.db.session import DatabaseSession
 from augur.tasks.github.pull_requests.files_model.core import *
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurSecondaryRepoCollectionTask
 from augur.application.db.util import execute_session_query
 
-@celery.task()
+@celery.task(base=AugurSecondaryRepoCollectionTask)
 def process_pull_request_files(repo_git: str) -> None:
 
     logger = logging.getLogger(process_pull_request_files.__name__)

--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -4,7 +4,7 @@ import traceback
 
 from augur.tasks.github.pull_requests.core import extract_data_from_pr_list
 from augur.tasks.init.celery_app import celery_app as celery
-from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask, AugurSecondaryRepoCollectionTask
 from augur.application.db.data_parse import *
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
@@ -187,7 +187,7 @@ def process_pull_request_review_contributor(pr_review: dict, tool_source: str, t
     return pr_review_cntrb
 
 
-@celery.task
+@celery.task(base=AugurSecondaryRepoCollectionTask)
 def collect_pull_request_review_comments(repo_git: str) -> None:
 
     owner, repo = get_owner_repo(repo_git)
@@ -304,7 +304,7 @@ def collect_pull_request_review_comments(repo_git: str) -> None:
 
 
 
-@celery.task
+@celery.task(base=AugurSecondaryRepoCollectionTask)
 def collect_pull_request_reviews(repo_git: str) -> None:
 
     logger = logging.getLogger(collect_pull_request_reviews.__name__)

--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -4,6 +4,7 @@ import traceback
 
 from augur.tasks.github.pull_requests.core import extract_data_from_pr_list
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
@@ -18,7 +19,7 @@ from ..messages.tasks import process_github_comment_contributors
 platform_id = 1
 
 
-@celery.task()
+@celery.task(base=AugurCoreRepoCollectionTask)
 def collect_pull_requests(repo_git: str) -> None:
 
     logger = logging.getLogger(collect_pull_requests.__name__)

--- a/augur/tasks/github/releases/tasks.py
+++ b/augur/tasks/github/releases/tasks.py
@@ -1,10 +1,11 @@
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.github.releases.core import *
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
 import traceback
 
-@celery.task
+@celery.task(base=AugurCoreRepoCollectionTask)
 def collect_releases(repo_git):
 
     logger = logging.getLogger(collect_releases.__name__)

--- a/augur/tasks/github/repo_info/tasks.py
+++ b/augur/tasks/github/repo_info/tasks.py
@@ -2,10 +2,11 @@ from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.application.db.session import DatabaseSession
 from augur.tasks.github.repo_info.core import *
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
 import traceback
 
-@celery.task()
+@celery.task(base=AugurCoreRepoCollectionTask)
 def collect_repo_info(repo_git: str):
 
     logger = logging.getLogger(collect_repo_info.__name__)

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -70,7 +70,7 @@ BACKEND_URL = f'{redis_conn_string}{redis_db_number+1}'
 
 
 class AugurTask(celery.Task):
-    def task_failed_util(self,exc,traceback,task_id,args, kwargs, einfo):
+    def on_failure(self,exc,traceback,task_id,args, kwargs, einfo):
 
         from augur.tasks.init.celery_app import engine
 


### PR DESCRIPTION
**Description**
- Add base classes for repo collection tasks that override the on_failure method of the Task celery class
- Change several facade related tasks to take a repo_git instead of a repo_id

**Signed commits**
- [x] Yes, I signed my commits.
