### PR TITLE
Fix confusing log statement

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -194,7 +194,7 @@ def start_primary_collection(session,max_repo):
     collection_size = start_block_of_repos(
         session.logger, session,
         and_(not_erroed, not_collecting,never_collected),
-        limit, primary_enabled_phases,sort=core_order
+        limit, primary_enabled_phases, repos_type="new", sort=core_order
     )
 
 
@@ -207,7 +207,7 @@ def start_primary_collection(session,max_repo):
         start_block_of_repos(
             session.logger, session,
             and_(not_erroed, not_collecting,collected_before),
-            limit, primary_enabled_phases,sort=core_order
+            limit, primary_enabled_phases, repos_type="old", sort=core_order
         )
 
 
@@ -245,6 +245,7 @@ def start_secondary_collection(session,max_repo):
         session.logger, session, 
         and_(primary_collected,not_erroed, not_collecting,never_collected), 
         limit, secondary_enabled_phases,
+        repos_type="new",
         hook="secondary",
         sort=secondary_order
     )
@@ -257,6 +258,7 @@ def start_secondary_collection(session,max_repo):
             session.logger, session, 
             and_(primary_collected,not_erroed, not_collecting,collected_before), 
             limit, secondary_enabled_phases,
+            repos_type="old",
             hook="secondary",
             sort=secondary_order
         )
@@ -329,6 +331,7 @@ def start_facade_collection(session,max_repo):
         session.logger, session,
         and_(not_pending,not_failed_clone,not_erroed, not_collecting, not_initializing,never_collected),
         limit, facade_enabled_phases,
+        repos_type="new",
         hook="facade",
         sort=facade_order
     )
@@ -341,6 +344,7 @@ def start_facade_collection(session,max_repo):
             session.logger, session,
             and_(not_pending,not_failed_clone,not_erroed, not_collecting, not_initializing,collected_before),
             limit, facade_enabled_phases,
+            repos_type="old",
             hook="facade",
             sort=facade_order
         )

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -396,10 +396,10 @@ class AugurTaskRoutine:
             #yield the value of the task_id to the calling method so that the proper collectionStatus field can be updated
             yield repo_git, task_id
 
-def start_block_of_repos(logger,session,condition,limit,phases,hook="core",sort=None):
+def start_block_of_repos(logger,session,condition,limit,phases,repos_type,hook="core",sort=None):
     repo_git_identifiers = get_collection_status_repo_git_from_filter(session,condition,limit,order=sort)
 
-    logger.info(f"Starting new collection on {hook}: {len(repo_git_identifiers)} repos")
+    logger.info(f"Starting collection on {len(repo_git_identifiers)} {repos_type} {hook} repos")
     if len(repo_git_identifiers) == 0:
         return 0
     


### PR DESCRIPTION
**Description**
I kept seeing this in the logs
`2023-04-21 14:48:06 augur_collection_monitor[1466426] INFO Starting new collection on core: 7 repos        
2023-04-21 14:48:06 augur_collection_monitor[1466426] INFO Starting new collection on core: 0 repos`
and it was really confusing me because I thought the augur collection monitor was being started twice, but I couldn't figure out where it was being ran a second time. Eventually I figured out that one of these logs is how many new core repos are being started and how many old core repos are being started. So I updated the code to print which type of repos were being started.

**Signed commits**
- [X] Yes, I signed my commits.
