### PR TITLE
[api] Add endpoint to get repo by ID

### DIFF
--- a/augur/api/routes/util.py
+++ b/augur/api/routes/util.py
@@ -1,20 +1,17 @@
 #SPDX-License-Identifier: MIT
+from augur.api.routes import AUGUR_API_VERSION
+from ..server import app, engine
 import base64
 import sqlalchemy as s
 import pandas as pd
 import json
 from flask import Response
-import logging
 
 from augur.application.db.session import DatabaseSession
 from augur.application.logs import AugurLogger
 from augur.application.config import AugurConfig
 
 logger = AugurLogger("augur").get_logger()
-
-from augur.api.routes import AUGUR_API_VERSION
-from ..server import app, engine
-
 
 @app.route('/{}/repo-groups'.format(AUGUR_API_VERSION))
 def get_all_repo_groups(): #TODO: make this name automatic - wrapper?
@@ -52,9 +49,9 @@ def get_all_repos():
             (select * from api_get_all_repos_issues) b
             on
             repo.repo_id = b.repo_id
-            left outer join 
-            (select * from api_get_all_repo_prs) c 
-            on repo.repo_id=c.repo_id 
+            left outer join
+            (select * from api_get_all_repo_prs) c
+            on repo.repo_id=c.repo_id
             JOIN repo_groups ON repo_groups.repo_group_id = repo.repo_group_id
         order by repo_name
     """)
@@ -91,9 +88,9 @@ def get_repos_in_repo_group(repo_group_id):
             (select * from api_get_all_repos_issues) b
             on
             repo.repo_id = b.repo_id
-            left outer join 
-            (select * from api_get_all_repo_prs) c 
-            on repo.repo_id=c.repo_id                 
+            left outer join
+            (select * from api_get_all_repo_prs) c
+            on repo.repo_id=c.repo_id
             JOIN repo_groups ON repo_groups.repo_group_id = repo.repo_group_id
         WHERE
             repo_groups.repo_group_id = :repo_group_id
@@ -103,6 +100,49 @@ def get_repos_in_repo_group(repo_group_id):
     results = pd.read_sql(repos_in_repo_groups_SQL, engine, params={'repo_group_id': repo_group_id})
     data = results.to_json(orient="records", date_format='iso', date_unit='ms')
     return Response(response=data,
+                    status=200,
+                    mimetype="application/json")
+
+@app.route('/{}/repos/<repo_id>'.format(AUGUR_API_VERSION))
+def get_repo_by_id(repo_id: int) -> Response:
+    repo_by_id_SQL = s.sql.text("""
+        SELECT
+            repo.repo_id,
+            repo.repo_name,
+            repo.description,
+            repo.repo_git AS url,
+            a.commits_all_time,
+            b.issues_all_time,
+            c.pull_requests_all_time,
+            rg_name,
+            repo.repo_group_id
+        FROM
+            repo
+            LEFT OUTER JOIN
+                (SELECT * FROM api_get_all_repos_commits) a
+            ON repo.repo_id = a.repo_id
+            LEFT OUTER JOIN
+                (SELECT * FROM api_get_all_repos_issues) b
+            ON repo.repo_id = b.repo_id
+            LEFT OUTER JOIN
+                (SELECT * FROM api_get_all_repo_prs) c
+            ON repo.repo_id = c.repo_id
+            JOIN repo_groups ON repo_groups.repo_group_id = repo.repo_group_id
+        WHERE
+            repo.repo_id = :id
+    """)
+
+    results = pd.read_sql(repo_by_id_SQL, engine, params={"id": repo_id})
+    results["url"] = results["url"].apply(lambda datum: datum.split("//")[1])  # cut "https://" off the URL
+    results["base64_url"] = [base64.b64encode(results.at[i, "url"].encode()) for i in results.index]
+    data = results.to_json(orient="records", date_format="iso", date_unit="ms")
+
+    if not data or data == "[]":
+        return Response(response='{"status": "Repository ' + str(repo_id) + ' does not exist"}',
+                        status=400,
+                        mimetype="application/json")
+
+    return Response(response=data[1:-1],  # cut off brackets at each end, turns list of length 1 into single value
                     status=200,
                     mimetype="application/json")
 

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -103,7 +103,7 @@ paths:
       responses:
         '200':
           description: OK
-          scema:
+          schema:
             items:
               properties:
                 base64_url:

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -98,7 +98,7 @@ paths:
       - utility
   /repos/:id:
     get:
-      description: Get a downloaded repo by its ID in Augur.
+      description: Get a downloaded repo by its ID in Augur. The schema block below says it is an array, but it is not.
       operationId: Get Repo By ID
       responses:
         '200':
@@ -136,7 +136,7 @@ paths:
                 url:
                   description: 'URL of this repository, sans leading protocol. Example: github.com/3scale/3scale-operator-metadata'
                   type: string
-            type: object
+            type: array
       tags:
       - utility
   /owner/:owner/repo/:repo:

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -96,6 +96,49 @@ paths:
             type: array
       tags:
       - utility
+  /repos/:id:
+    get:
+      description: Get a downloaded repo by its ID in Augur.
+      operationId: Get Repo By ID
+      responses:
+        '200':
+          description: OK
+          scema:
+            items:
+              properties:
+                base64_url:
+                  description: 'Base64 encode of the full URL. Example Z2l0aHViLmNvbS8zc2NhbGUvM3NjYWxlLW9wZXJhdG9yLW1ldGFkYXRh'
+                  type: string
+                description:
+                  description: 'Repository description. Example: null'
+                  type: string
+                commits_all_time:
+                  description: 'How many commits have been made to this respository. Example: 24'
+                  type: integer
+                issues_all_time:
+                  description: 'How many issues have been raised on this respository. Example: 1'
+                  type: integer
+                pull_requests_all_time:
+                  description: 'How many pull requests have been made to this reqpository. Example: 7'
+                  type: integer
+                repo_id:
+                  description: 'Repository ID, should match provided URL parameter. Example: 25551'
+                  type: integer
+                repo_name:
+                  description: 'Name of the provided rpository. Example: 3scale-operator-metadata'
+                  type: string
+                rg_name:
+                  description: 'Name of the repository group containing this repo. Example: 3scale'
+                  type: string
+                repo_group_id:
+                  description: 'ID of the repository group containing this repo. Example: 25431'
+                  type: integer
+                url:
+                  description: 'URL of this repository, sans leading protocol. Example: github.com/3scale/3scale-operator-metadata'
+                  type: string
+            type: object
+      tags:
+      - utility
   /owner/:owner/repo/:repo:
     get:
       description: Get the repo_group_id and repo_id of a particular repo.
@@ -284,12 +327,12 @@ paths:
       tags:
       - utility
   #risk endpoints
-  /metadata/repo_info: 
-    get: 
-      description: 'Returns the metadata about all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the default branch name, repository license file, forks, stars, watchers, and committers. Also includes metadata about current repository issue and pull request status and counts.' 
+  /metadata/repo_info:
+    get:
+      description: 'Returns the metadata about all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the default branch name, repository license file, forks, stars, watchers, and committers. Also includes metadata about current repository issue and pull request status and counts.'
       externalDocs:
         description: CHAOSS Metric Definition
-        url: https://github.com/chaoss/wg-risk/blob/main/focus-areas/business-risk.md  
+        url: https://github.com/chaoss/wg-risk/blob/main/focus-areas/business-risk.md
       operationId: Activity Metadata (Repo)
       responses:
         '200':
@@ -315,45 +358,45 @@ paths:
                 fork_count:
                   description: 'Example: 554'
                   type: integer
-                watchers_count: 
+                watchers_count:
                   description: 'Example: 424'
                   type: integer
-                stars_count: 
+                stars_count:
                   description: 'Example: 443'
                   type: integer
-                commits_count: 
+                commits_count:
                   description: '4434'
-                  type: integer 
-                committers_count: 
+                  type: integer
+                committers_count:
                   description: 'Example: 42'
                   type: integer
-                open_issues: 
+                open_issues:
                   description: 'Example: 7'
-                  type: integer 
-                issues_count: 
+                  type: integer
+                issues_count:
                   description: 'Example: 23332'
                   type: integer
-                issues_closed: 
+                issues_closed:
                   description: 'Example: 23322'
                   type: integer
-                pull_request_count: 
+                pull_request_count:
                   description: 'Example: 19445'
                   type: integer
-                pull_requests_open: 
+                pull_requests_open:
                   description: 'Example: 10'
                   type: integer
-                pull_requests_closed: 
+                pull_requests_closed:
                   description: 'Example: 19435'
                   type: integer
-                pull_requests_merged: 
+                pull_requests_merged:
                   description: 'Example: 17473'
                   type: integer
             type: array
       tags:
       - risk
-  /metadata/contributions_count: 
-    get: 
-      description: 'Returns a list of repositories contributed to by all the contributors in an Augur Instance: INCLUDING all repositories on a platform, *not* merely those repositories in the Augur Instance. Numerical totals represent total CONTRIBUTIONS.' 
+  /metadata/contributions_count:
+    get:
+      description: 'Returns a list of repositories contributed to by all the contributors in an Augur Instance: INCLUDING all repositories on a platform, *not* merely those repositories in the Augur Instance. Numerical totals represent total CONTRIBUTIONS.'
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/main/focus-areas/business-risk.md
@@ -373,9 +416,9 @@ paths:
             type: array
       tags:
       - risk
-  /metadata/contributors_count: 
-    get: 
-      description: 'Returns a list of repositories contributed to by all the contributors in an Augur Instance: INCLUDING all repositories on a platform, *not* merely those repositories in the Augur Instance. Numerical totals represent total CONTRIBUTORS.' 
+  /metadata/contributors_count:
+    get:
+      description: 'Returns a list of repositories contributed to by all the contributors in an Augur Instance: INCLUDING all repositories on a platform, *not* merely those repositories in the Augur Instance. Numerical totals represent total CONTRIBUTORS.'
       externalDocs:
         description: CHAOSS Metric Definition
         url: https://github.com/chaoss/wg-risk/blob/main/focus-areas/business-risk.md
@@ -5144,9 +5187,9 @@ paths:
             type: object
       tags:
         - visualizations
-  /complexity/project_lines: 
-    get: 
-      description: 'Returns project line data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average number of lines in the project repository.' 
+  /complexity/project_lines:
+    get:
+      description: 'Returns project line data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average number of lines in the project repository.'
       operationId: Total Lines (repo)
       responses:
         '200':
@@ -5172,9 +5215,9 @@ paths:
             type: array
       tags:
       - complexity
-  /complexity/project_file_complexity: 
-    get: 
-      description: 'Returns project file complexity data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average file complexity of the project repository.' 
+  /complexity/project_file_complexity:
+    get:
+      description: 'Returns project file complexity data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average file complexity of the project repository.'
       operationId: File Complexity (repo)
       responses:
         '200':
@@ -5200,9 +5243,9 @@ paths:
             type: array
       tags:
       - complexity
-  /complexity/project_blank_lines: 
-    get: 
-      description: 'Returns project blank line data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average number of blank lines in the project repository.' 
+  /complexity/project_blank_lines:
+    get:
+      description: 'Returns project blank line data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average number of blank lines in the project repository.'
       operationId: Total Blank Lines (repo)
       responses:
         '200':
@@ -5228,9 +5271,9 @@ paths:
             type: array
       tags:
       - complexity
-  /complexity/project_comment_lines: 
-    get: 
-      description: 'Returns project comment line data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average number of comment lines in the project repository.' 
+  /complexity/project_comment_lines:
+    get:
+      description: 'Returns project comment line data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total and average number of comment lines in the project repository.'
       operationId: Total Comment Lines (repo)
       responses:
         '200':
@@ -5256,9 +5299,9 @@ paths:
             type: array
       tags:
       - complexity
-  /complexity/project_files: 
-    get: 
-      description: 'Returns project file data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total number of files in the project repository.' 
+  /complexity/project_files:
+    get:
+      description: 'Returns project file data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the total number of files in the project repository.'
       operationId: Total Files (repo)
       responses:
         '200':
@@ -5281,9 +5324,9 @@ paths:
             type: array
       tags:
       - complexity
-  /complexity/project_languages: 
-    get: 
-      description: 'Returns project language data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the lines and files of a language in a repository.' 
+  /complexity/project_languages:
+    get:
+      description: 'Returns project language data for all repositories in an Augur instance, using information from a git platform (GitHub, GitLab, etc.). Each record includes the lines and files of a language in a repository.'
       operationId: Project Languages (repo)
       responses:
         '200':
@@ -5317,7 +5360,7 @@ paths:
       description: 'The number of messages exchanged for a repository group over a specified period.'
       externalDocs:
         description: CHAOSS Metric Definition
-        url: 
+        url:
       operationId: Repository Messages (Repo Group)
       parameters:
       - description: Repository Group ID


### PR DESCRIPTION
Documentation also written for this, though I'm not 100% sure "object" is a valid type. It definitely doesn't return an array.

**Description**
- Adds a utility endpoint to query a single repository. Contains much the same information as the /repos endpoint, but instead of returning an array of repositories, only one is returned. If the SQL read fails or no repository with the given ID is found, returns a 400.

I am told this functionality used to exist by using the special repo group ID 9999, and code using this feature [is still in Augur](https://github.com/chaoss/augur/blob/main/augur/tasks/data_analysis/insight_worker/tasks.py#L62), but that endpoint has been a 404 for as long as I have known Augur.

As usual, I also cleared linter warnings along the way (module-level import not at top of file and unused import) and removed ghostbytes.

**Notes for Reviewers**

The schema type is marked as `array` not because this endpoint actually returns an array -- it doesn't -- but because `object` wouldn't render the schema. For the first time, I had to document an error in the docs in the docs instead of fixing the error.

**Signed commits**
- [X] Yes, I signed my commits.