### PR TITLE
Make sure weight is updated after collection is completed for each collection hook 

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -116,7 +116,7 @@ def start(disable_collection, development, port):
 
         time.sleep(5)
 
-        create_collection_status(logger)
+        #create_collection_status(logger)
         
         with DatabaseSession(logger) as session:
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -529,6 +529,7 @@ def facade_phase(repo_git):
         if not limited_run or (limited_run and run_facade_contributors):
             facade_core_collection.append(generate_contributor_sequence(logger,repo_git,session))
 
+        facade_core_collection.append(git_update_commit_count_weight.si(repo_git))
 
         #These tasks need repos to be cloned by facade before they can work.
         facade_sequence.append(

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -529,7 +529,7 @@ def facade_phase(repo_git):
         if not limited_run or (limited_run and run_facade_contributors):
             facade_core_collection.append(generate_contributor_sequence(logger,repo_git,session))
 
-        facade_core_collection.append(git_update_commit_count_weight.si(repo_git))
+        #facade_core_collection.append(git_update_commit_count_weight.si(repo_git))
 
         #These tasks need repos to be cloned by facade before they can work.
         facade_sequence.append(

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -311,6 +311,11 @@ def start_facade_collection(session,max_repo):
 
     facade_enabled_phases.append(facade_task_success_util_gen)
 
+    def facade_task_update_weight_util_gen(repo_git):
+        return git_update_commit_count_weight.si(repo_git)
+
+    facade_enabled_phases.append(facade_task_update_weight_util_gen)
+
     active_repo_count = len(session.query(CollectionStatus).filter(CollectionStatus.facade_status == CollectionState.COLLECTING.value).all())
 
     #cutoff_date = datetime.datetime.now() - datetime.timedelta(days=days)

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -87,7 +87,7 @@ def primary_repo_collect_phase(repo_git):
 
     repo_task_group = group(
         repo_info_task,
-        chain(primary_repo_jobs | core_task_update_weight_util.s(repo_git=repo_git),secondary_repo_jobs,process_contributors.si()),
+        chain(primary_repo_jobs | issue_pr_task_update_weight_util.s(repo_git=repo_git),secondary_repo_jobs,process_contributors.si()),
         #facade_phase(logger,repo_git),
         
         collect_releases.si(repo_git),
@@ -391,7 +391,7 @@ def augur_collection_update_weights():
             status = repo.collection_status[0]
             raw_count = status.issue_pr_sum
 
-            core_task_update_weight_util([int(raw_count)],repo_git=repo_git,session=session)
+            issue_pr_task_update_weight_util([int(raw_count)],repo_git=repo_git,session=session)
     
         facade_not_pending = CollectionStatus.facade_status != CollectionState.PENDING.value
         facade_not_failed = CollectionStatus.facade_status != CollectionState.FAILED_CLONE.value


### PR DESCRIPTION
**Description**
Append Augur's collection hooks to update the weight after collection has finished. Core, facade, and secondary collection hooks now update the weight of the repo after they complete and populate the last_collected timestamp. 

This PR Fixes #2342

**Signed commits**
- [x] Yes, I signed my commits.
