### PR TITLE
Add exception handle in dependency analysis to use regex if ast can't be used due to version 

### DIFF
--- a/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
@@ -16,7 +16,7 @@ def get_files(path):
 def get_deps_for_file(path):
     try:
         return get_deps_for_file_ast(path)
-    except Exception as e:
+    except Exception:
         return get_deps_for_file_simple_regex(path)
 
 def get_deps_for_file_simple_regex(path):

--- a/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
@@ -14,7 +14,20 @@ def get_files(path):
 
 
 def get_deps_for_file(path):
+    try:
+        return get_deps_for_file_ast(path)
+    except Exception as e:
+        return get_deps_for_file_simple_regex(path)
 
+def get_deps_for_file_simple_regex(path):
+    f = open(path, 'r',encoding="utf-8")
+
+    matches = re.findall("import\s*(\w*)", f.read())
+    f.close()
+    return matches
+
+
+def get_deps_for_file_ast(path):
     with open(path, "r", encoding="utf-8") as f:
 
         imports = set()


### PR DESCRIPTION
**Description**
Fixed issue with python dependency analysis where versions older than python 3.4 couldn't be parsed. This was because the current version of python's ast (abstract syntax tree) module only supports versions greater than or equal to 3.4. The new method used uses a simple regex to find dependencies if issues are encountered using the ast method. 

**Signed commits**
- [x] Yes, I signed my commits.
