### PR TITLE
Add old linux badge worker functionality back to augur

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -1691,6 +1691,21 @@ class RepoBadging(Base):
 
     repo = relationship("Repo")
 
+    @staticmethod
+    def insert(session, repo_id: int, data: dict) -> dict:
+
+        insert_statement = text("""INSERT INTO repo_badging (repo_id,tool_source,tool_version,data_source,data)
+        VALUES (:repo_id,:t_source,:t_version,:d_source,:data)
+        """).bindparams(
+            repo_id=repo_id,
+            t_source="collect_linux_badge_info",
+            t_version="0.50.3",
+            d_source="OSSF CII",
+            data=data
+        )
+
+        session.execute_sql(insert_statement)
+
 
 class RepoClusterMessage(Base):
     __tablename__ = "repo_cluster_messages"

--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 import logging
 import re
 from typing import List, Any, Dict
+import json
 
 
 from augur.application.db.models.base import Base
@@ -1701,7 +1702,7 @@ class RepoBadging(Base):
             t_source="collect_linux_badge_info",
             t_version="0.50.3",
             d_source="OSSF CII",
-            data=data
+            data=json.dumps(data,indent=4)
         )
 
         session.execute_sql(insert_statement)

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -25,10 +25,10 @@ def process_dependency_metrics(repo_git):
 
 
 @celery.task(base=AugurCoreRepoCollectionTask)
-def process_ossf_scorecard_metrics(repo_git):
+def process_ossf_dependency_metrics(repo_git):
     from augur.tasks.init.celery_app import engine
     
-    logger = logging.getLogger(process_ossf_scorecard_metrics.__name__)
+    logger = logging.getLogger(process_ossf_dependency_metrics.__name__)
 
     with DatabaseSession(logger, engine) as session:
         logger.info(f"repo_git: {repo_git}")

--- a/augur/tasks/github/repo_info/core.py
+++ b/augur/tasks/github/repo_info/core.py
@@ -12,7 +12,8 @@ from augur.tasks.github.util.util import get_owner_repo
 from augur.tasks.github.util.gh_graphql_entities import hit_api_graphql, request_graphql_dict
 from augur.application.db.models import *
 from augur.tasks.github.util.github_task_session import *
-
+from augur.application.db.models.augur_data import RepoBadging
+from urllib.parse import quote
 
 def query_committers_count(key_auth, logger, owner, repo):
 
@@ -290,5 +291,35 @@ def repo_info_model(augur_db, key_auth, repo_orm_obj, logger):
     augur_db.execute_sql(update_repo_data)
 
     logger.info(f"Inserted info for {owner}/{repo}\n")
+
+
+def badges_model(logger,repo_git,repo_id,db):
+    """ Data collection and storage method
+        Query the CII API and store the result in the DB for the badges model
+
+        This is a github task because it only covers github repos, this is not 
+        part of the regular repo info model because it uses a differant api + github.
+    """
+    cii_endpoint = "https://bestpractices.coreinfrastructure.org/projects.json?pq="
+
+    logger.info(f"Collecting badge data for {repo_git}")
+    git_url_extension = quote(repo_git[0:-4])
+
+    url = cii_endpoint + git_url_extension
+    logger.debug(f"Hitting CII endpoint: {url}")
+
+    #Hit cii api with no api key.
+    response = hit_api(None, url, logger)
+
+    try:
+        response_data = response.json()
+    except:
+        response_data = json.loads(json.dumps(response.text))
+
+    #Insert any data that was returned
+    if len(response_data) > 0:
+        RepoBadging.insert(db, repo_id, data)
+    else:
+        logger.info(f"Could not find CII data for {repo_git}")
 
 

