### PR TITLE
Increase max secondary repos to 10

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -345,7 +345,7 @@ def augur_collection_monitor():
             start_primary_collection(session, max_repo=40)
         
         if secondary_repo_collect_phase.__name__ in enabled_phase_names:
-            start_secondary_collection(session, max_repo=5)
+            start_secondary_collection(session, max_repo=10)
 
         if facade_phase.__name__ in enabled_phase_names:
             start_facade_collection(session, max_repo=30)


### PR DESCRIPTION
**Description**
- Change the max number of secondary repos to 10 instead of 5 because we are scheduling the smallest repos first. Which means many of the smallest repos are before the collection monitor runs again, which creates downtime on the celery worker process. So raising the max number of repos to 10 for the secondary repo tasks will make sure more repos are being repos when the tasks are flying because they are such small repos

**Signed commits**
- [X] Yes, I signed my commits.
