### PR TITLE
make sure status of repo is updated when the cloning fails

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -359,6 +359,9 @@ def clone_repos():
             except GitCloneError:
                 # continue to next repo, since we can't calculate 
                 # commit_count or weight without the repo cloned
+
+                setattr(repoStatus,"facade_status", CollectionState.FAILED_CLONE.value)
+                session.commit()
                 continue
 
             # get the commit count


### PR DESCRIPTION
**Description**
Fix issue where repos were not getting marked as failed when cloning them via git fails. 

**Signed commits**
- [x] Yes, I signed my commits.
