### PR TITLE
Fix facade repo_name parsing

### DIFF
--- a/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
@@ -85,7 +85,7 @@ def git_repo_initialize(session, repo_git):
 
         # Get the name of repo
         repo_name = git[git.rfind('/', 0)+1:]
-        if repo_name.find('.git', 0) > -1:
+        if repo_name.endswith('.git'):
             repo_name = repo_name[:repo_name.find('.git', 0)]
             session.log_activity(
                 'Info', f"Repo Name from facade05, line 93: {repo_name}")


### PR DESCRIPTION
**Description**
- Fix issue where repos with the name `.github` are incorrectly parsed in facade. See attached details for more details

**Signed commits**
- [X] Yes, I signed my commits.
