### PR TITLE
Route pr review comments to secondary worker

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -128,6 +128,7 @@ celery_app.conf.task_routes = {
     'augur.tasks.github.pull_requests.commits_model.tasks.*': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.files_model.tasks.*': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.tasks.collect_pull_request_reviews': {'queue': 'secondary'},
+    'augur.tasks.github.pull_requests.tasks.collect_pull_request_review_comments': {'queue': 'secondary'},
     'augur.tasks.git.dependency_tasks.tasks.process_ossf_scorecard_metrics': {'queue': 'secondary'},
     'augur.tasks.git.dependency_tasks.tasks.process_dependency_metrics': {'queue': 'facade'},
     'augur.tasks.git.dependency_libyear_tasks.tasks.process_libyear_dependency_metrics': {'queue': 'facade'}


### PR DESCRIPTION
**Description**
- The `collect_pull_request_review_comments' task is causing the secondary worker to stall. This is because it is scheduled in the core worker, but it is scheduled in the `secondary_tasks`. Essentially what happens is the secondary worker finishes all the other secondary tasks, but then the core worker is backed up with core jobs, so the `collect_pull_request_review_comments` doesn't make it through. This causes no more secondary tasks to be scheduled until the `collect_pull_request_review_comments` tasks get to the front of the core worker queue, effectively stalling the secondary worker. To fix this, I changed the `collect_pull_request_review_comments` task to be scheduled in the secondary worker.

**Signed commits**
- [X] Yes, I signed my commits.
