### PR TITLE
Fix lack of uniformity in getting path for cloned repositories 

### DIFF
--- a/augur/tasks/git/dependency_libyear_tasks/core.py
+++ b/augur/tasks/git/dependency_libyear_tasks/core.py
@@ -11,18 +11,25 @@ from augur.application.config import AugurConfig
 from augur.application.db.util import execute_session_query
 from urllib.parse import quote
 from augur.tasks.git.dependency_libyear_tasks.libyear_util.util import get_deps_libyear_data
+from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path
 
 def deps_libyear_model( session, repo_id,repo_git,repo_group_id):
         """ Data collection and storage method
         """
         session.logger.info(f"This is the libyear deps model repo: {repo_git}")
 
-        result = re.search(r"https:\/\/(github\.com\/[A-Za-z0-9 \- _]+\/)([A-Za-z0-9 \- _ .]+)$", repo_git).groups()
+        #result = re.search(r"https:\/\/(github\.com\/[A-Za-z0-9 \- _]+\/)([A-Za-z0-9 \- _ .]+)$", repo_git).groups()
 
-        relative_repo_path = f"{repo_group_id}/{result[0]}{result[1]}"
+        #relative_repo_path = f"{repo_group_id}/{result[0]}{result[1]}"
+        query = session.query(Repo).filter(
+            Repo.repo_git == repo_git)
+        
+        result = execute_session_query(query, 'one')
+
         config = AugurConfig(session.logger, session)
         
-        absolute_repo_path = config.get_section("Facade")['repo_directory'] + relative_repo_path#self.config['repo_directory'] + relative_repo_path
+        absolute_repo_path = get_absolute_repo_path(config.get_section("Facade")['repo_directory'],repo_id,result.repo_path,result.repo_name)
+        #config.get_section("Facade")['repo_directory'] + relative_repo_path#self.config['repo_directory'] + relative_repo_path
 
         generate_deps_libyear_data(session,repo_id, absolute_repo_path)
 


### PR DESCRIPTION
**Description**
Fixed lack of uniformity in method of retrieving correct path to cloned repos in process_libyear_dependency_metrics 

**Signed commits**
- [x] Yes, I signed my commits.
