### PR TITLE
fix typo in on_failure logic

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -91,7 +91,7 @@ class AugurCoreRepoCollectionTask(celery.Task):
             #Only set to error if the repo was actually running at the time.
             #This is to allow for things like exiting from collection without error.
             #i.e. detect_repo_move changes the repo's repo_git and resets collection to pending without error
-            prevStatus = getattr(repoS, f"{collection_hook}_status")
+            prevStatus = getattr(repoStatus, f"{collection_hook}_status")
 
             if prevStatus == CollectionState.COLLECTING.value or prevStatus == CollectionState.INITIALIZING.value:
                 setattr(repoStatus, f"{collection_hook}_status", CollectionState.ERROR.value)


### PR DESCRIPTION
**Description**
- Fix typo in on_failure logic. repoStatus not repoS

**Signed commits**
- [ ] Yes, I signed my commits.
