### PR TITLE
Add config options for memory usage and frequency of refresh materialized views

### DIFF
--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -66,7 +66,9 @@ default_config = {
                 "log_level": "INFO",
             },
             "Celery": {
-                "concurrency": 12
+                "concurrency": 12,
+                "worker_process_vmem_cap": 0.25,
+                "refresh_materialized_views_interval_in_days": 7
             },
             "Redis": {
                 "cache_group": 0, 

--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -66,7 +66,6 @@ default_config = {
                 "log_level": "INFO",
             },
             "Celery": {
-                "concurrency": 12,
                 "worker_process_vmem_cap": 0.25,
                 "refresh_materialized_views_interval_in_days": 7
             },

--- a/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
+++ b/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
@@ -26,8 +26,10 @@ def upgrade():
         config = AugurConfig(logger,session)
         config_dict = config.load_config()
         
+        #Update the missing fields of the celery section in the config
         section = config_dict.get("Celery")
 
+        #Just copy the default if section doesn't exist.
         if section:
             if 'worker_process_vmem_cap' not in section.keys():
                 section['worker_process_vmem_cap'] = 0.25

--- a/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
+++ b/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
@@ -45,7 +45,7 @@ def downgrade():
 
     conn = op.get_bind()
 
-    con.execute(text(f"""
+    conn.execute(text(f"""
         DELETE FROM augur_operations.config
         WHERE section_name='Celery' AND (setting_name='worker_process_vmem_cap' OR setting_name='refresh_materialized_views_interval_in_days');
     """))

--- a/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
+++ b/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
@@ -41,6 +41,12 @@ def upgrade():
         
         config.add_section_from_json("Celery", section)
 
+        #delete old setting
+        session.execute_sql(text(f"""
+            DELETE FROM augur_operations.config
+            WHERE section_name='Celery' AND setting_name='concurrency';
+        """))
+
 
 
 def downgrade():
@@ -51,3 +57,10 @@ def downgrade():
         DELETE FROM augur_operations.config
         WHERE section_name='Celery' AND (setting_name='worker_process_vmem_cap' OR setting_name='refresh_materialized_views_interval_in_days');
     """))
+
+    try:
+        conn.execute(text(f"""
+            INSERT INTO augur_operations.config (section_name,setting_name,value,type) VALUES ('Celery','concurrency',12,'int');
+        """))
+    except:
+        pass

--- a/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
+++ b/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
@@ -1,0 +1,50 @@
+"""Add extra celery options to the config if they do not exist
+
+Revision ID: 19
+Revises: 18
+Create Date: 2023-05-15 12:03:57.171011
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from augur.application.db.session import DatabaseSession
+from augur.application.config import *
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '19'
+down_revision = '18'
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger(__name__)
+
+def upgrade():
+
+    with DatabaseSession(logger) as session:
+        config = AugurConfig(logger,session)
+        config_dict = config.load_config()
+        
+        section = config_dict.get("Celery")
+
+        if section:
+            if 'worker_process_vmem_cap' not in section.keys():
+                section['worker_process_vmem_cap'] = 0.25
+            
+            if 'refresh_materialized_views_interval_in_days' not in section.keys():
+                section['refresh_materialized_views_interval_in_days'] = 7
+        else:
+            section = config.default_config["Celery"]
+        
+        config.add_section_from_json("Celery", section)
+
+
+
+def downgrade():
+
+    conn = op.get_bind()
+
+    con.execute(text(f"""
+        DELETE FROM augur_operations.config
+        WHERE section_name='Celery' AND (setting_name='worker_process_vmem_cap' OR setting_name='refresh_materialized_views_interval_in_days');
+    """))

--- a/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
+++ b/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
@@ -10,6 +10,7 @@ import sqlalchemy as sa
 from augur.application.db.session import DatabaseSession
 from augur.application.config import *
 from sqlalchemy.sql import text
+import logging
 
 # revision identifiers, used by Alembic.
 revision = '19'

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -211,8 +211,9 @@ def setup_periodic_tasks(sender, **kwargs):
         logger.info(f"Scheduling non-repo-domain collection every {non_domain_collection_interval/60} minutes")
         sender.add_periodic_task(non_domain_collection_interval, non_repo_domain_tasks.s())
 
+        mat_views_interval = int(config.get_value('Celery', 'refresh_materialized_views_interval_in_days'))
         logger.info(f"Scheduling refresh materialized view every night at 1am CDT")
-        sender.add_periodic_task(datetime.timedelta(days=7), refresh_materialized_views.s())
+        sender.add_periodic_task(datetime.timedelta(days=mat_views_interval), refresh_materialized_views.s())
 
         logger.info(f"Scheduling update of collection weights on midnight each day")
         sender.add_periodic_task(crontab(hour=0, minute=0),augur_collection_update_weights.s())


### PR DESCRIPTION
**Description**

- Add default options to the config so users can set caps on celery worker memory usage as well as how often materialized views are refreshed. 

    - Default values are 7 days to refresh the materialized views and 0.25 (25%) for the virtual memory cap
- Add alembic script to handle updating existing configs to have the new options


**Signed commits**
- [x] Yes, I signed my commits.
