### PR TITLE
Wrong name in dependency metric modules

### DIFF
--- a/augur/tasks/git/dependency_tasks/dependency_util/kotlin_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/kotlin_deps.py
@@ -6,7 +6,7 @@ def get_files(path):
     files = list(p.glob('**/*.kt'))
     return files
 
-def get_imports_for_file(path):
+def get_deps_for_file(path):
     with open(path, 'r') as f:
         content = f.read()
         matches = re.findall('import\s+(.*?)(?:;|\n)', content, re.DOTALL)

--- a/augur/tasks/git/dependency_tasks/dependency_util/rust_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/rust_deps.py
@@ -9,7 +9,8 @@ def get_files(path):
     files = list(p.glob('**/*.rs'))
     return files
 
-def get_imports_for_file(path):
+def get_deps_for_file(path):
+    #gets imports in specified file path.
     with open(path, 'r') as f:
         content = f.read()
         matches = re.findall(r'use\s+([\w:]+)(\s+as\s+([\w:]+))?(\s*\*\s*)?(;|\n)', content)
@@ -18,4 +19,3 @@ def get_imports_for_file(path):
             import_path = m[0]
             imports.append(import_path)
         return imports
- 


### PR DESCRIPTION
**Description**
Change names of rust and kotlin dependency calculator functions to be uniform with the rest of the task.

**Signed commits**
- [x] Yes, I signed my commits.
