### PR TITLE
Frontend groups view improvements

### DIFF
--- a/augur/api/gunicorn_conf.py
+++ b/augur/api/gunicorn_conf.py
@@ -3,6 +3,7 @@ import multiprocessing
 import logging
 import os
 from pathlib import Path
+from glob import glob
 import shutil
 
 from augur.application.db.session import DatabaseSession
@@ -23,6 +24,7 @@ with DatabaseSession(logger) as session:
     workers = multiprocessing.cpu_count() * 2 + 1
     umask = 0o007
     reload = True
+    reload_extra_files = glob(str(Path.cwd() / '**/*.j2'), recursive=True)
 
     # set the log location for gunicorn    
     logs_directory = augur_config.get_value('Logging', 'logs_directory')

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -455,13 +455,39 @@ class User(Base):
 
         return self.groups, {"status": "success"}
 
-    def get_group_names(self):
+    def get_group_names(self, search=None, reversed=False):
 
         user_groups = self.get_groups()[0]
 
-        group_names = [group.name for group in user_groups]
+        if search is None:
+            group_names = [group.name for group in user_groups]
+        else:
+            group_names = [group.name for group in user_groups if search.lower() in group.name.lower()]
+            
+        group_names.sort(reverse = reversed)
 
         return group_names, {"status": "success"}
+    
+    def get_groups_info(self, search=None, reversed=False, sort="group_name"):
+        (groups, result) = self.get_groups()
+
+        if search is not None:
+            groups = [group for group in groups if search.lower() in group.name.lower()]
+        
+        for group in groups:
+            group.count = self.get_group_repo_count(group.name)[0]
+        
+        def sorting_function(group):
+            if sort == "group_name":
+                return group.name
+            elif sort == "repo_count":
+                return group.count
+            elif sort == "favorited":
+                return group.favorited
+        
+        groups = sorted(groups, key=sorting_function, reverse=reversed)
+
+        return groups, {"status": "success"}
 
 
     def get_repos(self, page=0, page_size=25, sort="repo_id", direction="ASC", search=None):
@@ -482,22 +508,22 @@ class User(Base):
         return result
 
 
-    def get_group_repos(self, group_name, page=0, page_size=25, sort="repo_id", direction="ASC"):
+    def get_group_repos(self, group_name, page=0, page_size=25, sort="repo_id", direction="ASC", search=None):
         from augur.util.repo_load_controller import RepoLoadController
 
         with DatabaseSession(logger) as session:
-            result = RepoLoadController(session).paginate_repos("group", page, page_size, sort, direction, user=self, group_name=group_name)
+            result = RepoLoadController(session).paginate_repos("group", page, page_size, sort, direction, user=self, group_name=group_name, search=search)
 
         return result
 
 
-    def get_group_repo_count(self, group_name):
+    def get_group_repo_count(self, group_name, search = None):
         from augur.util.repo_load_controller import RepoLoadController
 
         with DatabaseSession(logger) as session:
             controller = RepoLoadController(session)
 
-        result = controller.get_repo_count(source="group", group_name=group_name, user=self)
+        result = controller.get_repo_count(source="group", group_name=group_name, user=self, search=search)
 
         return result
 

