### PR TITLE
Improved error handling when cloning repositories 

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -353,25 +353,29 @@ def clone_repos():
             try:
                 git_repo_initialize(session, repo_git)
                 session.commit()
+
+                # get the commit count
+                commit_count = get_repo_commit_count(session, repo_git)
+                facade_weight = get_facade_weight_with_commit_count(session, repo_git, commit_count)
+
+                update_facade_scheduling_fields(session, repo_git, facade_weight, commit_count)
+
+                # set repo to update
+                setattr(repoStatus,"facade_status", CollectionState.UPDATE.value)
+                session.commit()
             except GitCloneError:
                 # continue to next repo, since we can't calculate 
                 # commit_count or weight without the repo cloned
-
                 setattr(repoStatus,"facade_status", CollectionState.FAILED_CLONE.value)
                 session.commit()
-                continue
-            
-            #logger.info("GOT HERE ISAAC")
+            except Exception as e:
+                logger.info(f"Ran into unexpected issue when cloning repositories \n Error: {e}")
+                # set repo to error
+                setattr(repoStatus,"facade_status", CollectionState.ERROR.value)
+                session.commit()
 
-            # get the commit count
-            commit_count = get_repo_commit_count(session, repo_git)
-            facade_weight = get_facade_weight_with_commit_count(session, repo_git, commit_count)
-
-            update_facade_scheduling_fields(session, repo_git, facade_weight, commit_count)
-
-            # set repo to update
-            setattr(repoStatus,"facade_status", CollectionState.UPDATE.value)
-            session.commit()
+                #Raise exception to activate handling before retry of task.
+                raise e
 
         clone_repos.si().apply_async(countdown=60*5)
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -369,7 +369,7 @@ def clone_repos():
                 setattr(repoStatus,"facade_status", CollectionState.FAILED_CLONE.value)
                 session.commit()
             except Exception as e:
-                logger.info(f"Ran into unexpected issue when cloning repositories \n Error: {e}")
+                logger.error(f"Ran into unexpected issue when cloning repositories \n Error: {e}")
                 # set repo to error
                 setattr(repoStatus,"facade_status", CollectionState.ERROR.value)
                 session.commit()

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -374,9 +374,6 @@ def clone_repos():
                 setattr(repoStatus,"facade_status", CollectionState.ERROR.value)
                 session.commit()
 
-                #Raise exception to activate handling before retry of task.
-                raise e
-
         clone_repos.si().apply_async(countdown=60*5)
 
 


### PR DESCRIPTION
**Description**
- Add error handling logic to the clone_repos method to handle errors that don't have to do with problems with running 'git clone'. 
- Add exception handle for general cases to set the repo to 'Error' when the repository can't be initialized for facade for unknown reasons.

This PR fixes #2401


**Signed commits**
- [x] Yes, I signed my commits.
