### PR TITLE
Fix bug in repo clone task

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -32,6 +32,7 @@ from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_
 
 from augur.tasks.github.facade_github.tasks import *
 from augur.tasks.util.collection_util import CollectionState, get_collection_status_repo_git_from_filter
+from augur.tasks.git.util.facade_worker.facade_worker.repofetch import GitCloneError, git_repo_initialize
 
 
 from augur.tasks.util.worker_util import create_grouped_task_load
@@ -354,7 +355,12 @@ def clone_repos():
             session.commit()
 
             # clone repo
-            git_repo_initialize(session, repo_git)
+            try:
+                git_repo_initialize(session, repo_git)
+            except GitCloneError:
+                # continue to next repo, since we can't calculate 
+                # commit_count or weight without the repo cloned
+                continue
 
             # get the commit count
             commit_count = get_repo_commit_count(session, repo_git)

--- a/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
@@ -43,6 +43,8 @@ from augur.application.db.models.augur_data import *
 from augur.application.db.models.augur_operations import CollectionStatus
 from augur.application.db.util import execute_session_query, convert_orm_list_to_dict_list
 
+class GitCloneError(Exception):
+    pass
 
 def git_repo_initialize(session, repo_git):
 
@@ -169,7 +171,7 @@ def git_repo_initialize(session, repo_git):
 
             session.log_activity('Error', f"Could not clone {git}")
 
-            raise Exception(f"Could not clone {git}")
+            raise GitCloneError(f"Could not clone {git}")
 
     session.log_activity('Info', f"Fetching new repos (complete)")
 


### PR DESCRIPTION
**Description**
- Currently if one of the repos fails to clone the clone task errors, and the clone repos task is never scheduled again
- I added a custom exception that it raised when a clone fails, and if this error is raised, the clone repos task catches it and continues to the next repo
- I also added retry logic to the clone repos task. So if any other unpredictable errors such as network errors occur, it will retry in 5 minutes. Also these errors are logged to flower in the reties tab so we will still know if there are frequent errors happening in the task, that need to be patched

**Signed commits**
- [X] Yes, I signed my commits.
