### PR TITLE
Repo group casing fix

### DIFF
--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -34,6 +34,8 @@ def av_add_user_repo():
     if group == "None":
         group = current_user.login_name + "_default"
 
+    urls = [url.lower() for url in urls]
+
     add_org_repo_list.si(current_user.user_id, group, urls).apply_async()
 
     flash("Adding repos and orgs in the background")

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -886,7 +886,7 @@ class UserRepo(Base):
 
         # if it doesn't exist create one
         if not repo_group:
-            repo_group = RepoGroup(rg_name=owner, rg_description="", rg_website="", rg_recache=0, rg_type="Unknown",
+            repo_group = RepoGroup(rg_name=owner.lower(), rg_description="", rg_website="", rg_recache=0, rg_type="Unknown",
                     tool_source="Loaded by user", tool_version="1.0", data_source="Git")
             session.add(repo_group)
             session.commit()


### PR DESCRIPTION
**Description**
- Updated repo group creation so it makes the repo groups always lower case
- Update add repo/org route so that it makes everything lowercase before processing them

**Notes for Reviewers**
I made both changes for double protection against incorrect casing

**Signed commits**
- [X] Yes, I signed my commits.
