### PR TITLE
Remove '/' from end of url when inserting repo

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -981,6 +981,9 @@ class Repo(Base):
         if not RepoGroup.is_valid_repo_group_id(session, repo_group_id):
             return None
         
+        if url.endswith("/"):
+            url = url[:-1]
+        
         url = url.lower()
         
         owner, repo = Repo.parse_github_repo_url(url)


### PR DESCRIPTION
**Description**
- The `Repo.insert()` method takes a url to add to the repo table. Sometimes this url has a `/` at the end and sometimes it doesn't (based on what the user puts in). This means there can be a duplicate repo in the table (one with slash an one without). With this I simply added a 2 lines to remove the forward slash if it exists.


**Signed commits**
- [X] Yes, I signed my commits.