### PR TITLE
Handle GitHub API 204 response

### DIFF
--- a/augur/tasks/github/util/github_paginator.py
+++ b/augur/tasks/github/util/github_paginator.py
@@ -384,6 +384,10 @@ class GithubPaginator(collections.abc.Sequence):
                 timeout = timeout * 1.1
                 num_attempts += 1
                 continue
+
+            # if api returns a status of 204 No Content then return empty list
+            if response.status_code == 204:
+                return [], response, GithubApiResult.SUCCESS
             
             
             page_data = parse_json_response(self.logger, response)


### PR DESCRIPTION
**Description**
- This endpoint, `https://api.github.com/repos/{owner}/{repo}/contributors?state=all`, which is used in `grab_commiters` returns a `204 No Content` status and an empty string when there are not contributors. This was causing the response to be processed as a string, and a warning was logged because it was unable to be processed. Now if a `204 No Content` status is returned by the Github API then all an empty list is returned with a status of `Success`

**Signed commits**
- [X] Yes, I signed my commits.
