### PR TITLE
Dev bugfixes 

### DIFF
--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_libyear_util.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_libyear_util.py
@@ -50,12 +50,12 @@ def get_version(pypi_data, version, lt=False):
 def handle_upper_limit_dependency(dependency, data):
     versions = dependency['requirement'].split(',')
     upper_limit = clean_version(versions[0])
-    lower_limit = clean_version(versions[1])
     release_list = list(data['releases'])
 
     if upper_limit not in release_list:
         upper_limit += '.0'
-    # print('the upper limit and lower limit is %s and %s' %(upper_limit,lower_limit))
+
+
     upper_index = release_list.index(upper_limit)
     return release_list[upper_index -1]
     # return get_version(data, upper_limit, lt= True)

--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
@@ -117,7 +117,7 @@ def get_deps_libyear_data(path, logger):
                 data = get_pypi_data(dependency['name'])
                 try:
                     current_version = sort_dependency_requirement(dependency,data)
-                except KeyError:
+                except (KeyError, TypeError) as e:
                     logger.error(f"Could not get current version of dependency for path {path}.\n  Dependency: {dependency}")
                     current_version = None
                 try:

--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
@@ -92,7 +92,7 @@ def get_libyear(current_version, current_release_date, latest_version, latest_re
     if not latest_release_date:
         return -1
 
-    if not current_version:
+    if not current_version or not current_release_date:
         return 0
 
     current_release_date= dateutil.parser.parse(current_release_date)

--- a/augur/tasks/github/releases/core.py
+++ b/augur/tasks/github/releases/core.py
@@ -201,7 +201,7 @@ def releases_model(augur_db, key_auth, logger, repo_git, repo_id):
                         if 'node' in n:
                             release = n['node']
                             #self.insert_release(task, repo_id, data['owner'], release, True)
-                            insert_release(augur_db, repo_id, data['owner'], release, True)
+                            insert_release(augur_db,logger, repo_id, data['owner'], release, True)
                         else:
                             logger.info("There's no release to insert. Current node is not available in releases: {}\n".format(n))
                 else:


### PR DESCRIPTION
**Description**
- Fix typo similar to previous issue where methods that used to take a session now take a logger and a key_auth object instead but the change was not made correctly universally. 
- Delete unused variable in libyear logic
- Stop libyear logic from trying to parse an empty date.
- Handle issue where regex was encountering empty string. 


**Signed commits**
- [x] Yes, I signed my commits.
