### PR TITLE
Fix typos in docstring for remove_duplicate_dicts

### DIFF
--- a/augur/tasks/util/worker_util.py
+++ b/augur/tasks/util/worker_util.py
@@ -38,7 +38,7 @@ def wait_child_tasks(ids_list):
 
 
 def remove_duplicate_dicts(data: List[dict]) -> List[dict]:
-    """Removed duplicate dics from a list
+    """Remove duplicate dicts from a list
 
     Args:
         data: list of dicts that is being modified

--- a/docs/new-install.md
+++ b/docs/new-install.md
@@ -308,8 +308,8 @@ redis.exceptions.ConnectionError: Error 111 connecting to 127.0.0.1:6379. Connec
 
 **COMMAND**: 
 ```
-hugeadm --thp-never` &&
-echo never > /sys/kernel/mm/transparent_hugepage/enabled
+sudo hugeadm --thp-never &&
+sudo echo never > /sys/kernel/mm/transparent_hugepage/enabled
 ```
 
 

--- a/docs/new-install.md
+++ b/docs/new-install.md
@@ -29,7 +29,7 @@ sudo apt install rabbitmq-server && #required
 sudo snap install go --classic && #required: Go Needs to be version 1.19.x or higher. Snap is the package manager that gets you to the right version. Classic enables it to actually be installed at the correct version.
 sudo apt install nginx && # required for hosting
 sudo add-apt-repository ppa:mozillateam/firefox-next &&
-sudo apt install firefox=111.0~b8+build1-0ubuntu0.22.04.1 &&
+sudo apt install firefox=115.0~b2+build1-0ubuntu0.22.04.1 &&
 sudo apt install firefox-geckodriver
 
 # You will almost certainly need to reboot after this. 


### PR DESCRIPTION
This fix addresses a couple of spelling typos in the docstring of the remove_duplicate_dicts function.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).

Thanks for reviewing!