### PR TITLE
Stop facade being bottlenecked by core worker processes

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -106,12 +106,14 @@ def start(disable_collection, development, port):
             os.remove("celerybeat-schedule.db")
 
         scheduling_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency=1 -n scheduling:{uuid.uuid4().hex}@%h -Q scheduling"
-        core_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency=60 -n core:{uuid.uuid4().hex}@%h"
+        core_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency=45 -n core:{uuid.uuid4().hex}@%h"
         secondary_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency=10 -n secondary:{uuid.uuid4().hex}@%h -Q secondary"
-        
+        facade_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency=15 -n facade:{uuid.uuid4().hex}@%h -Q facade"
+
         scheduling_worker_process = subprocess.Popen(scheduling_worker.split(" "))
         core_worker_process = subprocess.Popen(core_worker.split(" "))
         secondary_worker_process = subprocess.Popen(secondary_worker.split(" "))
+        facade_worker_process = subprocess.Popen(facade_worker.split(" "))
 
         time.sleep(5)
 
@@ -148,6 +150,10 @@ def start(disable_collection, development, port):
         if secondary_worker_process:
             logger.info("Shutting down celery process: secondary")
             secondary_worker_process.terminate()
+        
+        if facade_worker_process:
+            logger.info("Shutting down celery process: facade")
+            facade_worker_process,terminate()
 
         if celery_beat_process:
             logger.info("Shutting down celery beat process")

--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -221,7 +221,7 @@ def clear_redis_caches():
     redis_connection.flushdb()
 
 def clear_all_message_queues(connection_string):
-    queues = ['celery','secondary','scheduling']
+    queues = ['celery','secondary','scheduling','facade']
 
     virtual_host_string = connection_string.split("/")[-1]
 

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -123,10 +123,14 @@ celery_app = Celery('tasks', broker=BROKER_URL, backend=BACKEND_URL, include=tas
 celery_app.conf.task_routes = {
     'augur.tasks.start_tasks.*': {'queue': 'scheduling'},
     'augur.tasks.util.collection_util.*': {'queue': 'scheduling'},
+    'augur.tasks.git.facade_tasks.*': {'queue': 'facade'},
+    'augur.tasks.github.facade_github.tasks.*': {'queue': 'facade'},
     'augur.tasks.github.pull_requests.commits_model.tasks.*': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.files_model.tasks.*': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.tasks.collect_pull_request_reviews': {'queue': 'secondary'},
-    'augur.tasks.git.dependency_tasks.tasks.process_ossf_scorecard_metrics': {'queue': 'secondary'}
+    'augur.tasks.git.dependency_tasks.tasks.process_ossf_scorecard_metrics': {'queue': 'secondary'},
+    'augur.tasks.git.dependency_tasks.tasks.process_dependency_metrics': {'queue': 'facade'},
+    'augur.tasks.git.dependency_libyear_tasks.tasks.process_libyear_dependency_metrics': {'queue': 'facade'}
 }
 
 #Setting to be able to see more detailed states of running tasks


### PR DESCRIPTION
**Description**
- Facade tasks should be placed in a separate pool of processes than the core tasks because a significant portion of the facade tasks do not require GitHub API calls to work. Before, the core tasks would hog all the processes because they were sleeping due to rate limit error handling.
- Create an extra celery worker to handle facade tasks along with a respective rabbitmq queue. 
- Amend function to clear rabbitmq queue to also now clear the new facade queue
- Amend celery routing to route all facade tasks to be routed to the facade worker. 

**Signed commits**
- [x] Yes, I signed my commits.
