### PR TITLE
Remove stack trace print from invalid command output

### DIFF
--- a/augur/application/cli/_multicommand.py
+++ b/augur/application/cli/_multicommand.py
@@ -28,9 +28,7 @@ class AugurMultiCommand(click.MultiCommand):
             module = importlib.import_module('.' + name, 'augur.application.cli')
             return module.cli
         except ModuleNotFoundError:
-            print(f"Error")
-            print(traceback.format_exc())
-  
+            pass
 
 @click.command(cls=AugurMultiCommand, context_settings=CONTEXT_SETTINGS)
 @click.pass_context


### PR DESCRIPTION
**Description**
- Changed the invalid command exception, so that it no longer prints out the entire stack trace when a user enters an invalid command

**Signed commits**
- [X] Yes, I signed my commits.
