### PR TITLE
[WIP] [API] Paginate SQL queries

### DIFF
--- a/augur/application/db/engine.py
+++ b/augur/application/db/engine.py
@@ -15,7 +15,7 @@ from augur.application.db.util import catch_operational_error
 
 def parse_database_string(db_string) -> str:
     """Parse database string into the following components:
-        username, password, host, port, database 
+        username, password, host, port, database
     """
 
     match = re.match(r"postgresql\+psycopg2:\/\/(?P<username>[a-zA-Z0-9_]+):(?P<password>[^@]+)@(?P<host>[^:]+):(?P<port>\d+)\/(?P<database>\w+)", db_string)
@@ -55,9 +55,9 @@ def get_database_string() -> str:
     """Get database string from env or file
 
     Note:
-        If environment variable is defined the function 
-            will use that as the database string. And if the 
-            environment variable is not defined, it will use the 
+        If environment variable is defined the function
+            will use that as the database string. And if the
+            environment variable is not defined, it will use the
             db.config.json file to get the database string
 
     Returns:
@@ -91,15 +91,15 @@ def get_database_string() -> str:
 
     return db_conn_string
 
-def create_database_engine(url, **kwargs):  
-    """Create sqlalchemy database engine 
+def create_database_engine(url, **kwargs) -> Engine:
+    """Create sqlalchemy database engine
 
     Note:
         A new database engine is created each time the function is called
 
     Returns:
         sqlalchemy database engine
-    """ 
+    """
 
     engine = create_engine(url, **kwargs)
 
@@ -138,11 +138,11 @@ class DatabaseEngine():
         self._engine.dispose()
 
     @property
-    def engine(self):
+    def engine(self) -> Engine:
         return self._engine
 
 
-    def create_database_engine(self, **kwargs):  
+    def create_database_engine(self, **kwargs) -> Engine:
 
 
         db_conn_string = get_database_string()
@@ -166,8 +166,3 @@ class EngineConnection():
         func = engine.connect
 
         return catch_operational_error(func)
-
-        
-
-
-


### PR DESCRIPTION
**Description**

When finished, this PR will support and enforce pagination on SQL queries. At time of writing, only the `/api/unstable/repos` endpoint features this change.

Two URL parameters are accepted for pages: `page` contains the page number, defaulting to 1 if not provided, and `count` contains the number of elements (repos) per page, defaulting to 20 if not provided. Postgres provides `LIMIT` and `OFFSET` options for its `SELECT` queries which is used here to generate paginated responses.

- A naive defense against malicious URLs is present in the form of casting `request.args.get("foo")` from `str` to `int`, but I do not trust this fully enough for a production setting. The input of more experienced web developers would be greatly appreciated for this.
- It is not obvious to me how these changes could be factored out of the `get_all_repos` function and applied to other endpoints, such as `get_all_repo_groups` and `get_repos_in_repo_group`. Input is more than welcome.
- Being that this project belongs not to me but to CHAOSS, changes that their developers wish to see in the API design are important for me to consider, and are of course welcome in this thread.

[The `augur` branch of Mystic Evoker](https://opensource.ieee.org/rit/mystic-group/mystic-evoker/-/tree/augur?ref_type=heads) already contains support for these changes.

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->