### PR TITLE
Add a delay of a day before collecting repositories again

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -6,6 +6,7 @@ import os
 from enum import Enum
 import math
 import numpy as np
+import datetime
 #from celery.result import AsyncResult
 from celery import signature
 from celery import group, chain, chord, signature


### PR DESCRIPTION
**Description**
Add a restriction to repository collection when collecting old repositories; disallow repositories that have already been collected from being collected again until a day has passed since it was last collected 

This PR fixes #2349

**Signed commits**
- [x] Yes, I signed my commits.

