### PR TITLE
Fix issue with celery rabbitmq messages not getting cleared with celery_app.control.purge()

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -208,8 +208,8 @@ def clear_all_message_queues(connection_string):
     parsed = urlparse(connection_string)
 
     for q in queues:
-        curl_cmd = f"curl --verbose -i -u {parsed.username}:{parsed.password} -XDELETE http://localhost:{parsed.port}/api/queues/{virtual_host_string}/{q}"
-        subprocess.call(curl_cmd.split(" "))
+        curl_cmd = f"curl -i -u {parsed.username}:{parsed.password} -XDELETE http://localhost:15672/api/queues/{virtual_host_string}/{q}"
+        subprocess.call(curl_cmd.split(" "),stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 def clear_rabbitmq_messages(connection_string):

--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -208,7 +208,7 @@ def clear_all_message_queues(connection_string):
     parsed = urlparse(connection_string)
 
     for q in queues:
-        curl_cmd = f"curl -i -u {parsed.username}:{parsed.password} -XDELETE http://localhost:{parsed.port}/api/queues/{virtual_host_string}/{q}"
+        curl_cmd = f"curl --verbose -i -u {parsed.username}:{parsed.password} -XDELETE http://localhost:{parsed.port}/api/queues/{virtual_host_string}/{q}"
         subprocess.call(curl_cmd.split(" "))
 
 


### PR DESCRIPTION
**Description**
- Now when augur collection is told to stop it uses curl to send http requests to the local rabbitmq instance to explicitly delete the message queues that that instance was using. 

Note: for this change to do anything it requires the rabbitmq_management plugin and for the augur user to have the administrator tag otherwise behavior is unchanged. 

**Signed commits**
- [x] Yes, I signed my commits.
