### PR TITLE
Fix pr review message error

### DIFF
--- a/augur/application/db/data_parse.py
+++ b/augur/application/db/data_parse.py
@@ -427,6 +427,9 @@ def extract_needed_message_data(comment: dict, platform_id: int, repo_id: int, t
 
 def extract_needed_contributor_data(contributor, tool_source, tool_version, data_source):
 
+    if not contributor:
+        return None
+
     cntrb_id = GithubUUID()   
     cntrb_id["user"] = contributor["id"]
 

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -172,7 +172,9 @@ def process_messages(messages, task_name, repo_id, logger, augur_db):
                             extract_needed_message_data(message, platform_id, repo_id, tool_source, tool_version, data_source)
             )
 
-            contributors.append(contributor)
+            if contributor is not None:
+
+                contributors.append(contributor)
 
     contributors = remove_duplicate_dicts(contributors)
 
@@ -221,10 +223,13 @@ def is_issue_message(html_url):
 
 def process_github_comment_contributors(message, tool_source, tool_version, data_source):
 
-    message_cntrb = extract_needed_contributor_data(message["user"], tool_source, tool_version, data_source)
-    message["cntrb_id"] = message_cntrb["cntrb_id"]
+    contributor = extract_needed_contributor_data(message["user"], tool_source, tool_version, data_source)
+    if contributor:
+        message["cntrb_id"] = contributor["cntrb_id"]
+    else:
+        message["cntrb_id"] = None
 
-    return message, message_cntrb
+    return message, contributor
 
 
 # this function finds a dict in a list of dicts. 

--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -239,7 +239,10 @@ def collect_pull_request_review_comments(repo_git: str) -> None:
 
         contributors = []
         for comment in all_raw_pr_review_messages:
-            contributors.append(process_github_comment_contributors(comment, tool_source, tool_version, data_source))
+            
+            _, contributor = process_github_comment_contributors(comment, tool_source, tool_version, data_source)
+            if contributor is not None:
+                contributors.append()
 
         logger.info(f"{owner}/{repo} Pr review messages: Inserting {len(contributors)} contributors")
         augur_db.insert_data(contributors, Contributor, ["cntrb_id"])


### PR DESCRIPTION
**Description**
- Fix contributor NoneType error that is shown below

This PR fixes #
`Traceback (most recent call last):
  File "/home/sean/github/rh-k12/augur/tasks/github/pull_requests/tasks.py", line 242, in collect_pull_request_review_comments
    contributors.append(process_github_comment_contributors(comment, tool_source, tool_version, data_source))
  File "/home/sean/github/rh-k12/augur/tasks/github/messages/tasks.py", line 224, in process_github_comment_contributors
    message_cntrb = extract_needed_contributor_data(message["user"], tool_source, tool_version, data_source)
  File "/home/sean/github/rh-k12/augur/application/db/data_parse.py", line 431, in extract_needed_contributor_data
    cntrb_id["user"] = contributor["id"]
TypeError: 'NoneType' object is not subscriptable`

**Signed commits**
- [X] Yes, I signed my commits.
