### PR TITLE
Handle edge case facade NULL error

### DIFF
--- a/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
@@ -116,6 +116,12 @@ def git_repo_initialize(session, repo_git):
             collectionRecord.facade_task_id = None
             session.commit()
 
+            #Make sure repo in repo table reflects found path.
+            query = s.sql.text("""UPDATE repo SET repo_path=:pathParam, 
+            repo_name=:nameParam WHERE repo_id=:idParam
+            """).bindparams(pathParam=repo_relative_path, nameParam=repo_name, idParam=row.repo_id)
+
+            session.execute_sql(query)
             return
 
         # Create the prerequisite directories
@@ -133,6 +139,7 @@ def git_repo_initialize(session, repo_git):
 
         update_repo_log(session, row.repo_id, 'New (cloning)')
 
+        #Make sure newly cloned repo path is recorded in repo table
         query = s.sql.text("""UPDATE repo SET repo_path=:pathParam, 
             repo_name=:nameParam WHERE repo_id=:idParam
             """).bindparams(pathParam=repo_relative_path, nameParam=repo_name, idParam=row.repo_id)


### PR DESCRIPTION
**Description**
Add an update query to facade to handle the case when an existing repo path is found but the repo's record shows a path of null. This way the path is always updated to the path the repo has been cloned to. 


**Signed commits**
- [x] Yes, I signed my commits.
