### PR TITLE
Update contributor logic to be more testable and uniform

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -975,8 +975,6 @@ class Repo(Base):
             If repo row exists then it will update the repo_group_id if param repo_group_id is not a default. If it does not exist is will simply insert the repo.
         """
 
-        if not isinstance(url, str) or not isinstance(repo_group_id, int) or not isinstance(tool_source, str):
-
         if not isinstance(url, str) or not isinstance(repo_group_id, int) or not isinstance(tool_source, str) or not isinstance(repo_type, str):
             return None
 

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -4,8 +4,8 @@ import logging
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.data_parse import *
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
-from augur.tasks.github.util.github_task_session import GithubTaskSession
+from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api, retrieve_dict_from_endpoint
+from augur.tasks.github.util.github_task_session import GithubTaskSession, GithubTaskManifest
 from augur.tasks.github.util.util import get_owner_repo
 from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
@@ -17,7 +17,7 @@ from augur.tasks.git.util.facade_worker.facade_worker.facade00mainprogram import
 from sqlalchemy.orm.exc import NoResultFound
 
 
-def process_commit_metadata(session,contributorQueue,repo_id):
+def process_commit_metadata(logger,db,auth,contributorQueue,repo_id,platform_id):
 
     for contributor in contributorQueue:
         # Get the email from the commit data
@@ -28,11 +28,11 @@ def process_commit_metadata(session,contributorQueue,repo_id):
         # check the email to see if it already exists in contributor_aliases
         
         # Look up email to see if resolved
-        query = session.query(ContributorsAlias).filter_by(alias_email=email)
+        query = db.query(ContributorsAlias).filter_by(alias_email=email)
         alias_table_data = execute_session_query(query, 'all')
         if len(alias_table_data) >= 1:
             # Move on if email resolved
-            session.logger.info(
+            logger.info(
                 f"Email {email} has been resolved earlier.")
 
             continue
@@ -40,46 +40,46 @@ def process_commit_metadata(session,contributorQueue,repo_id):
         #Check the unresolved_commits table to avoid hitting endpoints that we know don't have relevant data needlessly
         
             
-        query = session.query(UnresolvedCommitEmail).filter_by(name=name)
+        query = db.query(UnresolvedCommitEmail).filter_by(name=name)
         unresolved_query_result = execute_session_query(query, 'all')
 
         if len(unresolved_query_result) >= 1:
 
-            session.logger.info(f"Commit data with email {email} has been unresolved in the past, skipping...")
+            logger.info(f"Commit data with email {email} has been unresolved in the past, skipping...")
             continue
 
         login = None
     
         #Check the contributors table for a login for the given name
 
-        query = session.query(Contributor).filter_by(cntrb_full_name=name)
+        query = db.query(Contributor).filter_by(cntrb_full_name=name)
         contributors_with_matching_name = execute_session_query(query, 'first')
 
         if not contributors_with_matching_name:
-            session.logger.debug("Failed local login lookup")
+            logger.debug("Failed local login lookup")
         else:
             login = contributors_with_matching_name.gh_login
         
 
         # Try to get the login from the commit sha
         if login == None or login == "":
-            login = get_login_with_commit_hash(session,contributor, repo_id)
+            login = get_login_with_commit_hash(logger,db,auth,contributor, repo_id)
     
         if login == None or login == "":
-            session.logger.info("Failed to get login from commit hash")
+            logger.info("Failed to get login from commit hash")
             # Try to get the login from supplemental data if not found with the commit hash
-            login = get_login_with_supplemental_data(session,contributor)
+            login = get_login_with_supplemental_data(logger, db, auth,contributor)
     
         if login == None or login == "":
-            session.logger.error("Failed to get login from supplemental data!")
+            logger.error("Failed to get login from supplemental data!")
             continue
 
         url = ("https://api.github.com/users/" + login)
 
-        user_data = request_dict_from_endpoint(session,url)
+        user_data, _ = retrieve_dict_from_endpoint(logger, auth, url)
 
         if user_data == None:
-            session.logger.warning(
+            logger.warning(
                 f"user_data was unable to be reached. Skipping...")
             continue
 
@@ -91,11 +91,9 @@ def process_commit_metadata(session,contributorQueue,repo_id):
         name_field = contributor['commit_name'] if 'commit_name' in contributor else contributor['name']
 
 
-        #cntrb_id = AugurUUID(session.platform_id,user_data['id']).to_UUID()
-
         cntrb_id = GithubUUID()
         cntrb_id["user"] = int(user_data['id'])
-        cntrb_id["platform"] = session.platform_id
+        cntrb_id["platform"] = platform_id
 
         # try to add contributor to database
         cntrb = {
@@ -133,23 +131,21 @@ def process_commit_metadata(session,contributorQueue,repo_id):
             #"data_source": interface.data_source
         }
 
-        #session.logger.info(f"{cntrb}")
-
 
         
         #Executes an upsert with sqlalchemy 
         cntrb_natural_keys = ['cntrb_login']
         
-        session.insert_data(cntrb,Contributor,cntrb_natural_keys)
+        db.insert_data(cntrb,Contributor,cntrb_natural_keys)
 
 
         try:
             # Update alias after insertion. Insertion needs to happen first so we can get the autoincrementkey
-            insert_alias(session,cntrb, emailFromCommitData)
+            insert_alias(logger, db,cntrb, emailFromCommitData)
         except LookupError as e:
-            session.logger.info(
+            logger.info(
                 ''.join(traceback.format_exception(None, e, e.__traceback__)))
-            session.logger.info(
+            logger.info(
                 f"Contributor id not able to be found in database despite the user_id existing. Something very wrong is happening. Error: {e}")
             return 
         
@@ -166,15 +162,12 @@ def process_commit_metadata(session,contributorQueue,repo_id):
             WHERE email='{}'
         """.format(escapedEmail))
 
