### PR TITLE
Fix seed data so repo path and repo name are correct

### DIFF
--- a/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
+++ b/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import text
 import re
+from augur.application.db.models import Repo
 
 
 # revision identifiers, used by Alembic.
@@ -26,12 +27,13 @@ def upgrade():
     if result:
 
         for row in result:
-            regex = re.search(r"https:\/\/(github\.com\/[A-Za-z0-9 \- _]+\/)([A-Za-z0-9 \- _ .]+)$", row.repo_git)
-            if not regex:
+
+            owner_name, repo_name = Repo.parse_github_repo_url(row.repo_git)
+            if not owner_name or not repo_name:
                 continue
-            
-            repo_path = regex[0]
-            repo_name = regex[1]
+
+            repo_path = f"github.com/{owner_name}/"
+        
             conn.execute(text(f"""
                 UPDATE "repo"
                 SET repo_path=:path,repo_name=:name


### PR DESCRIPTION
**Description**
- The repo path and repo name are not correct in the seed data. I figured out that it was because the regex in the 7th migration was not capturing the repo path and repo name correctly, so I changed it to use the standard function that gets the repo owner and repo name. Then I constructed the repo path with the repo owner

**Signed commits**
- [X] Yes, I signed my commits.
