### PR TITLE
Fix celery error when augur is stopped without collection running

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -154,10 +154,12 @@ def start(disable_collection, development, port):
             logger.info("Shutting down celery beat process")
             celery_beat_process.terminate()
 
-        try:
-            cleanup_after_collection_halt(logger)
-        except RedisConnectionError:
-            pass
+        if not disable_collection:
+
+            try:
+                cleanup_after_collection_halt(logger)
+            except RedisConnectionError:
+                pass
 
 
 @cli.command('stop')


### PR DESCRIPTION
**Description**
- Running `augur backend stop`, `augur backend kill` or `cntrl-C` on an instance of augur that had collection disabled was causing an error because it was trying to purge the celery queue even though celery was never started. 
- To fix this I added a check if collection is disabled when running `cntrl-C`, and for `stop` and `kill` I added a check to see if there are any celery processes running before purging the queues

This pr fixes issue #2299 

**Signed commits**
- [X] Yes, I signed my commits.