### PR TITLE
Avoid import * from .init

### DIFF
--- a/augur/api/view/utils.py
+++ b/augur/api/view/utils.py
@@ -1,16 +1,13 @@
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
 from flask import render_template, flash, url_for, Flask
-from .init import *
 from .server import User
 from ..server import app, db_session
 from augur.application.config import AugurConfig
 import urllib.request, urllib.error, json, os, math, yaml, urllib3, time, logging, re
+from .init import logger, init_logging
 
 init_logging()
-
-from .init import logger
-
 config = AugurConfig(logger, db_session)
 
 def parse_url(url):


### PR DESCRIPTION
'import *' shouldn't be used, as that may import
variable and modules that overrides existing symbol, and have side effect. It also make harder to refactor the code.


**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->