### PR TITLE
Fix old and bad method of getting absolute directory for cloned repos for the main dependency task

### DIFF
--- a/augur/tasks/git/dependency_tasks/core.py
+++ b/augur/tasks/git/dependency_tasks/core.py
@@ -14,7 +14,7 @@ from augur.application.db.util import execute_session_query
 from augur.tasks.git.dependency_tasks.dependency_util import dependency_calculator as dep_calc
 
 def generate_deps_data(session, repo_id, path):
-        """Runs scc on repo and stores data in database
+        """Runs deps modules on repo and stores data in database
         :param repo_id: Repository ID
         :param path: Absolute path of the Repostiory
         """
@@ -46,22 +46,16 @@ def generate_deps_data(session, repo_id, path):
         
         session.logger.info(f"Inserted {len(deps)} dependencies for repo {repo_id}")
 
+"""
+def deps_model(session, repo_id,repo_git,repo_path,repo_name):
+    # Data collection and storage method
 
-def deps_model(session, repo_id,repo_git,repo_group_id):
-    """ Data collection and storage method
-    """
     session.logger.info(f"This is the deps model repo: {repo_git}.")
 
     
 
-    #result = session.execute_sql(repo_path_sql)
-    result = re.search(r"https:\/\/(github\.com\/[A-Za-z0-9 \- _]+\/)([A-Za-z0-9 \- _ .]+)$", repo_git).groups()
-    
-    relative_repo_path = f"{repo_group_id}/{result[0]}{result[1]}"
-    config = AugurConfig(session.logger, session)
-    absolute_repo_path = config.get_section("Facade")['repo_directory'] + relative_repo_path
-
     generate_deps_data(session,repo_id, absolute_repo_path)
+"""
 
 def generate_scorecard(session,repo_id,path):
     """Runs scorecard on repo and stores data in database

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -26,6 +26,9 @@ def process_dependency_metrics(repo_git):
         config = AugurConfig(session.logger, session)
     
         absolute_repo_path = get_absolute_repo_path(config.get_section("Facade")['repo_directory'],repo.repo_id,repo.repo_path,repo.repo_name)
+
+        session.logger.debug(f"This is the deps model repo: {repo_git}.")
+
         generate_deps_data(session,repo.repo_id,absolute_repo_path)
 
 

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -6,6 +6,7 @@ from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask, AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path
+from augur.application.config import AugurConfig
 
 
 @celery.task(base=AugurFacadeRepoCollectionTask)

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -5,6 +5,7 @@ from augur.tasks.git.dependency_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask, AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
+from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path
 
 
 @celery.task(base=AugurFacadeRepoCollectionTask)
@@ -21,7 +22,11 @@ def process_dependency_metrics(repo_git):
         
 
         repo = execute_session_query(query,'one')
-        deps_model(session, repo.repo_id,repo_git,repo.repo_group_id)
+
+        config = AugurConfig(session.logger, session)
+    
+        absolute_repo_path = get_absolute_repo_path(config.get_section("Facade")['repo_directory'],repo.repo_id,repo.repo_path,repo.repo_name)
+        generate_deps_data(session,repo.repo_id,absolute_repo_path)
 
 
 @celery.task(base=AugurCoreRepoCollectionTask)


### PR DESCRIPTION
**Description**
Fixed out of date method for getting absolute directory of a repository in the deps_model. Now uses the same method that facade and everything else that needs to get an absolute directory of a cloned repo should use. 

**Signed commits**
- [x] Yes, I signed my commits.