### PR TITLE
Change default collection interval to every 30 seconds

### DIFF
--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -76,7 +76,7 @@ default_config = {
                 "connection_string": "amqp://augur:password123@localhost:5672/augur_vhost"
             },
             "Tasks": {
-                "collection_interval": 60
+                "collection_interval": 30
             },
             "Message_Insights": {
                     "insight_days": 30,


### PR DESCRIPTION
**Description**
- Change default collection interval to 30 seconds because we are scheduling the smallest repos first. Which means many of the smallest repos are finishing before the 60 seconds is up, which creates downtime on the celery worker process. To reduce the chance for downtime while not adding a lot of messages to the queue I reduced to frequency that we check for new repos to collect

**Signed commits**
- [X] Yes, I signed my commits.
