### PR TITLE
Fix facade collection limit

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -297,7 +297,9 @@ def start_facade_collection(session,max_repo,days_until_collect_again = 1):
     not_initializing = CollectionStatus.facade_status != str(CollectionState.INITIALIZING.value)
     never_collected = CollectionStatus.facade_data_last_collected == None
 
-    limit = max_repo
+    active_repo_count = len(session.query(CollectionStatus).filter(CollectionStatus.facade_status == CollectionState.COLLECTING.value).all())
+
+    limit = max_repo - active_repo_count
 
     facade_order = CollectionStatus.facade_weight
 


### PR DESCRIPTION
**Description**
- Facade collection wasn't taking into account active repos so it was just scheduling more and more collection jobs every time the monitor ran

**Signed commits**
- [X] Yes, I signed my commits.
