### PR TITLE
Fix timestamp not being updated when repo collection fails because of 404

### DIFF
--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -106,9 +106,11 @@ def ping_github_for_repo_move(augur_db, key_auth, repo, logger,collection_hook='
     if collection_hook == 'core':
         collectionRecord.core_status = CollectionState.PENDING.value
         collectionRecord.core_task_id = None
+        collectionRecord.core_data_last_collected = datetime.today().strftime('%Y-%m-%dT%H:%M:%SZ')
     elif collection_hook == 'secondary':
         collectionRecord.secondary_status = CollectionState.PENDING.value
         collectionRecord.secondary_task_id = None
+        collectionRecord.secondary_data_last_collected = datetime.today().strftime('%Y-%m-%dT%H:%M:%SZ')
 
     augur_db.session.commit()
 

--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -64,7 +64,8 @@ def ping_github_for_repo_move(augur_db, key_auth, repo, logger,collection_hook='
         'repo_git': repo.repo_git,
         'repo_path': None,
         'repo_name': None,
-        'description': f"During our check for this repo on {datetime.today().strftime('%Y-%m-%d')}, a 404 error was returned. The repository does not appear to have moved. Instead, it appears to be deleted"
+        'description': f"During our check for this repo on {datetime.today().strftime('%Y-%m-%d')}, a 404 error was returned. The repository does not appear to have moved. Instead, it appears to be deleted",
+        'data_collection_date': datetime.today().strftime('%Y-%m-%dT%H:%M:%SZ')
         }
 
         update_repo_with_dict(current_repo_dict, repo_update_dict, logger, augur_db)


### PR DESCRIPTION
**Description**
- ping_github_for_repo_move now updates timestamp of the corresponding collection hook when a 404 happens
- This is to prevent 404 repos from showing up as much older than they actually are 

**Signed commits**
- [x] Yes, I signed my commits.
