### PR TITLE
No valid Github API keys fix

### DIFF
--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -40,14 +40,14 @@ def av_add_user_repo():
 
         # matches https://github.com/{org}/ or htts://github.com/{org}
         if Repo.parse_github_org_url(url):
-            added = current_user.add_org(group, url)
+            added = current_user.add_org(group, url)[0]
             if added:
                 added_orgs += 1
 
         # matches https://github.com/{org}/{repo}/ or htts://github.com/{org}/{repo}
         elif Repo.parse_github_repo_url(url)[0]:
             print("Adding repo")
-            added = current_user.add_repo(group, url)
+            added = current_user.add_repo(group, url)[0]
             if added:
                 print("Repo added")
                 added_repos += 1
@@ -56,7 +56,7 @@ def av_add_user_repo():
         elif (match := re.match(r'^\/?([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)\/?$', url)):
             org, repo = match.groups()
             repo_url = f"https://github.com/{org}/{repo}/"
-            added = current_user.add_repo(group, repo_url)
+            added = current_user.add_repo(group, repo_url)[0]
             if added:
                 added_repos += 1
 
@@ -64,10 +64,9 @@ def av_add_user_repo():
         elif (match := re.match(r'^\/?([a-zA-Z0-9_-]+)\/?$', url)):
             org = match.group(1)
             org_url = f"https://github.com/{org}/"
-            added = current_user.add_org(group, org_url)
+            added = current_user.add_org(group, org_url)[0]
             if added:
                 added_orgs += 1
-
 
     if not added_orgs and not added_repos:
         flash(f"Unable to add any repos or orgs")

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -429,9 +429,14 @@ class User(Base):
     def add_repo(self, group_name, repo_url):
         
         from augur.tasks.github.util.github_task_session import GithubTaskSession
+        from augur.tasks.github.util.github_api_key_handler import NoValidKeysError
 
         with GithubTaskSession(logger) as session:
-            result = UserRepo.add(session, repo_url, self.user_id, group_name)
+        try:
+            with GithubTaskSession(logger) as session:
+                result = UserRepo.add(session, repo_url, self.user_id, group_name)
+        except NoValidKeysError:
+            return False, {"status": "No valid keys"}
 
         return result
 
@@ -445,9 +450,13 @@ class User(Base):
     def add_org(self, group_name, org_url):
 
         from augur.tasks.github.util.github_task_session import GithubTaskSession
+        from augur.tasks.github.util.github_api_key_handler import NoValidKeysError
 
-        with GithubTaskSession(logger) as session:
-            result = UserRepo.add_org_repos(session, org_url, self.user_id, group_name)
+        try:
+            with GithubTaskSession(logger) as session:
+                result = UserRepo.add_org_repos(session, org_url, self.user_id, group_name)
+        except NoValidKeysError:
+            return False, {"status": "No valid keys"}
 
         return result
 

--- a/augur/tasks/github/util/github_api_key_handler.py
+++ b/augur/tasks/github/util/github_api_key_handler.py
@@ -8,6 +8,11 @@ from augur.tasks.util.redis_list import RedisList
 from augur.application.db.session import DatabaseSession
 from augur.application.config import AugurConfig
 
+
+class NoValidKeysError(Exception):
+    pass
+
+
 class GithubApiKeyHandler():
     """Handles Github API key retrieval from the database and redis
 
@@ -121,6 +126,9 @@ class GithubApiKeyHandler():
 
         # add all the keys to redis
         self.redis_key_list.extend(valid_keys)
+
+        if not valid_keys:
+            raise NoValidKeysError("No valid github api keys found in the config or worker oauth table")
 
         return valid_keys
 


### PR DESCRIPTION
**Description**
- I came across these issues when I saw the frontend flash that a repo was added, but it actually wasn't. The issue was that I had no valid Github API keys. To fix this issue, I made the Github API key handler raise a `NoValidKeysError` when there are no valid github api keys. This improves the case when all the Github API keys are expired or invalid, because it now raises an exception rather than just silently not working. 
- Now in the add repo and add org code it catches NoValidKeysError and returns False so the frontend shows that the repos weren't added
- I also came across an issue in the view code, where it wasn't unpacking a tuple before checking if the repo or org was added. This issue is why we were always see it flash that the repos were added even it they really weren't


**Notes for Reviewers**
There are two imports of the `NoValidKeysError` in `augur_operations.py` that are each inside of a function, this is because adding the import at the module level, creates a circular dependency (it has proved difficult to not get circular dependencies in the model files so we have been doing imports in the functions most of the time)

**Signed commits**
- [X] Yes, I signed my commits.
