### PR TITLE
Add orgs and repos at same time

### DIFF
--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -16,23 +16,27 @@ def cache(file=None):
 @login_required
 def av_add_user_repo():
 
-    urls = request.form.get('url').split(",")
+    urls = request.form.get('urls')
     group = request.form.get("group_name")
 
-    print(urls)
-
     if not urls:
-        return jsonify({"status": "No URLs provided"}), 400
+        flash("No URLs provided")
+        return redirect(url_for("user_settings") + "?section=tracker")
+    
+    # split on commas, carriage returns, and whitespace
+    urls = re.split(r'[,\r\s]+', urls)
+
+    # Remove duplicates and empty strings
+    # passing None to fitler removes any 
+    # values that don't evaluate to true
+    urls = list(filter(None, set(urls)))
 
     if group == "None":
         group = current_user.login_name + "_default"
 
     added_orgs = 0
     added_repos = 0
-
     for url in urls:
-
-        url = url.strip()
 
         if Repo.parse_github_org_url(url):
             added = current_user.add_org(group, url)
@@ -51,7 +55,6 @@ def av_add_user_repo():
     else:
         flash(f"Successfully added {added_repos} repos and {added_orgs} orgs")
             
-    
     return redirect(url_for("user_settings") + "?section=tracker")
 
 @app.route('/account/update', methods = ['POST'])

--- a/augur/templates/settings.j2
+++ b/augur/templates/settings.j2
@@ -176,7 +176,7 @@
                                     <form id="user_repo_form" class="form-inline user-settings-form" method="POST" action="{{ url_for('av_add_user_repo') }}">
                                         <div class="form-group">
                                             <label for="repo_url">New Repo or Organization URL</label>
-                                            <input type="text" id="repo_url" name="url" class="form-control" required>
+                                            <textarea id="repo_url" name="urls" class="form-control" rows="4" required></textarea>
                                         </div>
                                         <br>
                                         <div class="form-group">

--- a/augur/templates/settings.j2
+++ b/augur/templates/settings.j2
@@ -176,7 +176,7 @@
                                     <form id="user_repo_form" class="form-inline user-settings-form" method="POST" action="{{ url_for('av_add_user_repo') }}">
                                         <div class="form-group">
                                             <label for="repo_url">New Repo or Organization URL</label>
-                                            <textarea id="repo_url" name="urls" class="form-control" rows="4" required></textarea>
+                                            <textarea id="repo_url" name="urls" class="form-control" rows="4" placeholder="{org}/{repo}&#10{org}&#10https://github.com/{org}/{repo}/&#10https://github.com/{org}/" required></textarea>
                                         </div>
                                         <br>
                                         <div class="form-group">


### PR DESCRIPTION
**Description**
- Added the ability to add repos and orgs at the same time on the frontend
- Added the ability to add orgs by simply specifying the name, and repos by entering {org_name}/{repo_name}
- The text input has been changed to a text area to allow for multiline input
- The orgs and repos can be delimited by carriage returns, commas, spaces


**Signed commits**
- [X] Yes, I signed my commits.
