### PR TITLE
Add ability to add all of a users repos and update CLI with new features

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -975,8 +975,6 @@ class Repo(Base):
             If repo row exists then it will update the repo_group_id if param repo_group_id is not a default. If it does not exist is will simply insert the repo.
         """
 
-        if not isinstance(url, str) or not isinstance(repo_group_id, int) or not isinstance(tool_source, str):
-
         if not isinstance(url, str) or not isinstance(repo_group_id, int) or not isinstance(tool_source, str) or not isinstance(repo_type, str):
             return None
 

--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -925,13 +925,8 @@ class Repo(Base):
         Returns:
             Tuple of owner and repo. Or a tuple of None and None if the url is invalid.
         """
-
-        if url.endswith(".github") or url.endswith(".github.io") or url.endswith(".js"):
-
-            result = re.search(r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$", url)
-        else:
-
-            result = re.search(r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _]+)(.git)?\/?$", url)
+        
+        result = re.search(r"https?:\/\/github\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$", url)
 
         if not result:
             return None, None

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -20,7 +20,7 @@ from augur.application.db.models.base import Base
 FRONTEND_REPO_GROUP_NAME = "Frontend Repos"
 logger = logging.getLogger(__name__)
 
-def retrieve_org_repos(session, url: str) -> List[str]:
+def retrieve_owner_repos(session, owner: str) -> List[str]:
     """Get the repos for an org.
 
     Note:
@@ -32,21 +32,33 @@ def retrieve_org_repos(session, url: str) -> List[str]:
     Returns
         List of valid repo urls or empty list if invalid org
     """
-    from augur.tasks.github.util.github_paginator import GithubPaginator
+    from augur.tasks.github.util.github_paginator import GithubPaginator, retrieve_dict_from_endpoint
 
-    ORG_REPOS_ENDPOINT = "https://api.github.com/orgs/{}/repos?per_page=100"
-
-    owner = Repo.parse_github_org_url(url)
-    if not owner:
-        return None, {"status": "Invalid owner url"}
-
-    url = ORG_REPOS_ENDPOINT.format(owner)
-
-    repos = []
-
+    OWNER_INFO_ENDPOINT = f"https://api.github.com/users/{owner}"
+    ORG_REPOS_ENDPOINT = f"https://api.github.com/orgs/{owner}/repos?per_page=100"
+    USER_REPOS_ENDPOINT = f"https://api.github.com/users/{owner}/repos?per_page=100"
+    
     if not session.oauths.list_of_keys:
         return None, {"status": "No valid github api keys to retrieve data with"}
+    
+    # determine whether the owner is a user or an organization
+    data, _ = retrieve_dict_from_endpoint(logger, session.oauths, OWNER_INFO_ENDPOINT)
+    if not data:
+        return None, {"status": "Invalid owner"}
+    
+    owner_type = data["type"]
 
+
+    if owner_type == "User":
+        url = USER_REPOS_ENDPOINT
+    elif owner_type == "Organization":
+        url = ORG_REPOS_ENDPOINT
+    else:
+        return None, {"status": f"Invalid owner type: {owner_type}"}
+    
+    
+    # collect repo urls for the given owner
+    repos = []
     for page_data, page in GithubPaginator(url, session.oauths, logger).iter_pages():
 
         if page_data is None:
@@ -56,7 +68,7 @@ def retrieve_org_repos(session, url: str) -> List[str]:
 
     repo_urls = [repo["html_url"] for repo in repos]
 
-    return repo_urls, {"status": "success", "owner_type": "Organization"}
+    return repo_urls, {"status": "success", "owner_type": owner_type}
 
     
 metadata = Base.metadata
@@ -798,30 +810,32 @@ class UserRepo(Base):
         group_id = UserGroup.convert_group_name_to_id(session, user_id, group_name)
         if group_id is None:
             return False, {"status": "Invalid group name"}
+        
+        # parse github owner url to get owner name
+        owner = Repo.parse_github_org_url(url)
+        if not owner:
+            return False, {"status": "Invalid owner url"}
 
-        result = retrieve_org_repos(session, url)
+        result = retrieve_owner_repos(session, owner)
+
+        # if the result is returns None or []
         if not result[0]:
             return False, result[1]
+        
         repos = result[0]
         type = result[1]["owner_type"]
         
-
-        # parse github org url to get org name
-        org_name = Repo.parse_github_org_url(url)
-        if not org_name:
-            return False, {"status": "Invalid org url"}
-        
         # get repo group if it exists
         try:
-            repo_group = RepoGroup.get_by_name(session, org_name)
+            repo_group = RepoGroup.get_by_name(session, owner)
         except MultipleResultsFound:
-            print("Error: Multiple Repo Groups with the same name found with name: {}".format(org_name))
+            print("Error: Multiple Repo Groups with the same name found with name: {}".format(owner))
 
             return False, {"status": "Multiple Repo Groups with the same name found"}
 
         # if it doesn't exist create one
         if not repo_group:
