### PR TITLE
Make facade scheduling dynamic 

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -390,7 +390,7 @@ def augur_collection_monitor():
         if facade_phase.__name__ in enabled_phase_names:
             #Schedule facade collection before clone/updates as that is a higher priority
             start_facade_collection(session, max_repo=15)
-            start_facade_clone_update(session,max_repo=5,days=30)
+            start_facade_clone_update(session,max_repo=15,days=30)
 
 
 @celery.task


### PR DESCRIPTION
**Description**
- Currently facade initialization tasks are not being scheduled often enough to ensure there are always repos available to be collected by the facade collection tasks. To solve this, @IsaacMilarky and I came up with a solution that limits the number of cloning tasks and collection tasks we start based on the number of each task we start rather than just saying a specific number of repos for each can run. This is best explained with examples.
For example. 
Say there are 500 repos ready to be cloned. This is what the augur collection monitor would start each minute, assuming that all the clones finished in the minute, and the collection tasks also finished. If they didn't, then less tasks would be scheduled
1. 108 cloned 0 collected
2. 108 cloned 21 collected
3. 108 cloned 21 collected
4. 108 cloned 21 collected
5. 68 cloned 24 collected
6. 0 cloned 30 collected
6. 0 cloned 30 collected

As you can see, this process prioritizes cloning repos while still giving some room in the queue to start collecting some of the repos. Then eventually once all of the repos are cloned the whole queue is used for collection. Essentially the process starts up to 108 cloning jobs and up to 30 collection jobs depending on how many clones are running.

Note: All 30 of the collection jobs should finish each minute if the repos have less than 600 commits. If we wanted to keep the pipe full the entire minute for repos with an average of 100 commits, then we would need to schedule around 75-100 repos. I just started with 30 repos so that we were at least collecting for the whole minute when the repos are around 600 commits. Also these numbers are taken from some of the chaoss repos commit counts and how long they took to run through facade collection, repos with larger or smaller commits could yield slightly different results. The goal I'm shooting for is minimizing downtime in the queue since we are scheduling the smallest repos first


**Signed commits**
- [X] Yes, I signed my commits.
