### PR TITLE
Simplify facade collection process

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -20,6 +20,7 @@ from datetime import datetime
 
 from augur import instance_id
 from augur.tasks.start_tasks import augur_collection_monitor, CollectionState, create_collection_status_records
+from augur.tasks.git.facade_tasks import clone_repos
 from augur.tasks.init.redis_connection import redis_connection 
 from augur.application.db.models import Repo, CollectionStatus
 from augur.application.db.session import DatabaseSession
@@ -112,8 +113,13 @@ def start(disable_collection, development, port):
         
         create_collection_status_records.si().apply_async()
         time.sleep(3)
-        augur_collection_monitor.si().apply_async()
 
+        # start cloning repos when augur starts
+        clone_repos.si().apply_async()
+
+        augur_collection_monitor.si().apply_async()
+        
+        
         celery_command = "celery -A augur.tasks.init.celery_app.celery_app beat -l debug"
         celery_beat_process = subprocess.Popen(celery_command.split(" "))    
 

--- a/augur/application/schema/alembic/versions/17_add_collection_status_constraints.py
+++ b/augur/application/schema/alembic/versions/17_add_collection_status_constraints.py
@@ -50,8 +50,8 @@ def upgrade():
     op.create_check_constraint(
         constraint_name="facade_task_id_check",
         table_name="collection_status",
-        condition="NOT (facade_task_id IS NOT NULL AND facade_status IN ('Pending', 'Success', 'Error', 'Failed Clone')) AND "
-        "NOT (facade_task_id IS NULL AND facade_status IN ('Collecting','Initializing'))"
+        condition="NOT (facade_task_id IS NOT NULL AND facade_status IN ('Pending', 'Success', 'Error', 'Failed Clone', 'Initializing')) AND "
+        "NOT (facade_task_id IS NULL AND facade_status IN ('Collecting'))"
     )
     op.create_check_constraint(
         constraint_name="core_secondary_dependency_check",

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -367,7 +367,7 @@ def clone_repos():
             setattr(repoStatus,"facade_status", CollectionState.UPDATE.value)
             session.commit()
 
-        clone_repos.si().apply_async(countdown=60)
+        clone_repos.si().apply_async(countdown=60*5)
 
 
 

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -215,10 +215,6 @@ def setup_periodic_tasks(sender, **kwargs):
         logger.info(f"Scheduling update of collection weights on midnight on even numbered days.")
         sender.add_periodic_task(crontab(0, 0,day_of_month='2-30/2'),augur_collection_update_weights.s())
 
-        cloning_interval = 5*60
-        logger.info(f"Scheduling collection every {cloning_interval/60} minutes")
-        sender.add_periodic_task(cloning_interval,clone_repos.s())
-
 
 @after_setup_logger.connect
 def setup_loggers(*args,**kwargs):

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -193,13 +193,12 @@ def setup_periodic_tasks(sender, **kwargs):
     from celery.schedules import crontab
     from augur.tasks.start_tasks import augur_collection_monitor, augur_collection_update_weights
     from augur.tasks.start_tasks import non_repo_domain_tasks
+    from augur.tasks.git.facade_tasks import clone_repos
     from augur.tasks.db.refresh_materialized_views import refresh_materialized_views
     
     with DatabaseEngine() as engine, DatabaseSession(logger, engine) as session:
 
         config = AugurConfig(logger, session)
-
-        print(augur_collection_monitor)
 
         collection_interval = config.get_value('Tasks', 'collection_interval')
         logger.info(f"Scheduling collection every {collection_interval/60} minutes")
@@ -215,6 +214,10 @@ def setup_periodic_tasks(sender, **kwargs):
 
         logger.info(f"Scheduling update of collection weights on midnight on even numbered days.")
         sender.add_periodic_task(crontab(0, 0,day_of_month='2-30/2'),augur_collection_update_weights.s())
+
+        cloning_interval = 5*60
+        logger.info(f"Scheduling collection every {cloning_interval/60} minutes")
+        sender.add_periodic_task(cloning_interval,clone_repos.s())
 
 
 @after_setup_logger.connect

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -308,7 +308,17 @@ def start_facade_processes(session, pipe_size, clone_percentage=0.6):
     # divide collecting_section_size by 12 because each collection task is counted as 12
     collecting_repo_count = collecting_section_size//12
 
-    start_facade_collection(session, max_repo=collecting_repo_count)
+    # start collecting repos if there are slots available
+    # sometimes the collecting_repo_count can be negative
+    # because the collecting repos will fill the pipe if 
+    # there are no repos to clone. So when more repos are
+    # added and take up the clone space there is no longer
+    # the full pipe available for collecting so the count 
+    # ends up being negative because it is using more 
+    # than its section of the pipe
+    if collecting_repo_count > 0:
+
+        start_facade_collection(session, max_repo=collecting_repo_count)
             
 
 # fills up to 60% of the pipe with cloning repos

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -272,92 +272,6 @@ def start_secondary_collection(session,max_repo, days_until_collect_again = 1):
             sort=secondary_order
         )
 
