### PR TITLE
Scale celery memory use to system's available memory

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -145,7 +145,8 @@ def start_celery_worker_processes():
     #Calculate process scaling based on how much memory is available on the system in bytes.
     #Each celery process takes ~500MB or 500 * 1024^2 bytes
 
-    available_memory_in_bytes = psutil.virtual_memory().available
+    #Cap memory usage to 30% of total virtual memory
+    available_memory_in_bytes = psutil.virtual_memory().total * .3
     available_memory_in_megabytes = available_memory_in_bytes / (1024 ** 2)
     max_process_estimate = available_memory_in_megabytes // 500
 

--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -156,6 +156,7 @@ def start_celery_worker_processes():
 
     #2 processes are always reserved as a baseline.
     scheduling_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency=2 -n scheduling:{uuid.uuid4().hex}@%h -Q scheduling"
+    max_process_estimate -= 2
 
     core_num_processes = determine_worker_processes(.6, 45)
     #60% of estimate, Maximum value of 45
@@ -165,7 +166,7 @@ def start_celery_worker_processes():
     #20% of estimate, Maximum value of 25
     secondary_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency={secondary_num_processes} -n secondary:{uuid.uuid4().hex}@%h -Q secondary"
 
-    facade_num_processes = determine_worker_processes(.15, 20)
+    facade_num_processes = determine_worker_processes(.2, 20)
     #15% of estimate, Maximum value of 20
     facade_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency={facade_num_processes} -n facade:{uuid.uuid4().hex}@%h -Q facade"
 

--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -146,7 +146,7 @@ def start_celery_worker_processes():
     #Each celery process takes ~500MB or 500 * 1024^2 bytes
 
     #Cap memory usage to 30% of total virtual memory
-    available_memory_in_bytes = psutil.virtual_memory().total * .4
+    available_memory_in_bytes = psutil.virtual_memory().total * .25
     available_memory_in_megabytes = available_memory_in_bytes / (1024 ** 2)
     max_process_estimate = available_memory_in_megabytes // 500
 

--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -146,13 +146,13 @@ def start_celery_worker_processes():
     #Each celery process takes ~500MB or 500 * 1024^2 bytes
 
     #Cap memory usage to 30% of total virtual memory
-    available_memory_in_bytes = psutil.virtual_memory().total * .3
+    available_memory_in_bytes = psutil.virtual_memory().total * .4
     available_memory_in_megabytes = available_memory_in_bytes / (1024 ** 2)
     max_process_estimate = available_memory_in_megabytes // 500
 
     #Get a subset of the maximum procesess available using a ratio, not exceeding a maximum value
     def determine_worker_processes(ratio,maximum):
-        return min(round(max_process_estimate * ratio),maximum)
+        return max(min(round(max_process_estimate * ratio),maximum),1)
 
     #2 processes are always reserved as a baseline.
     scheduling_worker = f"celery -A augur.tasks.init.celery_app.celery_app worker -l info --concurrency=2 -n scheduling:{uuid.uuid4().hex}@%h -Q scheduling"


### PR DESCRIPTION
**Description**
- Reduce/Increase the amount of processes celery is allowed to use depending on the amount of available memory on the system. Data is gathered with psutil
- Hard cap the maximum amount of processes for each worker process to the previous default values

**Notes for Reviewers**
These changes should help to preserve some memory on systems with smaller amounts of it without hampering collection on larger memory instances. 

**Signed commits**
- [x] Yes, I signed my commits.
