### PR TITLE
Handle when repo has a dependency file that cannot be found

### DIFF
--- a/augur/tasks/git/dependency_tasks/dependency_util/dependency_calculator.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/dependency_calculator.py
@@ -56,6 +56,9 @@ def get_language_deps(path, language, name,logger):
 		except IsADirectoryError as e:
 			logger.error(f"Given file's path is a directory!\n file: {f}\n path: {path}\n Error: {e}")
 			return []
+		except FileNotFoundError as e:
+			logger.error(f"Given file not found!\n file: {f}\n path: {path}\n Error: {e}")
+			return []
 
 		if f_deps is None:
 			continue


### PR DESCRIPTION
**Description**
Handle edge case where repository finds a language file in the path listing via a regex query and is then unable to open that same file because of a *FileNotFoundError* exception. 

**Signed commits**
- [x] Yes, I signed my commits.
