### PR TITLE
Update weight scheduling to once a day

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -213,8 +213,8 @@ def setup_periodic_tasks(sender, **kwargs):
         logger.info(f"Scheduling refresh materialized view every night at 1am CDT")
         sender.add_periodic_task(crontab(hour=1, minute=0), refresh_materialized_views.s())
 
-        logger.info(f"Scheduling update of collection weights on midnight on even numbered days.")
-        sender.add_periodic_task(crontab(0, 0,day_of_month='2-30/2'),augur_collection_update_weights.s())
+        logger.info(f"Scheduling update of collection weights on midnight each day")
+        sender.add_periodic_task(crontab(hour=0, minute=0),augur_collection_update_weights.s())
 
 
 @after_setup_logger.connect


### PR DESCRIPTION
**Description**
- Set update weight task to run once a day rather than every 2 days since the weight can change a lot in 2 days
- This is something @IsaacMilarky and I discussed previously but it never got changed

**Signed commits**
- [X] Yes, I signed my commits.
