### PR TITLE
Fix duplicate repos caused by mixed casing

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -969,6 +969,8 @@ class Repo(Base):
         if not RepoGroup.is_valid_repo_group_id(session, repo_group_id):
             return None
         
+        url = url.lower()
+        
         owner, repo = Repo.parse_github_repo_url(url)
         if not owner or not repo:
             return None


### PR DESCRIPTION
**Description**
- Made all the repo urls that get added to the database lowercase, so that mixed casing doesn't allow duplicate repos to be added

**Signed commits**
- [X] Yes, I signed my commits.
