### PR TITLE
Move github contributors query outside of facade collection hook

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -82,22 +82,6 @@ def facade_analysis_init_facade_task(repo_git):
         session.update_status('Running analysis')
         session.log_activity('Info',f"Beginning analysis.")
 
-@celery.task(base=AugurFacadeRepoCollectionTask)
-def grab_comitters(repo_git,platform="github"):
-
-    from augur.tasks.init.celery_app import engine
-
-    logger = logging.getLogger(grab_comitters.__name__)
-    with FacadeSession(logger) as session:
-
-        repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
-        repo_id = repo.repo_id
-
-    try:
-        grab_committer_list(GithubTaskSession(logger, engine), repo_id,platform)
-    except Exception as e:
-        logger.error(f"Could not grab committers from github endpoint!\n Reason: {e} \n Traceback: {''.join(traceback.format_exception(None, e, e.__traceback__))}")
-
 
 @celery.task(base=AugurFacadeRepoCollectionTask)
 def trim_commits_facade_task(repo_git):
@@ -399,8 +383,6 @@ def generate_analysis_sequence(logger,repo_git, session):
     repo_id = repo_ids.pop(0)
 
     analysis_sequence.append(facade_analysis_init_facade_task.si(repo_git))
-
-    analysis_sequence.append(grab_comitters.si(repo_git))
 
     analysis_sequence.append(trim_commits_facade_task.si(repo_git))
 

--- a/augur/tasks/github/contributors/tasks.py
+++ b/augur/tasks/github/contributors/tasks.py
@@ -13,7 +13,7 @@ from augur.application.db.models import PullRequest, Message, PullRequestReview,
 from augur.application.db.util import execute_session_query
 
 
-@celery.task(base=AugurCoreRepoCollectionTask)
+@celery.task
 def process_contributors():
 
     logger = logging.getLogger(process_contributors.__name__)

--- a/augur/tasks/github/contributors/tasks.py
+++ b/augur/tasks/github/contributors/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
@@ -12,7 +13,7 @@ from augur.application.db.models import PullRequest, Message, PullRequestReview,
 from augur.application.db.util import execute_session_query
 
 
-@celery.task
+@celery.task(base=AugurCoreRepoCollectionTask)
 def process_contributors():
 
     logger = logging.getLogger(process_contributors.__name__)

--- a/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
+++ b/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
@@ -33,6 +33,7 @@ A few interesting ideas: Maybe get the top committers from each repo first? curl
 
 # Hit the endpoint specified by the url and return the json that it returns if it returns a dict.
 # Returns None on failure.
+# NOTE: This function is being deprecated in favor of retrieve_dict_from_endpoint
 def request_dict_from_endpoint(session, url, timeout_wait=10):
     #session.logger.info(f"Hitting endpoint: {url}")
 
@@ -406,18 +407,18 @@ def get_login_with_commit_hash(session, commit_data, repo_id):
 
 
 
-def create_endpoint_from_repo_id(session, repo_id):
+def create_endpoint_from_repo_id(manifest, repo_id):
     
     """
         SELECT repo_git from repo
         WHERE repo_id = :repo_id_bind
     """
     #ORM syntax of above statement
-    query = session.query(Repo).filter_by(repo_id=repo_id)
+    query = manifest.augur_db.session.query(Repo).filter_by(repo_id=repo_id)
     result = execute_session_query(query, 'one')
 
     url = result.repo_git
-    session.logger.info(f"Url: {url}")
+    manifest.logger.info(f"Url: {url}")
 
     return url
 

--- a/augur/tasks/github/facade_github/core.py
+++ b/augur/tasks/github/facade_github/core.py
@@ -12,7 +12,7 @@ from augur.tasks.util.AugurUUID import AugurUUID, GithubUUID, UnresolvableUUID
 
 
 