-        session.logger.info(f"Updating now resolved email {email}")
+        logger.info(f"Updating now resolved email {email}")
 
         try:
-            #interface.db.execute(query)
-            #session.query(UnresolvedCommitEmail).filter(UnresolvedCommitEmail.email == email).delete()
-            #session.commit()
-            session.execute_sql(query)
+            db.execute_sql(query)
         except Exception as e:
-            session.logger.info(
+            logger.info(
                 f"Deleting now resolved email failed with error: {e}")
             raise e
     
@@ -213,13 +206,13 @@ def insert_facade_contributors(repo_id):
 
     logger = logging.getLogger(insert_facade_contributors.__name__)
 
-    with GithubTaskSession(logger, engine) as session:
+    with GithubTaskManifest(logger) as manifest:
         
 
         # Get all of the commit data's emails and names from the commit table that do not appear
         # in the contributors table or the contributors_aliases table.
 
-        session.logger.info(
+        manifest.logger.info(
         "Beginning process to insert contributors from facade commits for repo w entry info: {}\n".format(repo_id))
         new_contrib_sql = s.sql.text("""
                 SELECT DISTINCT
@@ -259,7 +252,7 @@ def insert_facade_contributors(repo_id):
         """).bindparams(repo_id=repo_id)
 
         #Execute statement with session.
-        result = session.execute_sql(new_contrib_sql).fetchall()
+        result = manifest.augur_db.execute_sql(new_contrib_sql).fetchall()
         new_contribs = [dict(zip(row.keys(), row)) for row in result]
 
         #print(new_contribs)
@@ -269,9 +262,9 @@ def insert_facade_contributors(repo_id):
 
 
 
-        process_commit_metadata(session,list(new_contribs),repo_id)
+        process_commit_metadata(manifest.logger,manifest.augur_db,manifest.key_auth,list(new_contribs),repo_id,manifest.platform_id)
 
-        session.logger.debug("DEBUG: Got through the new_contribs")
+        manifest.logger.debug("DEBUG: Got through the new_contribs")
     
 
     with FacadeSession(logger) as session:

--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -242,7 +242,7 @@ def collect_pull_request_review_comments(repo_git: str) -> None:
             
             _, contributor = process_github_comment_contributors(comment, tool_source, tool_version, data_source)
             if contributor is not None:
-                contributors.append()
+                contributors.append(contributor)
 
         logger.info(f"{owner}/{repo} Pr review messages: Inserting {len(contributors)} contributors")
         augur_db.insert_data(contributors, Contributor, ["cntrb_id"])


### PR DESCRIPTION
**Description**
Update contributor resolution logic to be cleaner and more testable. Also now uses less deprecated functions overall. GithubTaskSession is no longer used now in favor of a GithubTaskManifest that passes its attributes. 