-
-
-def start_facade_processes(session, pipe_size, clone_percentage=0.6):
-
-    # for facade collection we are maintaining a pipe size,
-    # this is the number of messages that can be added to the queue at a time for facade
-    # each clone task is counted for 1, each collection task is counted for 12 since those 
-    # are the number of messages they add to the queue
-    
-    # also the clone percentage determines how much of the pipe is dedicated to clone tasks
-    # after cloning is done, the rest of the pipe is filled with collection tasks
-
-    cloning_section_size = pipe_size * clone_percentage
-    cloning_count = len(session.query(CollectionStatus).filter(CollectionStatus.facade_status == CollectionState.INITIALIZING.value).all())
-
-    # remove the number of repos that are already being cloned from cloning_section_size
-    cloning_section_size = cloning_section_size - cloning_count
-
-    # start cloning tasks until the cloning_section is full. We passing cloning 
-    # section size directly as the max repos because each clone task is counted as 1
-    pipe_space_left = start_facade_clone(session, max_repo=cloning_section_size)
-
-    
-
-    collecting_section_size = pipe_size * (1-clone_percentage)
-    collecting_count = len(session.query(CollectionStatus).filter(CollectionStatus.facade_status == CollectionState.COLLECTING.value).all())
-
-    # remove the number of repos that are already being collected multiplied by 12 from collecting_section_size
-    collecting_section_size = collecting_section_size - (collecting_count*12)
-
-    # add the extra space that is left in the pipe after cloning to the collecting_section_size
-    collecting_section_size = collecting_section_size + pipe_space_left
-
-    # divide collecting_section_size by 12 because each collection task is counted as 12
-    collecting_repo_count = collecting_section_size//12
-
-    # start collecting repos if there are slots available
-    # sometimes the collecting_repo_count can be negative
-    # because the collecting repos will fill the pipe if 
-    # there are no repos to clone. So when more repos are
-    # added and take up the clone space there is no longer
-    # the full pipe available for collecting so the count 
-    # ends up being negative because it is using more 
-    # than its section of the pipe
-    if collecting_repo_count > 0:
-
-        start_facade_collection(session, max_repo=collecting_repo_count)
-            
-
-# fills up to 60% of the pipe with cloning repos
-# each repo clone is counted as 1
-#clone new repos that don't have a weight yet.
-def start_facade_clone(session,max_repo):
-    facade_enabled_phases = []
-
-    facade_enabled_phases.append(start_facade_clone_phase)
-
-    def facade_clone_success_util_gen(repo_git):
-        return facade_clone_success_util.si(repo_git)
-    
-    facade_enabled_phases.append(facade_clone_success_util_gen)
-
-    
-    not_erroed = CollectionStatus.facade_status != str(CollectionState.ERROR.value)
-    not_failed_clone = CollectionStatus.facade_status != str(CollectionState.FAILED_CLONE.value)
-    not_collecting = CollectionStatus.facade_status != str(CollectionState.COLLECTING.value)
-    not_initializing = CollectionStatus.facade_status != str(CollectionState.INITIALIZING.value)
-    never_collected = CollectionStatus.facade_status == CollectionState.PENDING.value
-
-
-    repo_git_identifiers = get_collection_status_repo_git_from_filter(session,and_(not_failed_clone,not_erroed, not_collecting, not_initializing, never_collected),max_repo)
-
-    session.logger.info(f"Starting facade clone/update on {len(repo_git_identifiers)} repos")
-    if len(repo_git_identifiers) == 0:
-        return max_repo
-
-    session.logger.info(f"Facade clone/update starting for: {tuple(repo_git_identifiers)}")
-
-    facade_augur_collection = AugurTaskRoutine(session,repos=repo_git_identifiers,collection_phases=facade_enabled_phases,collection_hook="facade")
-    #Change start state so cloning repos appear as initializing instead of collecting.
-    facade_augur_collection.start_state = CollectionState.INITIALIZING.value
-
-    facade_augur_collection.start_data_collection()
-
-    return max_repo - len(repo_git_identifiers)
-
 def start_facade_collection(session,max_repo,days_until_collect_again = 1):
 
     #Deal with secondary collection
@@ -434,9 +348,7 @@ def augur_collection_monitor():
             start_secondary_collection(session, max_repo=5)
 
         if facade_phase.__name__ in enabled_phase_names:
-            #Schedule facade collection before clone/updates as that is a higher priority
-
-            start_facade_processes(session, pipe_size=360, clone_percentage=0.3)
+            start_facade_collection(session, max_repo=30)
            
 
 


### PR DESCRIPTION
**Description**
- Simplify facade collection scheduling by running the cloning task for all the repos that need cloning. Then scheduling the cloning task 5 minutes after all of them are finished to see if there are any new ones

Note: The facade clone task only gets one repo at a time to initialize so more than one of the task can run at the same time if a clone task is taking more than 5 minutes

**Signed commits**
- [X] Yes, I signed my commits.