-def query_github_contributors(session, github_url):
+def query_github_contributors(manifest, github_url):
 
     """ Data collection function
     Query the GitHub API for contributors
@@ -22,7 +22,7 @@ def query_github_contributors(session, github_url):
     try:
         owner, name = get_owner_repo(github_url)
     except IndexError as e:
-        session.logger.error(f"Encountered bad url: {github_url}")
+        manifest.logger.error(f"Encountered bad url: {github_url}")
         raise e
 
     # Set the base of the url and place to hold contributors to insert
@@ -40,11 +40,11 @@ def query_github_contributors(session, github_url):
     duplicate_col_map = {'cntrb_login': 'login'}
 
     #list to hold contributors needing insertion or update
-    contributor_list = GithubPaginator(contributors_url, session.oauths,session.logger)#paginate(contributors_url, duplicate_col_map, update_col_map, table, table_pkey)
+    contributor_list = GithubPaginator(contributors_url, manifest.key_auth,manifest.logger)#paginate(contributors_url, duplicate_col_map, update_col_map, table, table_pkey)
 
     len_contributor_list = len(contributor_list)
 
-    session.logger.info("Count of contributors needing insertion: " + str(len_contributor_list) + "\n")
+    manifest.logger.info("Count of contributors needing insertion: " + str(len_contributor_list) + "\n")
 
     if len_contributor_list == 0:
         return
@@ -57,13 +57,13 @@ def query_github_contributors(session, github_url):
             cntrb_url = ("https://api.github.com/users/" + repo_contributor['login'])
 
             
-            session.logger.info("Hitting endpoint: " + cntrb_url + " ...\n")
+            manifest.logger.info("Hitting endpoint: " + cntrb_url + " ...\n")
             #r = hit_api(session.oauths, cntrb_url, session.logger)
             #contributor = r.json()
 
-            contributor = request_dict_from_endpoint(session, cntrb_url)
+            contributor = retrieve_dict_from_endpoint(manifest, cntrb_url)
 
-            #session.logger.info(f"Contributor: {contributor} \n")
+            manifest.logger.info(f"Contributor: {contributor} \n")
             company = None
             location = None
             email = None
@@ -81,7 +81,7 @@ def query_github_contributors(session, github_url):
             #cntrb_id = AugurUUID(session.platform_id,contributor['id']).to_UUID()
             cntrb_id = GithubUUID()
             cntrb_id["user"] = int(contributor['id'])
-            cntrb_id["platform"] = session.platform_id
+            cntrb_id["platform"] = manifest.platform_id
 
             cntrb = {
                 "cntrb_id" : cntrb_id.to_UUID(),
@@ -120,20 +120,20 @@ def query_github_contributors(session, github_url):
             cntrb_natural_keys = ['cntrb_id']
             #insert cntrb to table.
             #session.logger.info(f"Contributor:  {cntrb}  \n")
-            session.insert_data(cntrb,Contributor,cntrb_natural_keys)
+            manifest.augur_db.insert_data(cntrb,Contributor,cntrb_natural_keys)
             
         except Exception as e:
-            session.logger.error("Caught exception: {}".format(e))
-            session.logger.error("Cascading Contributor Anomalie from missing repo contributor data: {} ...\n".format(cntrb_url))
+            manifest.logger.error("Caught exception: {}".format(e))
+            manifest.logger.error("Cascading Contributor Anomalie from missing repo contributor data: {} ...\n".format(cntrb_url))
             raise e
 
 # Get all the committer data for a repo.
 # Used by facade in facade03analyzecommit
-def grab_committer_list(session, repo_id, platform="github"):
+def grab_committer_list(manifest, repo_id, platform="github"):
 
     # Create API endpoint from repo_id
 
-    endpoint = create_endpoint_from_repo_id(session, repo_id)
+    endpoint = create_endpoint_from_repo_id(manifest, repo_id)
 
-    query_github_contributors(session,endpoint)
+    query_github_contributors(manifest,endpoint)
     

--- a/augur/tasks/github/facade_github/core.py
+++ b/augur/tasks/github/facade_github/core.py
@@ -61,7 +61,7 @@ def query_github_contributors(manifest, github_url):
             #r = hit_api(session.oauths, cntrb_url, session.logger)
             #contributor = r.json()
 
-            contributor = retrieve_dict_from_endpoint(manifest, cntrb_url)
+            contributor, result = retrieve_dict_from_endpoint(manifest, cntrb_url)
 
             manifest.logger.info(f"Contributor: {contributor} \n")
             company = None

--- a/augur/tasks/github/facade_github/core.py
+++ b/augur/tasks/github/facade_github/core.py
@@ -63,7 +63,7 @@ def query_github_contributors(manifest, github_url):
 
             contributor, result = retrieve_dict_from_endpoint(manifest, cntrb_url)
 
-            manifest.logger.info(f"Contributor: {contributor} \n")
+            #manifest.logger.info(f"Contributor: {contributor} \n")
             company = None
             location = None
             email = None

--- a/augur/tasks/github/util/github_paginator.py
+++ b/augur/tasks/github/util/github_paginator.py
@@ -406,7 +406,7 @@ class GithubPaginator(collections.abc.Sequence):
                     continue                    
 
             if isinstance(page_data, str) is True:
-                str_processing_result: Union[str, List[dict]] = self.process_str_response(page_data)
+                str_processing_result: Union[str, List[dict]] = process_str_response(self.logger,page_data)
 
                 if isinstance(str_processing_result, list):
                     return str_processing_result, response, GithubApiResult.SUCCESS
@@ -455,31 +455,6 @@ class GithubPaginator(collections.abc.Sequence):
 
 ###################################################
 
-    def process_str_response(self, page_data: str) -> Union[str, List[dict]]:
-        """Process an api response of type string.
-
-        Args:
-            page_data: the string response from the api that is being processed
-
-        Returns:
-            html_response, empty_string, and failed_to_parse_jsonif the data is not processable. 
-                Or a list of dicts if the json was parasable
-        """
-        self.logger.info(f"Warning! page_data was string: {page_data}\n")
-        
-        if "<!DOCTYPE html>" in page_data:
-            self.logger.info("HTML was returned, trying again...\n")
-            return GithubApiResult.HTML
-
-        if not page_data:
-            self.logger.info("Empty string, trying again...\n")
-            return GithubApiResult.EMPTY_STRING
-
-        try:
-            list_of_dict_page_data = json.loads(page_data)
-            return list_of_dict_page_data
-        except TypeError:
-            return "failed_to_parse_json"
 
 
 ################################################################################
@@ -504,6 +479,32 @@ def clean_url(url: str, keys: List[str]) -> str:
     u = u._replace(query=urlencode(query, True))
     
     return urlunparse(u)
+
+def process_str_response(logger, page_data: str) -> Union[str, List[dict]]:
+    """Process an api response of type string.
+
+    Args:
+        page_data: the string response from the api that is being processed
+
+    Returns:
+        html_response, empty_string, and failed_to_parse_jsonif the data is not processable. 
+            Or a list of dicts if the json was parasable
+    """
+    logger.info(f"Warning! page_data was string: {page_data}\n")
+    
+    if "<!DOCTYPE html>" in page_data:
+        logger.info("HTML was returned, trying again...\n")
+        return GithubApiResult.HTML
+
+    if not page_data:
+        logger.info("Empty string, trying again...\n")
+        return GithubApiResult.EMPTY_STRING
+
+    try:
+        list_of_dict_page_data = json.loads(page_data)
+        return list_of_dict_page_data
+    except TypeError:
+        return "failed_to_parse_json"
 
 
 def add_query_params(url: str, additional_params: dict) -> str:
@@ -551,3 +552,67 @@ def get_url_page_number(url: str) -> int:
         return 1
 
     return page_number
+
+
+def retrieve_dict_from_endpoint(manifest, url, timeout_wait=10) -> Tuple[Optional[dict], GithubApiResult]:
+    timeout = timeout_wait
+    timeout_count = 0
+    num_attempts = 1
+
+    while num_attempts <= 10:
+
+        response = hit_api(manifest.key_auth, url, manifest.logger, timeout)
+
+        if response is None:
+            if timeout_count == 10:
+                manifest.logger.error(f"Request timed out 10 times for {url}")
+                return None, GithubApiResult.TIMEOUT
+
+            timeout = timeout * 1.1
+            num_attempts += 1
+            continue
+        
+        
+        page_data = parse_json_response(manifest.logger, response)
+
+        if isinstance(page_data, str):
+            str_processing_result: Union[str, List[dict]] = process_str_response(manifest.logger,page_data)
+
+            if isinstance(str_processing_result, dict):
+                #return str_processing_result, response, GithubApiResult.SUCCESS
+                page_data = str_processing_result
+            else:
+                num_attempts += 1
+                continue
+
+        # if the data is a list, then return it and the response
+        if isinstance(page_data, list):
+            manifest.logger.warning("Wrong type returned, trying again...")
+            manifest.logger.info(f"Returned list: {response_data}")
+
+        # if the data is a dict then call process_dict_response, and 
+        elif isinstance(page_data, dict):
+            dict_processing_result = process_dict_response(manifest.logger, response, page_data)
+
+            if dict_processing_result == GithubApiResult.SUCCESS:
+                return page_data, dict_processing_result
+            if dict_processing_result == GithubApiResult.NEW_RESULT:
+                manifest.logger.info(f"Encountered new dict response from api on url: {url}. Response: {page_data}")
+                return None, GithubApiResult.NEW_RESULT
+
+            if dict_processing_result == GithubApiResult.REPO_NOT_FOUND:
+                return None, GithubApiResult.REPO_NOT_FOUND
+
+            if dict_processing_result in (GithubApiResult.SECONDARY_RATE_LIMIT, GithubApiResult.ABUSE_MECHANISM_TRIGGERED):
+                continue
+
+            if dict_processing_result == GithubApiResult.RATE_LIMIT_EXCEEDED:
+                num_attempts = 0
+                continue                    
+
+        
+
+        num_attempts += 1
+
+    manifest.logger.error("Unable to collect data in 10 attempts")
+    return None, GithubApiResult.NO_MORE_ATTEMPTS

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -91,7 +91,7 @@ def primary_repo_collect_phase(repo_git):
         #facade_phase(logger,repo_git),
         
         collect_releases.si(repo_git),
-        grab_comitters(repo_git)
+        grab_comitters.si(repo_git)
     )
 
     return repo_task_group

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -90,7 +90,8 @@ def primary_repo_collect_phase(repo_git):
         chain(primary_repo_jobs,secondary_repo_jobs,process_contributors.si()),
         #facade_phase(logger,repo_git),
         
-        collect_releases.si(repo_git)
+        collect_releases.si(repo_git),
+        grab_comitters(repo_git)
     )
 
     return repo_task_group

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -74,36 +74,6 @@ def primary_repo_collect_phase(repo_git):
     #A chain is needed for each repo.
     repo_info_task = collect_repo_info.si(repo_git)#collection_task_wrapper(self)
 
-
-## I think this section is outdated
-# ### Section from traffic metric merge that may need to be changed
-
-#     with DatabaseSession(logger) as session:
-#         query = session.query(Repo)
-#         repos = execute_session_query(query, 'all')
-#         #Just use list comprehension for simple group
-#         repo_info_tasks = [collect_repo_info.si(repo.repo_git) for repo in repos]
-
-#         for repo in repos:
-#             first_tasks_repo = group(collect_issues.si(repo.repo_git),collect_pull_requests.si(repo.repo_git),collect_github_repo_clones_data.si(repo.repo_git))
-#             second_tasks_repo = group(collect_events.si(repo.repo_git),
-#                 collect_github_messages.si(repo.repo_git),process_pull_request_files.si(repo.repo_git), process_pull_request_commits.si(repo.repo_git))
-
-#             repo_chain = chain(first_tasks_repo,second_tasks_repo)
-#             issue_dependent_tasks.append(repo_chain)
-
-#         repo_task_group = group(
-#             *repo_info_tasks,
-#             chain(group(*issue_dependent_tasks),process_contributors.si()),
-#             generate_facade_chain(logger),
-#             collect_releases.si()
-#         )
-    
-#     chain(repo_task_group, refresh_materialized_views.si()).apply_async()
-
-# #### End of section from traffic metric merge that may need to be changed
-
-
     primary_repo_jobs = group(
         collect_issues.si(repo_git),
         collect_pull_requests.si(repo_git)


### PR DESCRIPTION
**Description**
- Move the grab_committers task out of the facade collection hook. This is done because it was slowing down the rest of facade collection and because the task doesn't rely on commit data. The facade collection hook should really be reserved for tasks that directly relate to facade commit data.
- Improve grab_committers task to use GithubTaskManifest instead of GithubTaskSession which is in the process of being deprecated. 
- Improve grab_committers task to use new retrieve_dict_from_endpoint method instead of request_dict_from_endpoint method which is in the process of being deprecated.
- Create retrieve_dict_from_endpoint method that is more uniform with the rest of how augur now paginates the github REST api. This method is better because it checks the validity of returned data the same way as everything else instead of the older way that request_dict_from_endpoint does. The new method is modeled after the retrieve_data method used in pagination but for the purpose of single data retrieval instead which is used throughout contributor resolution. 


**Signed commits**
- [x] Yes, I signed my commits.
