### PR TITLE
Fix clean collection status

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -245,19 +245,26 @@ def clean_collection_status(session):
         UPDATE augur_operations.collection_status 
         SET core_status='Pending',core_task_id = NULL
         WHERE core_status='Collecting' AND core_data_last_collected IS NULL;
+
         UPDATE augur_operations.collection_status
         SET core_status='Success',core_task_id = NULL
         WHERE core_status='Collecting' AND core_data_last_collected IS NOT NULL;
+
         UPDATE augur_operations.collection_status 
         SET secondary_status='Pending',secondary_task_id = NULL
         WHERE secondary_status='Collecting' AND secondary_data_last_collected IS NULL;
+
         UPDATE augur_operations.collection_status 
         SET secondary_status='Success',secondary_task_id = NULL
         WHERE secondary_status='Collecting' AND secondary_data_last_collected IS NOT NULL;
 
         UPDATE augur_operations.collection_status 
         SET facade_status='Update', facade_task_id=NULL
-        WHERE facade_status LIKE '%Collecting%';
+        WHERE facade_status LIKE '%Collecting%' and facade_data_last_collected IS NULL;
+
+        UPDATE augur_operations.collection_status 
+        SET facade_status='Success', facade_task_id=NULL
+        WHERE facade_status LIKE '%Collecting%' and facade_data_last_collected IS NOT NULL;
 
         UPDATE augur_operations.collection_status
         SET facade_status='Pending', facade_task_id=NULL

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -1064,7 +1064,7 @@ class CollectionStatus(Base):
         #Disallow facade_data_last_collected to be set when facade_status indicates task hasn't been run
         CheckConstraint(
             "NOT (facade_data_last_collected IS NULL AND facade_status  = 'Success' ) AND"
-            "NOT (facade_data_last_collected IS NOT NULL AND facade_status IN ('Pending','Initializing'))",
+            "NOT (facade_data_last_collected IS NOT NULL AND facade_status IN ('Pending','Initializing', 'Update'))",
             name='facade_data_last_collected_check'
         ),
 
@@ -1073,7 +1073,7 @@ class CollectionStatus(Base):
         #Disallow facade_task_id to not be set when facade_status indicates task is running
         CheckConstraint(
             "NOT (facade_task_id IS NOT NULL AND facade_status IN ('Pending', 'Success', 'Error', 'Failed Clone')) AND "
-            "NOT (facade_task_id IS NULL AND facade_status IN ('Collecting','Initializing'))",
+            "NOT (facade_task_id IS NULL AND facade_status IN ('Collecting'))",
             name='facade_task_id_check'
         ),
 

--- a/augur/application/schema/alembic/versions/17_add_collection_status_constraints.py
+++ b/augur/application/schema/alembic/versions/17_add_collection_status_constraints.py
@@ -45,7 +45,7 @@ def upgrade():
         constraint_name="facade_data_last_collected_check",
         table_name="collection_status",
         condition="NOT (facade_data_last_collected IS NULL AND facade_status  = 'Success' ) AND "
-        "NOT (facade_data_last_collected IS NOT NULL AND facade_status IN ('Pending','Initializing'))"
+        "NOT (facade_data_last_collected IS NOT NULL AND facade_status IN ('Pending','Initializing', 'Update'))"
     )
     op.create_check_constraint(
         constraint_name="facade_task_id_check",


### PR DESCRIPTION
**Description**
- The clean collection status was setting all facade statuses to `Update` if they were collecting. So I changed it so that it sets the status to `Update` if the repo hasn't been collected yet, and `Success` if the repo has been collected before. The goal of this is to reset it to the status it had before it started collecting.So if a repo is collecting and doens't have a collection date then its status was update beforehand, and if it is collecting and has a collection date it must be recollecting meaning that it had a status of 'Success' before. 

To fix this I updated the clean collection status to achieve this behavior, and I also added a check constraint to ensure that a repo is never set to update when it has a facade collection date 

**Signed commits**
- [X] Yes, I signed my commits.
