### PR TITLE
Split ENTRYPOINT script in 2

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -42,5 +42,7 @@ RUN ./scripts/docker/install-go.sh
 RUN mkdir -p repos/ logs/ /augur/facade/
 
 COPY ./docker/backend/entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT /entrypoint.sh
+COPY ./docker/backend/init.sh /
+RUN chmod +x /entrypoint.sh /init.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD /init.sh

--- a/docker/backend/entrypoint.sh
+++ b/docker/backend/entrypoint.sh
@@ -13,15 +13,6 @@ elif [[ "$AUGUR_DB" == *"127.0.0.1"* ]]; then
     export AUGUR_DB="${AUGUR_DB/127.0.0.1/host.docker.internal}"
 fi
 
-
-
-if [[ "$AUGUR_DB_SCHEMA_BUILD" == "1" ]]; then
-    echo "why"
-    augur db create-schema
-fi
-
-target="docker"
-echo $target
 export AUGUR_FACADE_REPO_DIRECTORY=/augur/facade/
 export AUGUR_DOCKER_DEPLOY="1"
 
@@ -33,16 +24,4 @@ else
     export redis_conn_string=$REDIS_CONN_STRING
 fi
 
-if [ ! -v AUGUR_NO_CONFIG ]; then
-	./scripts/install/config.sh $target
-fi
-
-if [[ -f /repo_groups.csv ]]; then
-    augur db add-repo-groups /repo_groups.csv
-fi
-
-if [[ -f /repos.csv ]]; then
-   augur db add-repos /repos.csv
-fi
-
-exec augur backend start
+exec $*

--- a/docker/backend/init.sh
+++ b/docker/backend/init.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SPDX-License-Identifier: MIT
+set -e
+
+if [[ "$AUGUR_DB_SCHEMA_BUILD" == "1" ]]; then
+    augur db create-schema
+fi
+
+
+if [ ! -v AUGUR_NO_CONFIG ]; then
+	./scripts/install/config.sh docker
+fi
+
+if [[ -f /repo_groups.csv ]]; then
+    augur db add-repo-groups /repo_groups.csv
+fi
+
+if [[ -f /repos.csv ]]; then
+   augur db add-repos /repos.csv
+fi
+
+exec augur backend start


### PR DESCRIPTION
ENTRYPOINT is made to be used when the container is running one specific executable (think bash, or python) and is hard to override. However, when using the container, it is sometime needed to execute specific subcommand, such as augur db upgrade-db-version

**Signed commits**
- [X] Yes, I signed my commits.

