### PR TITLE
[docs] Address missing installation details

### DIFF
--- a/docs/new-install.md
+++ b/docs/new-install.md
@@ -71,11 +71,22 @@ CREATE USER augur WITH ENCRYPTED PASSWORD 'password';
 GRANT ALL PRIVILEGES ON DATABASE augur TO augur;
 ```
 
-Once you are successfully logged out, return to your user by exiting `psql`, then typing `exit` to exit the postgres user, and `exit` a SECOND time to exit the root user. 
+**If you're using PostgreSQL 15 or later**, default database permissions will prevent Augur's installer from configuring the database. Add one last line after the above to fix this:
+```sql
+GRANT ALL ON SCHEMA public TO augur;
+```
+
+After that, return to your user by exiting `psql`
 ```
 postgres=# \quit
 ```
 
+Here we want to start an SSL connection to the `augur` database on port 5432:
+```shell
+psql -h localhost -U postgres -p 5432
+```
+
+Now type `exit` to log off the postgres user, and `exit` a SECOND time to log off the root user.
 ```shell
 exit
 exit 
@@ -97,6 +108,11 @@ sudo rabbitmqctl set_permissions -p augur_vhost augur ".*" ".*" ".*"
 - We then set permissions 
 
 NOTE: it is important to have a static hostname when using rabbitmq as it uses hostname to communicate with nodes.
+
+RabbitMQ's server can then be started from systemd:
+```shell
+sudo systemctl start rabbitmq-server
+```
 
 If your setup of rabbitmq is successful your broker url should look like this:
 
@@ -139,7 +155,7 @@ Where AugurB is the vhost. The management API at port 15672 will only exist if y
 ## Proxying Augur through Nginx
 Assumes nginx is installed. 
 
-Then you create a file for the server you want Augur to run under in the location of your `sites-enabled` directory for nginx (In this example, Augur is running on port 5038: (the long timeouts on the settings page is for when a user adds a large number of repos or orgs in a single session to prevent timeouts from nginx)
+Then you create a file for the server you want Augur to run under in the location of your `sites-enabled` directory for nginx. In this example, Augur is running on port 5038: (the long timeouts on the settings page is for when a user adds a large number of repos or orgs in a single session to prevent timeouts from nginx)
 
 ```
 server {
@@ -323,6 +339,8 @@ Augur will generally hold up to 150 simultaneous connections while collecting da
 To access command line options, use `augur --help`. To load repos from GitHub organizations prior to collection, or in other ways, the direct route is `augur db --help`. 
 
 Start a Flower Dashboard, which you can use to monitor progress, and report any failed processes as issues on the Augur GitHub site. The error rate for tasks is currently 0.04%, and most errors involve unhandled platform API timeouts. We continue to identify and add fixes to handle these errors through additional retries. Starting Flower: `(nohup celery -A augur.tasks.init.celery_app.celery_app flower --port=8400 --max-tasks=1000000 &)` NOTE: You can use any open port on your server, and access the dashboard in a browser with http://servername-or-ip:8400 in the example above (assuming you have access to that port, and its open on your network.)
+
+If you're using a virtual machine within Windows and you get an error about missing AVX instructions, you should kill Hyper-V. Even if it doesn't *appear* to be active, it might still be affecting your VM. Follow [these instructions](https://stackoverflow.com/a/68214280) to disable Hyper-V, and afterward AVX should pass to the VM.
 
 ## Starting your Augur Instance
 Start Augur: `(nohup augur backend start &)`

--- a/docs/new-install.rst
+++ b/docs/new-install.rst
@@ -100,13 +100,28 @@ Then, from within the resulting postgresql shell:
    CREATE USER augur WITH ENCRYPTED PASSWORD 'password';
    GRANT ALL PRIVILEGES ON DATABASE augur TO augur;
 
-Once you are successfully logged out, return to your user by exiting
-``psql``, then typing ``exit`` to exit the postgres user, and ``exit`` a
-SECOND time to exit the root user.
+**If you're using PostgreSQL 15 or later**, default database permissions will
+prevent Augur's installer from configuring the database. Add one last line
+after the above to fix this:
+
+.. code:: sql
+
+   GRANT ALL ON SCHEMA public TO augur;
+
+After that, return to your user by exiting ``psql``
 
 ::
 
    postgres=# \quit
+
+Here we want to start an SSL connection to the ``augur`` database on port 5432:
+
+.. code:: shell
+
+   psql -h localhost -U postgres -p 5432
+
+Now type ``exit`` to log off the postgres user, and ``exit`` a SECOND time to
+log off the root user.
 
 .. code:: shell
 
@@ -135,6 +150,12 @@ instance. You can accomplish this by running the below commands:
 
 NOTE: it is important to have a static hostname when using rabbitmq as
 it uses hostname to communicate with nodes.
+
+RabbitMQ's server can then be started from systemd:
+
+.. code:: shell
+
+   sudo systemctl start rabbitmq-server
 
 If your setup of rabbitmq is successful your broker url should look like
 this:
@@ -438,6 +459,12 @@ to handle these errors through additional retries. Starting Flower:
 NOTE: You can use any open port on your server, and access the dashboard
 in a browser with http://servername-or-ip:8400 in the example above
 (assuming you have access to that port, and its open on your network.)
+
+If you're using a virtual machine within Windows and you get an error about
+missing AVX instructions, you should kill Hyper-V. Even if it doesn't *appear*
+to be active, it might still be affecting your VM. Follow
+`these instructions <https://stackoverflow.com/a/68214280>`_ to disable
+Hyper-V, and afterward AVX should pass to the VM.
 
 Starting your Augur Instance
 ----------------------------


### PR DESCRIPTION
**Description**
Adds some critical installation steps to `new-install.md` and `new-install.rst`:

- create an SSL connection to the database for `make install` to access
- add PostgreSQL 15+ privileges to `augur` user
- start RabbitMQ server systemd service
- address AVX instruction error when in a VM under Windows (an issue with Hyper-V)

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->