### PR TITLE
[docs] Clarify prompts during `make install`

### DIFF
--- a/docs/new-install.md
+++ b/docs/new-install.md
@@ -250,9 +250,17 @@ Create a Python Virtual Environment `python3 -m venv ~/virtual-env-directory`
 
 Activate your Python Virtual Environment `source ~/virtual-env-directory/bin/activate`
 
-From the root of the Augur Directory, type `make install`
+From the root of the Augur Directory, type `make install`. You will be prompted to provide:
 
-You will be prompted to provide your GitHub username and password, your GitLab username and password, and the postgresql database where you want to have the Augur Schema built. You will also be prompted to provide a directory where repositories will be clone into. 
+- "User" is the PSQL database user, which is `augur` if you followed instructions exactly
+- "Password" is the above user's password
+- "Host" is the domain used with nginx, e.g. `ai.chaoss.io`
+- "Port" is 5432 unless you reconfigured something
+- "Database" is the name of the Augur database, which is `augur` if you followed instructions exactly
+- The GitHub token created earlier
+- Then the username associated with it
+- Then the same for GitLab
+- and finally a directory to clone repositories to
 
 ## Post Installation of Augur
 

--- a/docs/new-install.rst
+++ b/docs/new-install.rst
@@ -317,12 +317,20 @@ Create a Python Virtual Environment
 Activate your Python Virtual Environment
 ``source ~/virtual-env-directory/bin/activate``
 
-From the root of the Augur Directory, type ``make install``
+From the root of the Augur Directory, type ``make install``. You will be
+prompted to provide:
 
-You will be prompted to provide your GitHub username and password, your
-GitLab username and password, and the postgresql database where you want
-to have the Augur Schema built. You will also be prompted to provide a
-directory where repositories will be clone into.
+- "User" is the PSQL database user, which is ``augur`` if you followed
+  instructions exactly
+- "Password" is the above user's password
+- "Host" is the domain used with nginx, e.g. ``ai.chaoss.io``
+- "Port" is 5432 unless you reconfigured something
+- "Database" is the name of the Augur database, which is ``augur`` if you
+  followed instructions exactly
+- The GitHub token created earlier
+- Then the username associated with it
+- Then the same for GitLab
+- and finally a directory to clone repositories to
 
 Post Installation of Augur
 --------------------------


### PR DESCRIPTION
**Description**
The new install guide does not actually explain most of the prompts generated in the install script. It also claims the user is expected to input their own passwords which is (a) not true and (b) cause for users' concern.

This commit explains all the prompts and removes any notion of plaintext GitHub/GitLab passwords.

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->