### PR TITLE
Fix wrong base class assignment and make sure repos don't get marked as errored when a new host is found

### DIFF
--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -70,7 +70,7 @@ def ping_github_for_repo_move(augur_db, key_auth, repo, logger,collection_hook='
         update_repo_with_dict(current_repo_dict, repo_update_dict, logger, augur_db)
 
         raise Exception(f"ERROR: Repo not found at requested host {repo.repo_git}")
-    elif attempts == 10:
+    elif attempts >= 10:
         logger.warning(f"Could not check if repo moved because the api timed out 10 times. Url: {url}")
         return
     

--- a/augur/tasks/github/detect_move/tasks.py
+++ b/augur/tasks/github/detect_move/tasks.py
@@ -1,7 +1,7 @@
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.github.detect_move.core import *
 from augur.tasks.init.celery_app import celery_app as celery
-from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask, AugurSecondaryRepoCollectionTask
 from augur.application.db.util import execute_session_query
 import traceback
 
@@ -23,7 +23,7 @@ def detect_github_repo_move_core(repo_git : str) -> None:
         ping_github_for_repo_move(augur_db, manifest.key_auth, repo, logger)
 
 
-@celery.task(base=AugurCoreRepoCollectionTask)
+@celery.task(base=AugurSecondaryRepoCollectionTask)
 def detect_github_repo_move_secondary(repo_git : str) -> None:
 
     logger = logging.getLogger(detect_github_repo_move_secondary.__name__)


### PR DESCRIPTION
**Description**
- Fix syntax issue where detect_github_repo_move_secondary had a base task class of AugurCoreRepoCollectionTask instead of AugurSecondaryRepoCollectionTask. 
- Fix logic error where some repos would be marked as errored when a new host is found for them through a Github api endpoint

**Signed commits**
- [x] Yes, I signed my commits.