--- a/augur/templates/groups-table.j2
+++ b/augur/templates/groups-table.j2
@@ -1,20 +1,61 @@
-{#% if groups %}
+{% if groups %}
+<!-- Top pagination menu start -->
+<h1>Your Groups</h1>
+<nav aria-label="Group pagination menu" class="overflow-auto">
+    <ul class="pagination">
+        <li class="page-item {% if activePage == 0 %} disabled {% else %} w3-hover-purple {% endif %}">
+            <a class="page-link" href="{{ url_for(PS, q=query_key, p=(activePage - 1), s=sorting, r=reverse, group=group)}}" {% if activePage == 0 %} tabindex="-1" {% endif %}>Previous</a>
+        </li>
+        {% for page in range(0, pages|int + 1) %}
+        <li class="page-item">
+            <a class="page-link {% if page == activePage %} paginationActive {% else %} w3-hover-blue {% endif %}" href="{{ url_for(PS, q=query_key, p=page, s=sorting, r=reverse, group=group)}}">{{page + 1}}</a>
+        </li>
+        {% endfor %}
+        <li class="page-item {% if activePage == pages|int %} disabled {% endif %}">
+            <a class="page-link" href="{{ url_for(PS, q=query_key, p=(activePage + 1), s=sorting, r=reverse, group=group)}}" {% if activePage == pages|int %} tabindex="-1" {% endif %}>Next</a>
+        </li>
+    </ul>
+</nav>
+<!-- Table start -->
+{# Create the header row for the repo table:
+    Here we dynamically generate the header row by defining a dictionary list
+    which contains the titles of each column, accompanied by an optional "key"
+    item. If a column definition contains a "key" item, that column is assumed
+    to be sortable, sorting links for that data are generated using the given
+    key. It is done this way because the client does not receive the full data
+    each time they load the page, and instead the server sorts the full data.
+#}
+{# "title" : "Group", "key" : "rg_name"}, #}
+    {%- set tableHeaders =
+    [{"title" : "#"},
+    {"title" : "Group Name", "key" : "group_name"},
+    {"title" : "Repo Count", "key": "repo_count"},
+    {"title" : "Favorited", "key" : "favorited"}] -%}
     <div class="rounded display-table w3-animate-opacity">
         <table class="table table-striped table-bordered">
             <thead>
                 <tr>
-                    <th scope="col">#</th>
-                    <th scope="col">Group Name</th>
-                    <th scope="col">Data Collectio</th>
+                {%- for header in tableHeaders -%}
+                {% if header.key %}
+                    {%- if sorting == header.key -%}
+                        {%- set sorting_link = url_for(PS, q=query_key, p=activePage, s=header.key, r= not reverse) -%}
+                    {%- else -%}
+                        {%- set sorting_link = url_for(PS, q=query_key, p=activePage, s=header.key) -%}
+                    {%- endif -%}
+                <th scope="col"><a class="sorting-link" href="{{ sorting_link }}"> {{ header.title }}
+                    {%- if sorting == header.key and reverse %} ▲ {% elif sorting == header.key %} ▼ {% endif %}</a></th>
+                {% else -%}
+                <th scope="col">{{ header.title }}</th>
+                {% endif %} {%- endfor -%}
                 </tr>
             </thead>
             <tbody>
         {% for group in groups %}
                 <tr>
                     <th scope="row">{{loop.index}}</th>
-                    <td><a href="{{ url_for('repo_groups_view', group=group.repo_group_id) }}">{{ group.name }}</a></td>
-                    <td>{{ group.data_collection_date }}</td>
-                    <td>TODO</td>
+                    <td><a href="{{ url_for('user_group_view', group=group.name) }}">{{ group.name }}</a></td>
+                    <td>{{ group.count }}</td>
+                    <td><i onclick="toggleFavorite(this, '{{ group.name }}')" class="bi {% if group.favorited %} bi-star-fill {% else %} bi-star {% endif %} cursor-pointer"></i></td>
                 </tr>
         {% endfor %}
             </tbody>
@@ -24,4 +65,21 @@
     <h1>Your search did not match any results</h1>
 {% else %}
     <h1>Unable to load group information</h1>
-{% endif %#}
+{% endif %}
+<script>
+    var toggleFavorite = function(button, group) {
+        fetch("{{ url_for('toggle_user_group_favorite') }}?group_name=" + group)
+            .then((response) => response.json())
+            .then((data) => {
+                if (data.status == "Success") {
+                    if (button.classList.contains("bi-star-fill")) {
+                        button.classList.remove("bi-star-fill");
+                        button.classList.add("bi-star");
+                    } else {
+                        button.classList.remove("bi-star");
+                        button.classList.add("bi-star-fill");
+                    }
+                }
+            });
+    }
+</script>

--- a/augur/templates/navbar.j2
+++ b/augur/templates/navbar.j2
@@ -28,9 +28,13 @@
                 </li>
                 {% else %}
                 <li class="nav-item">
-                    <a class="nav-link active" aria-current="page" href="{{ url_for('user_login') }}">Login</a>
+                    <a class="nav-link" aria-current="page" href="{{ url_for('user_login') }}">Login</a>
                 </li>
                 {% endif %}
+
+                <li class="nav-item">
+                    <a class="nav-link {% if title == 'Groups' %} active {% endif %}" aria-current="page" href="{{ url_for('user_groups_view') }}">Groups</a>
+                </li>
 
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle {% if title == 'Repos' %} active {% endif %}" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/augur/templates/settings.j2
+++ b/augur/templates/settings.j2
@@ -146,7 +146,7 @@
                                             <tbody>
                                                 {% for group in groups %}
                                                 <tr>
-                                                    <th scope="row"><a href="{{ url_for('user_group_view') }}?group={{ group.name }}">{{ group.name }}</a></th>
+                                                    <th scope="row"><a href="{{ url_for('user_group_view', group=group.name) }}">{{ group.name }}</a></th>
                                                     <td>{{ group.repos | length }}</td>
                                                     <td><i onclick="toggleFavorite(this, '{{ group.name }}')" class="bi {% if group.favorited %} bi-star-fill {% else %} bi-star {% endif %} cursor-pointer"></i></td>
                                                     <td><button class="btn btn-outline-primary btn-sm" onclick="delgroup(this, '{{ group.name }}')">Delete</button></td>

--- a/augur/templates/user-group-repos-table.j2
+++ b/augur/templates/user-group-repos-table.j2
@@ -1,18 +1,18 @@
 {% if repos %}
 <!-- Top pagination menu start -->
-<h1>{{ group }}</h1>
+<h1>Group: {{ group }}</h1>
 <nav aria-label="Repository pagination menu" class="overflow-auto">
     <ul class="pagination">
         <li class="page-item {% if activePage == 0 %} disabled {% else %} w3-hover-purple {% endif %}">
-            <a class="page-link" href="{{ url_for(PS, q=query_key, p=(activePage - 1), s=sorting, r=reverse, group=group)}}" {% if activePage == 0 %} tabindex="-1" {% endif %}>Previous</a>
+            <a class="page-link" href="{{ url_for(PS, q=query_key, p=(activePage - 1), s=sorting, r=reverse, group = group)}}" {% if activePage == 0 %} tabindex="-1" {% endif %}>Previous</a>
         </li>
         {% for page in range(0, pages|int + 1) %}
         <li class="page-item">
-            <a class="page-link {% if page == activePage %} paginationActive {% else %} w3-hover-blue {% endif %}" href="{{ url_for(PS, q=query_key, p=page, s=sorting, r=reverse, group=group)}}">{{page + 1}}</a>
+            <a class="page-link {% if page == activePage %} paginationActive {% else %} w3-hover-blue {% endif %}" href="{{ url_for(PS, q=query_key, p=page, s=sorting, r=reverse, group = group)}}">{{page + 1}}</a>
         </li>
         {% endfor %}
         <li class="page-item {% if activePage == pages|int %} disabled {% endif %}">
-            <a class="page-link" href="{{ url_for(PS, q=query_key, p=(activePage + 1), s=sorting, r=reverse, group=group)}}" {% if activePage == pages|int %} tabindex="-1" {% endif %}>Next</a>
+            <a class="page-link" href="{{ url_for(PS, q=query_key, p=(activePage + 1), s=sorting, r=reverse, group = group)}}" {% if activePage == pages|int %} tabindex="-1" {% endif %}>Next</a>
         </li>
     </ul>
 </nav>
@@ -42,9 +42,9 @@
                 {%- for header in tableHeaders -%}
                 {% if header.key %}
                     {%- if sorting == header.key -%}
-                        {%- set sorting_link = url_for(PS, q=query_key, p=activePage, s=header.key, r= not reverse) -%}
+                        {%- set sorting_link = url_for(PS, q=query_key, p=activePage, s=header.key, r= not reverse, group = group) -%}
                     {%- else -%}
-                        {%- set sorting_link = url_for(PS, q=query_key, p=activePage, s=header.key) -%}
+                        {%- set sorting_link = url_for(PS, q=query_key, p=activePage, s=header.key, group = group) -%}
                     {%- endif -%}
                 <th scope="col"><a class="sorting-link" href="{{ sorting_link }}"> {{ header.title }}
                     {%- if sorting == header.key and reverse %} ▲ {% elif sorting == header.key %} ▼ {% endif %}</a></th>
@@ -85,11 +85,8 @@
         </li>
     </ul>
 </nav>
-{% elif query_key %}
+{% elif query_key and activePage == 0 %}
 <h1>Your search did not match any repositories</h1>
-{% elif current_user.is_authenticated %}
-<h1>No Repos Tracked</h1>
-<p>Add repos to your personal tracker in your <a href="{{ url_for('user_settings') }}">profile page</a></p>
 {% elif activePage != 0 %}
 <h1>Invalid Page</h1>
 <a href="{{ url_for(PS, q=query_key, s=sorting, r=reverse, group=group)}}">Click here to go back</a>

--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -196,8 +196,8 @@ class RepoLoadController:
             select = f"""    DISTINCT(augur_data.repo.repo_id),
                     augur_data.repo.description,
                     augur_data.repo.repo_git AS url,
-                    a.commits_all_time,
-                    b.issues_all_time,
+                    COALESCE(a.commits_all_time, 0) as commits_all_time,
+                    COALESCE(b.issues_all_time, 0) as issues_all_time,
                     rg_name,
                     (regexp_match(augur_data.repo.repo_git, 'github\.com\/[A-Za-z0-9 \- _]+\/([A-Za-z0-9 \- _ .]+)$'))[1] as repo_name,
                     augur_data.repo.repo_group_id"""


### PR DESCRIPTION
- Enable reload detection for jinja templates in gunicorn config
- Add user groups frontend view
- Fix user group view parameter smashing
- Add get_groups_info function on User class to auto-collate data
- Add search parameters to group repo count
- Update groups-table template to work with user groups
- Add groups view to navbar
- Update groups table in profile to handle new groups table page
- Update user-group-repos-table template
- Fix sorting with NULL values on repo columns

Co-authored-by: Andrew Brain <andrewbrain2019@gmail.com>
Signed-off-by: Ulincsys <28362836a@gmail.com>

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->
