### PR TITLE
Fix issue assignees being wrongly assigned the issue user's cntrb_id

### DIFF
--- a/augur/tasks/github/issues/tasks.py
+++ b/augur/tasks/github/issues/tasks.py
@@ -207,7 +207,7 @@ def process_issue_contributors(issue, tool_source, tool_version, data_source):
 
     for assignee in issue["assignees"]:
 
-        issue_assignee_cntrb = extract_needed_contributor_data(issue["user"], tool_source, tool_version, data_source)
+        issue_assignee_cntrb = extract_needed_contributor_data(assignee, tool_source, tool_version, data_source)
         assignee["cntrb_id"] = issue_assignee_cntrb["cntrb_id"]
         contributors.append(issue_assignee_cntrb)
 


### PR DESCRIPTION
This PR fixes #
- Bug where the issue user's cntrb-id is assigned to all the issue assignee rows

**Signed commits**
- [X] Yes, I signed my commits.