-            repo_group = RepoGroup(rg_name=org_name, rg_description="", rg_website="", rg_recache=0, rg_type="Unknown",
+            repo_group = RepoGroup(rg_name=owner, rg_description="", rg_website="", rg_recache=0, rg_type="Unknown",
                     tool_source="Loaded by user", tool_version="1.0", data_source="Git")
             session.add(repo_group)
             session.commit()
@@ -844,7 +858,7 @@ class UserRepo(Base):
         # is a part of the org and existed before org added
         update_stmt = (
             update(Repo)
-            .where(Repo.repo_path == f"github.com/{org_name}/")
+            .where(Repo.repo_path == f"github.com/{owner}/")
             .where(Repo.repo_group_id != repo_group_id)
             .values(repo_group_id=repo_group_id)
         )

--- a/augur/tasks/github/util/github_paginator.py
+++ b/augur/tasks/github/util/github_paginator.py
@@ -587,7 +587,7 @@ def retrieve_dict_from_endpoint(logger, key_auth, url, timeout_wait=10) -> Tuple
         # if the data is a list, then return it and the response
         if isinstance(page_data, list):
             logger.warning("Wrong type returned, trying again...")
-            logger.info(f"Returned list: {response_data}")
+            logger.info(f"Returned list: {page_data}")
 
         # if the data is a dict then call process_dict_response, and 
         elif isinstance(page_data, dict):

--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -73,29 +73,44 @@ class RepoLoadController:
         self.session = gh_session
 
 
-    def add_cli_repo(self, repo_data: Dict[str, Any], valid_repo=False):
+    def add_cli_repo(self, repo_data: Dict[str, Any], from_org_list=False, repo_type=None):
         """Add list of repos to specified repo_groups
 
         Args:
             url_data: dict with repo_group_id and repo urls
         """
 
+        # if the repo is from an org list then 
+        # the repo type must be passed in
+        # so we don't have to hit an endpoint 
+        # for every repo to get its type
+        if from_org_list and not repo_type:
+            return False, {"status": "Repo type must be passed if the repo is from an organization's list of repos"}
+
         url = repo_data["url"]
         repo_group_id = repo_data["repo_group_id"]
 
-        if valid_repo or Repo.is_valid_github_repo(self.session, url)[0]:
+        # if it is from not from an org list then we need to check its validity, and get the repo type
+        if not from_org_list:
+            result = Repo.is_valid_github_repo(self.session, url)
+            if not result[0]:
+                return False, {"status": result[1]["status"], "repo_url": url}
+            
+            repo_type = result[1]["repo_type"]
 
-            # if the repo doesn't exist it adds it
-            # if the repo does exist it updates the repo_group_id
-            repo_id = Repo.insert(self.session, url, repo_group_id, "CLI")
 
-            if not repo_id:
-                logger.warning(f"Invalid repo group id specified for {url}, skipping.")
-                return {"status": f"Invalid repo group id specified for {url}, skipping."}
+        # if the repo doesn't exist it adds it
+        repo_id = Repo.insert(self.session, url, repo_group_id, "CLI", repo_type)
 
-            UserRepo.insert(self.session, repo_id)
+        if not repo_id:
+            logger.warning(f"Invalid repo group id specified for {url}, skipping.")
+            return False, {"status": f"Invalid repo group id specified for {url}, skipping."}
 
-            CollectionStatus.insert(self.session, repo_id)
+        UserRepo.insert(self.session, repo_id)
+
+        CollectionStatus.insert(self.session, repo_id)
+
+        return True, {"status": "Repo added", "repo_url": url}
 
     def add_cli_org(self, org_name):
         """Add list of orgs and their repos to specified repo_groups
@@ -104,7 +119,9 @@ class RepoLoadController:
             org_data: dict with repo_group_id and org urls
         """
         
-        repos = retrieve_owner_repos(self.session, org_name)[0]
+        result = retrieve_owner_repos(self.session, org_name)
+        repos = result[0]
+        type = result[1]["owner_type"]
         if not repos:
             print(
                 f"No organization with name {org_name} could be found")
@@ -125,12 +142,13 @@ class RepoLoadController:
         self.session.add(rg)
         self.session.commit()
         repo_group_id = rg.repo_group_id
-        logger.info(f"{org_name} repo group created")
+        print(f"{org_name} repo group created")
 
         for repo_url in repos:
-            logger.info(
-                f"Adding {repo_url}")
-            self.add_cli_repo({"url": repo_url, "repo_group_id": repo_group_id}, valid_repo=True)
+            print(f"Adding {repo_url}")
+            result, status = self.add_cli_repo({"url": repo_url, "repo_group_id": repo_group_id}, from_org_list=True, repo_type=type)
+            if not result:
+                print(status["status"])
 
         return {"status": "Org added"}
 

--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -9,7 +9,7 @@ from typing import List, Any, Dict
 
 from augur.application.db.engine import DatabaseEngine
 from augur.application.db.models import Repo, UserRepo, RepoGroup, UserGroup, User, CollectionStatus
-from augur.application.db.models.augur_operations import retrieve_org_repos
+from augur.application.db.models.augur_operations import retrieve_owner_repos
 from augur.application.db.util import execute_session_query
 
 
@@ -103,9 +103,8 @@ class RepoLoadController:
         Args:
             org_data: dict with repo_group_id and org urls
         """
-
-        url = f"https://github.com/{org_name}"
-        repos = retrieve_org_repos(self.session, url)[0]
+        
+        repos = retrieve_owner_repos(self.session, org_name)[0]
         if not repos:
             print(
                 f"No organization with name {org_name} could be found")


### PR DESCRIPTION
**Description**
- You can now add all of a users repos at once instead of only being add orgs.
- For example if I wanted to add all my public repos. I can now put `ABrain7710` in the text box on the frontend, hit add, and all of my public repos will be added.
- This also updates the CLI so it inserts the `repo_type` when adding repos
- The regex that parses the repo url has been changed to allow periods anywhere in the repo name. At first I thought only certain extensions were allowed at the end of repo names, but after coming across a few weird ones. I came to the conclusion that they are allowed anywhere in the repo name when I was able to create a repo with the name `a.b.c.d.e`

**Signed commits**
- [X] Yes, I signed my commits.
