### PR TITLE
Contributor upsert fix

### DIFF
--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -133,7 +133,7 @@ def process_commit_metadata(logger,db,auth,contributorQueue,repo_id,platform_id)
 
         
         #Executes an upsert with sqlalchemy 
-        cntrb_natural_keys = ['cntrb_login']
+        cntrb_natural_keys = ['cntrb_id']
         
         db.insert_data(cntrb,Contributor,cntrb_natural_keys)
 


### PR DESCRIPTION
**Description**
- Update contributor upsert to use the cntrb_id as the unique instead of the cntrb_login

**Signed commits**
- [X] Yes, I signed my commits.
