### PR TITLE
Fix commit count task error

### DIFF
--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -159,6 +159,26 @@ def get_repo_commit_count(session,repo_git):
 
 	return commit_count
 
+def get_repo_commit_count(session, repo_git):
+    
+	repo = Repo.get_by_repo_git(session, repo_git)
+
+	absolute_path = get_absolute_repo_path(session.repo_base_directory, repo.repo_group_id, repo.repo_path, repo.repo_name)
+	repo_loc = (f"{absolute_path}/.git")
+
+	# Check if the absolute_path exists, raise an error if not
+	if not os.path.exists(absolute_path):
+		raise FileNotFoundError(f"The directory {absolute_path} does not exist.")
+
+	# If .git doens't exist, return 0
+	if not os.path.exists(repo_loc):
+		return 0
+
+	check_commit_count_cmd = check_output(["git", "--git-dir", repo_loc, "rev-list", "--count", "HEAD"])
+	commit_count = int(check_commit_count_cmd)
+
+	return commit_count
+
 def get_facade_weight_time_factor(session,repo_git):
 	repo = Repo.get_by_repo_git(session, repo_git)
 	


### PR DESCRIPTION
**Description**
- An error occurs in get_repo_commit_count when the repo is empty (.git doesn't exist)

This PR fixes #
`Traceback (most recent call last):
  File "/home/sean/github/rh-k12/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py", line 156, in get_repo_commit_count
    check_commit_count_cmd = check_output(["git","--git-dir",repo_loc, "rev-list", "--count", "HEAD"])
  File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', '--git-dir', '/mnt/data/repopadre/25478/github.com/apache/incubator-guacamole/.git', 'rev-list', '--count', 'HEAD']' returned non-zero exit status 128.`

**Signed commits**
- [X] Yes, I signed my commits.