### PR TITLE
Fix issue in ossf scorecard with Github API keys

### DIFF
--- a/augur/tasks/git/dependency_tasks/core.py
+++ b/augur/tasks/git/dependency_tasks/core.py
@@ -9,6 +9,7 @@ import traceback
 from augur.application.db.models import *
 from augur.application.db.session import DatabaseSession
 from augur.application.config import AugurConfig
+from augur.tasks.github.util.github_api_key_handler import GithubApiKeyHandler
 from augur.application.db.util import execute_session_query
 from augur.tasks.git.dependency_tasks.dependency_util import dependency_calculator as dep_calc
 
@@ -81,9 +82,9 @@ def generate_scorecard(session,repo_id,path):
     #this is path where our scorecard project is located
     path_to_scorecard = os.environ['HOME'] + '/scorecard'
 
-    #setting the environmental variable which is required by scorecard  
-    config = AugurConfig(session.logger, session)
-    os.environ['GITHUB_AUTH_TOKEN'] = config.get_section("Keys")['github_api_key']#self.config['gh_api_key']
+    #setting the environmental variable which is required by scorecard
+    key_handler = GithubApiKeyHandler(session)       
+    os.environ['GITHUB_AUTH_TOKEN'] = key_handler.get_random_key()
     
     p= subprocess.run(['./scorecard', command, '--format=json'], cwd= path_to_scorecard ,capture_output=True, text=True, timeout=None)
     session.logger.info('subprocess completed successfully... ')

--- a/augur/tasks/github/util/github_api_key_handler.py
+++ b/augur/tasks/github/util/github_api_key_handler.py
@@ -1,5 +1,6 @@
 import httpx
 import time
+import random
 
 from typing import Optional, List
 
@@ -34,6 +35,15 @@ class GithubApiKeyHandler():
         self.keys = self.get_api_keys()
 
         # self.logger.debug(f"Retrieved {len(self.keys)} github api keys for use")
+
+    def get_random_key(self):
+        """Retrieves a random key from the list of keys
+
+        Returns:
+            A random github api key
+        """
+
+        return random.choice(self.keys)
 
     def get_config_key(self) -> str:
         """Retrieves the users github api key from their config table


### PR DESCRIPTION
**Description**
- The ossf scorecard task was using the github api located in the database config to run the scorecard process. The problem with this is that it ran that Github API key out of requests very quickly and left a bunch of scorecard tasks in the queue waiting for the API key to get more requests. Now the task gets a random API key from the list of keys and runs with that one so that no one key is overwhelmed. This also effected other Github tasks because the ossf scorecard task would run out that one Github API key before all the others, so the other Github tasks that randomly selected that key would sleep until it gets more requests.

Note: This is why we were seeing a bunch of scorecard tasks all of a sudden taking a super long time to run

**Signed commits**
- [X] Yes, I signed my commits.