--- a/augur/tasks/github/repo_info/core.py
+++ b/augur/tasks/github/repo_info/core.py
@@ -302,6 +302,8 @@ def badges_model(logger,repo_git,repo_id,db):
     """
     cii_endpoint = "https://bestpractices.coreinfrastructure.org/projects.json?pq="
 
+    
+    #https://github.com/chaoss/grimoirelab-hatstall
     logger.info(f"Collecting badge data for {repo_git}")
     git_url_extension = quote(repo_git[0:-4])
 
@@ -318,7 +320,7 @@ def badges_model(logger,repo_git,repo_id,db):
 
     #Insert any data that was returned
     if len(response_data) > 0:
-        RepoBadging.insert(db, repo_id, data)
+        RepoBadging.insert(db, repo_id, response_data)
     else:
         logger.info(f"Could not find CII data for {repo_git}")
 

--- a/augur/tasks/github/repo_info/tasks.py
+++ b/augur/tasks/github/repo_info/tasks.py
@@ -6,6 +6,8 @@ from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
 import traceback
 
+
+#Task to get regular misc github info
 @celery.task(base=AugurCoreRepoCollectionTask)
 def collect_repo_info(repo_git: str):
 
@@ -17,3 +19,17 @@ def collect_repo_info(repo_git: str):
         repo = execute_session_query(query, 'one')
         
         repo_info_model(augur_db, manifest.key_auth, repo, logger)
+
+
+#Task to get CII api data for linux badge info using github data.
+@celery.task(base=AugurCoreRepoCollectionTask)
+def collect_linux_badge_info(repo_git: str):
+
+    logger = logging.getLogger(collect_linux_badge_info.__name__)
+
+    with GithubTaskManifest(logger) as manifest:
+        augur_db = manifest.augur_db
+        query = augur_db.session.query(Repo).filter(Repo.repo_git == repo_git)
+        repo = execute_session_query(query, 'one')
+
+        badges_model(logger, repo_git, repo.repo_id, augur_db)

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -132,7 +132,7 @@ celery_app.conf.task_routes = {
     'augur.tasks.github.pull_requests.files_model.tasks.*': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.tasks.collect_pull_request_reviews': {'queue': 'secondary'},
     'augur.tasks.github.pull_requests.tasks.collect_pull_request_review_comments': {'queue': 'secondary'},
-    'augur.tasks.git.dependency_tasks.tasks.process_ossf_scorecard_metrics': {'queue': 'secondary'},
+    'augur.tasks.git.dependency_tasks.tasks.process_ossf_dependency_metrics': {'queue': 'secondary'},
     'augur.tasks.git.dependency_tasks.tasks.process_dependency_metrics': {'queue': 'facade'},
     'augur.tasks.git.dependency_libyear_tasks.tasks.process_libyear_dependency_metrics': {'queue': 'facade'},
     'augur.tasks.frontend.*': {'queue': 'frontend'}

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -22,7 +22,7 @@ from augur.tasks.github.releases.tasks import collect_releases
 from augur.tasks.github.repo_info.tasks import collect_repo_info
 from augur.tasks.github.pull_requests.files_model.tasks import process_pull_request_files
 from augur.tasks.github.pull_requests.commits_model.tasks import process_pull_request_commits
-from augur.tasks.git.dependency_tasks.tasks import process_ossf_scorecard_metrics
+from augur.tasks.git.dependency_tasks.tasks import process_ossf_dependency_metrics
 from augur.tasks.github.traffic.tasks import collect_github_repo_clones_data
 from augur.tasks.git.facade_tasks import *
 from augur.tasks.db.refresh_materialized_views import *
@@ -107,7 +107,7 @@ def secondary_repo_collect_phase(repo_git):
     repo_task_group = group(
         process_pull_request_files.si(repo_git),
         process_pull_request_commits.si(repo_git),
-        process_ossf_scorecard_metrics.si(repo_git),
+        process_ossf_dependency_metrics.si(repo_git),
         chain(collect_pull_request_reviews.si(repo_git), collect_pull_request_review_comments.si(repo_git))
     )
 


### PR DESCRIPTION
**Description**
- Add a new task called collect_linux_badge_info that collects the data the linux badge worker used to
- This task is in the same file as the repo_info task because it collects misc info about the repo
- The only reason it is in its own task is because it relies on both github and the CII api.
- Add an orm method to insert badge data.

**Notes for Reviewers**
Link to the old badge worker code: https://github.com/chaoss/augur/blob/old-main/workers/linux_badge_worker/linux_badge_worker.py

**Signed commits**
- [x] Yes, I signed my commits.
