### PR TITLE
Dev alembic fix 123

### DIFF
--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -67,7 +67,7 @@ def add_fix_keys_25(upgrade=True):
             ----
             DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";
 
-                DROP MATERIALIZED VIEW "augur_data"."augur_new_contributors";
+                DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";
 
                 CREATE MATERIALIZED VIEW "augur_data"."augur_new_contributors"
                 AS

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -278,11 +278,11 @@ def add_fix_keys_25(upgrade=True):
 
       conn = op.get_bind()
       conn.execute(text("""
-        CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, created_at, repo_id, month, login, year, rank); """)) 
+        CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, created_at, repo_id, repo_name, login, rank); """)) 
       conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()
       conn.execute(text("""
-        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, month, year, repo_id, login, rank); """)) 
+        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, repo_id, repo_name, login, rank); """)) 
       conn.execute(text("""COMMIT;"""))
 

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -271,14 +271,19 @@ def add_fix_keys_25(upgrade=True):
             WHERE (a.repo_id = repo.repo_id)
             ORDER BY a.created_at DESC;
             
-             update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';
-             CREATE  UNIQUE INDEX ON augur_data.explorer_contributor_actions(cntrb_id,created_at,repo_id, action, repo_name,login, rank);"""))
+             update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';"""))
 
       conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, created_at, repo_id, repo_name, login, rank); """)) 
+      conn.execute(text("""COMMIT;"""))
+
+
+      conn = op.get_bind()
+      conn.execute(text("""
+        CREATE  UNIQUE INDEX ON augur_data.explorer_contributor_actions(cntrb_id,created_at,repo_id, action, repo_name,login, rank); """)) 
       conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -67,8 +67,6 @@ def add_fix_keys_25(upgrade=True):
             ----
             DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";
 
-                DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";
-
                 CREATE MATERIALIZED VIEW "augur_data"."augur_new_contributors"
                 AS
                 SELECT a.id AS cntrb_id,

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -65,9 +65,13 @@ def add_fix_keys_25(upgrade=True):
 
 
             ----
-            DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";
+            DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";"""))
 
-                CREATE MATERIALIZED VIEW "augur_data"."augur_new_contributors"
+      conn.execute(text("""COMMIT;"""))
+
+      conn = op.get_bind()
+      conn.execute(text(""" 
+                create MATERIALIZED VIEW "augur_data"."augur_new_contributors"
                 AS
                 SELECT a.id AS cntrb_id,
                     a.created_at,
@@ -170,109 +174,108 @@ def add_fix_keys_25(upgrade=True):
                 ALTER MATERIALIZED VIEW "augur_data"."augur_new_contributors" OWNER TO "augur";
 
             ----
-          create materialized view augur_data.explorer_contributor_actions as 
-          SELECT a.id AS cntrb_id,
-              a.created_at,
-              a.repo_id,
-              a.action,
-              repo.repo_name,
-              a.login,
-              row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at desc) AS rank
-             FROM ( SELECT commits.cmt_ght_author_id AS id,
-                      commits.cmt_author_timestamp AS created_at,
-                      commits.repo_id,
-                      'commit'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM (augur_data.commits
-                       LEFT JOIN augur_data.contributors ON (((contributors.cntrb_id)::text = (commits.cmt_ght_author_id)::text)))
-                    GROUP BY commits.cmt_commit_hash, commits.cmt_ght_author_id, commits.repo_id, commits.cmt_author_timestamp, 'commit'::text, contributors.cntrb_login
-                  UNION ALL
-                   SELECT issues.reporter_id AS id,
-                      issues.created_at,
-                      issues.repo_id,
-                      'issue_opened'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM (augur_data.issues
-                       LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issues.reporter_id)))
-                    WHERE (issues.pull_request IS NULL)
-                  UNION ALL
-                   SELECT pull_request_events.cntrb_id AS id,
-                      pull_request_events.created_at,
-                      pull_requests.repo_id,
-                      'pull_request_closed'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM augur_data.pull_requests,
-                      (augur_data.pull_request_events
-                       LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_events.cntrb_id)))
-                    WHERE ((pull_requests.pull_request_id = pull_request_events.pull_request_id) AND (pull_requests.pr_merged_at IS NULL) AND ((pull_request_events.action)::text = 'closed'::text))
-                  UNION ALL
-                   SELECT pull_request_events.cntrb_id AS id,
-                      pull_request_events.created_at,
-                      pull_requests.repo_id,
-                      'pull_request_merged'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM augur_data.pull_requests,
-                      (augur_data.pull_request_events
-                       LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_events.cntrb_id)))
-                    WHERE ((pull_requests.pull_request_id = pull_request_events.pull_request_id) AND ((pull_request_events.action)::text = 'merged'::text)) 
-                  UNION ALL
-                   SELECT issue_events.cntrb_id AS id,
-                      issue_events.created_at,
-                      issues.repo_id,
-                      'issue_closed'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM augur_data.issues,
-                      (augur_data.issue_events
-                       LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issue_events.cntrb_id)))
-                    WHERE ((issues.issue_id = issue_events.issue_id) AND (issues.pull_request IS NULL) AND ((issue_events.action)::text = 'closed'::text))
-                  UNION ALL
-                   SELECT pull_request_reviews.cntrb_id AS id,
-                      pull_request_reviews.pr_review_submitted_at AS created_at,
-                      pull_requests.repo_id,
-                      ('pull_request_review_'::text || (pull_request_reviews.pr_review_state)::text) AS action,
-                      contributors.cntrb_login AS login
-                     FROM augur_data.pull_requests,
-                      (augur_data.pull_request_reviews
-                       LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_reviews.cntrb_id)))
-                    WHERE (pull_requests.pull_request_id = pull_request_reviews.pull_request_id)
-                  UNION ALL
-                   SELECT pull_requests.pr_augur_contributor_id AS id,
-                      pull_requests.pr_created_at AS created_at,
-                      pull_requests.repo_id,
-                      'pull_request_open'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM (augur_data.pull_requests
-                       LEFT JOIN augur_data.contributors ON ((pull_requests.pr_augur_contributor_id = contributors.cntrb_id)))
-                  UNION ALL
-                   SELECT message.cntrb_id AS id,
-                      message.msg_timestamp AS created_at,
-                      pull_requests.repo_id,
-                      'pull_request_comment'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM augur_data.pull_requests,
-                      augur_data.pull_request_message_ref,
-                      (augur_data.message
-                       LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
-                    WHERE ((pull_request_message_ref.pull_request_id = pull_requests.pull_request_id) AND (pull_request_message_ref.msg_id = message.msg_id))
-                  UNION ALL
-                   SELECT issues.reporter_id AS id,
-                      message.msg_timestamp AS created_at,
-                      issues.repo_id,
-                      'issue_comment'::text AS action,
-                      contributors.cntrb_login AS login
-                     FROM augur_data.issues,
-                      augur_data.issue_message_ref,
-                      (augur_data.message
-                       LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
-                    WHERE ((issue_message_ref.msg_id = message.msg_id) AND (issues.issue_id = issue_message_ref.issue_id) AND (issues.closed_at <> message.msg_timestamp))) a,
-              augur_data.repo
-            WHERE (a.repo_id = repo.repo_id)
-            ORDER BY a.created_at DESC;
-            
-             update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';"""))
+              create materialized view augur_data.explorer_contributor_actions as 
+              SELECT a.id AS cntrb_id,
+                  a.created_at,
+                  a.repo_id,
+                  a.action,
+                  repo.repo_name,
+                  a.login,
+                  row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at desc) AS rank
+                 FROM ( SELECT commits.cmt_ght_author_id AS id,
+                          commits.cmt_author_timestamp AS created_at,
+                          commits.repo_id,
+                          'commit'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM (augur_data.commits
+                           LEFT JOIN augur_data.contributors ON (((contributors.cntrb_id)::text = (commits.cmt_ght_author_id)::text)))
+                        GROUP BY commits.cmt_commit_hash, commits.cmt_ght_author_id, commits.repo_id, commits.cmt_author_timestamp, 'commit'::text, contributors.cntrb_login
+                      UNION ALL
+                       SELECT issues.reporter_id AS id,
+                          issues.created_at,
+                          issues.repo_id,
+                          'issue_opened'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM (augur_data.issues
+                           LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issues.reporter_id)))
+                        WHERE (issues.pull_request IS NULL)
+                      UNION ALL
+                       SELECT pull_request_events.cntrb_id AS id,
+                          pull_request_events.created_at,
+                          pull_requests.repo_id,
+                          'pull_request_closed'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM augur_data.pull_requests,
+                          (augur_data.pull_request_events
+                           LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_events.cntrb_id)))
+                        WHERE ((pull_requests.pull_request_id = pull_request_events.pull_request_id) AND (pull_requests.pr_merged_at IS NULL) AND ((pull_request_events.action)::text = 'closed'::text))
+                      UNION ALL
+                       SELECT pull_request_events.cntrb_id AS id,
+                          pull_request_events.created_at,
+                          pull_requests.repo_id,
+                          'pull_request_merged'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM augur_data.pull_requests,
+                          (augur_data.pull_request_events
+                           LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_events.cntrb_id)))
+                        WHERE ((pull_requests.pull_request_id = pull_request_events.pull_request_id) AND ((pull_request_events.action)::text = 'merged'::text)) 
+                      UNION ALL
+                       SELECT issue_events.cntrb_id AS id,
+                          issue_events.created_at,
+                          issues.repo_id,
+                          'issue_closed'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM augur_data.issues,
+                          (augur_data.issue_events
+                           LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issue_events.cntrb_id)))
+                        WHERE ((issues.issue_id = issue_events.issue_id) AND (issues.pull_request IS NULL) AND ((issue_events.action)::text = 'closed'::text))
+                      UNION ALL
+                       SELECT pull_request_reviews.cntrb_id AS id,
+                          pull_request_reviews.pr_review_submitted_at AS created_at,
+                          pull_requests.repo_id,
+                          ('pull_request_review_'::text || (pull_request_reviews.pr_review_state)::text) AS action,
+                          contributors.cntrb_login AS login
+                         FROM augur_data.pull_requests,
+                          (augur_data.pull_request_reviews
+                           LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_reviews.cntrb_id)))
+                        WHERE (pull_requests.pull_request_id = pull_request_reviews.pull_request_id)
+                      UNION ALL
+                       SELECT pull_requests.pr_augur_contributor_id AS id,
+                          pull_requests.pr_created_at AS created_at,
+                          pull_requests.repo_id,
+                          'pull_request_open'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM (augur_data.pull_requests
+                           LEFT JOIN augur_data.contributors ON ((pull_requests.pr_augur_contributor_id = contributors.cntrb_id)))
+                      UNION ALL
+                       SELECT message.cntrb_id AS id,
+                          message.msg_timestamp AS created_at,
+                          pull_requests.repo_id,
+                          'pull_request_comment'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM augur_data.pull_requests,
+                          augur_data.pull_request_message_ref,
+                          (augur_data.message
+                           LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                        WHERE ((pull_request_message_ref.pull_request_id = pull_requests.pull_request_id) AND (pull_request_message_ref.msg_id = message.msg_id))
+                      UNION ALL
+                       SELECT issues.reporter_id AS id,
+                          message.msg_timestamp AS created_at,
+                          issues.repo_id,
+                          'issue_comment'::text AS action,
+                          contributors.cntrb_login AS login
+                         FROM augur_data.issues,
+                          augur_data.issue_message_ref,
+                          (augur_data.message
+                           LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                        WHERE ((issue_message_ref.msg_id = message.msg_id) AND (issues.issue_id = issue_message_ref.issue_id) AND (issues.closed_at <> message.msg_timestamp))) a,
+                  augur_data.repo
+                WHERE (a.repo_id = repo.repo_id)
+                ORDER BY a.created_at DESC;
+                
+                 update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';"""))
 
       conn.execute(text("""COMMIT;"""))
-
 
       conn.execute(text(""" drop materialized view if exists augur_data.explorer_new_contributors;
                     create materialized view augur_data.explorer_new_contributors

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -65,184 +65,118 @@ def add_fix_keys_25(upgrade=True):
             ----
             DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";
 
-            CREATE MATERIALIZED VIEW "augur_data"."augur_new_contributors"
-            AS
-            SELECT x.cntrb_id,
-                x.created_at,
-                x.month,
-                x.year,
-                x.repo_id,
-                x.repo_name,
-                x.full_name,
-                x.login,
-                x.rank
-               FROM ( SELECT b.cntrb_id,
-                        b.created_at,
-                        b.month,
-                        b.year,
-                        b.repo_id,
-                        b.repo_name,
-                        b.full_name,
-                        b.login,
-                        b.action,
-                        b.rank
-                       FROM ( SELECT a.id AS cntrb_id,
-                                a.created_at,
-                                date_part('month'::text, (a.created_at)::date) AS month,
-                                date_part('year'::text, (a.created_at)::date) AS year,
-                                a.repo_id,
-                                repo.repo_name,
-                                a.full_name,
-                                a.login,
-                                a.action,
-                                row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at) AS rank
-                               FROM ( SELECT canonical_full_names.canonical_id AS id,
-                                        issues.created_at,
-                                        issues.repo_id,
-                                        'issue_opened'::text AS action,
-                                        contributors.cntrb_full_name AS full_name,
-                                        contributors.cntrb_login AS login
-                                       FROM ((augur_data.issues
-                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issues.reporter_id)))
-                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
-                                                contributors_1.cntrb_canonical AS canonical_email,
-                                                contributors_1.data_collection_date,
-                                                contributors_1.cntrb_id AS canonical_id
-                                               FROM augur_data.contributors contributors_1
-                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
-                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
-                                      WHERE (issues.pull_request IS NULL)
-                                      GROUP BY canonical_full_names.canonical_id, issues.repo_id, issues.created_at, contributors.cntrb_full_name, contributors.cntrb_login
-                                    UNION ALL
-                                     SELECT canonical_full_names.canonical_id AS id,
-                                        to_timestamp((commits.cmt_author_date)::text, 'YYYY-MM-DD'::text) AS created_at,
-                                        commits.repo_id,
-                                        'commit'::text AS action,
-                                        contributors.cntrb_full_name AS full_name,
-                                        contributors.cntrb_login AS login
-                                       FROM ((augur_data.commits
-                                         LEFT JOIN augur_data.contributors ON (((contributors.cntrb_email)::text = (commits.cmt_author_email)::text)))
-                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
-                                                contributors_1.cntrb_canonical AS canonical_email,
-                                                contributors_1.data_collection_date,
-                                                contributors_1.cntrb_id AS canonical_id
-                                               FROM augur_data.contributors contributors_1
-                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
-                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
-                                      GROUP BY commits.repo_id, canonical_full_names.canonical_email, canonical_full_names.canonical_id, commits.cmt_author_date, contributors.cntrb_full_name, contributors.cntrb_login
-                                    UNION ALL
-                                     SELECT message.cntrb_id AS id,
-                                        commit_comment_ref.created_at,
-                                        commits.repo_id,
-                                        'commit_comment'::text AS action,
-                                        contributors.cntrb_full_name AS full_name,
-                                        contributors.cntrb_login AS login
-                                       FROM augur_data.commit_comment_ref,
-                                        augur_data.commits,
-                                        ((augur_data.message
-                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
-                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
-                                                contributors_1.cntrb_canonical AS canonical_email,
-                                                contributors_1.data_collection_date,
-                                                contributors_1.cntrb_id AS canonical_id
-                                               FROM augur_data.contributors contributors_1
-                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
-                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
-                                      WHERE ((commits.cmt_id = commit_comment_ref.cmt_id) AND (commit_comment_ref.msg_id = message.msg_id))
-                                      GROUP BY message.cntrb_id, commits.repo_id, commit_comment_ref.created_at, contributors.cntrb_full_name, contributors.cntrb_login
-                                    UNION ALL
-                                     SELECT issue_events.cntrb_id AS id,
-                                        issue_events.created_at,
-                                        issues.repo_id,
-                                        'issue_closed'::text AS action,
-                                        contributors.cntrb_full_name AS full_name,
-                                        contributors.cntrb_login AS login
-                                       FROM augur_data.issues,
-                                        ((augur_data.issue_events
-                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issue_events.cntrb_id)))
-                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
-                                                contributors_1.cntrb_canonical AS canonical_email,
-                                                contributors_1.data_collection_date,
-                                                contributors_1.cntrb_id AS canonical_id
-                                               FROM augur_data.contributors contributors_1
-                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
-                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
-                                      WHERE ((issues.issue_id = issue_events.issue_id) AND (issues.pull_request IS NULL) AND (issue_events.cntrb_id IS NOT NULL) AND ((issue_events.action)::text = 'closed'::text))
-                                      GROUP BY issue_events.cntrb_id, issues.repo_id, issue_events.created_at, contributors.cntrb_full_name, contributors.cntrb_login
-                                    UNION ALL
-                                     SELECT pull_requests.pr_augur_contributor_id AS id,
-                                        pull_requests.pr_created_at AS created_at,
-                                        pull_requests.repo_id,
-                                        'open_pull_request'::text AS action,
-                                        contributors.cntrb_full_name AS full_name,
-                                        contributors.cntrb_login AS login
-                                       FROM ((augur_data.pull_requests
-                                         LEFT JOIN augur_data.contributors ON ((pull_requests.pr_augur_contributor_id = contributors.cntrb_id)))
-                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
-                                                contributors_1.cntrb_canonical AS canonical_email,
-                                                contributors_1.data_collection_date,
-                                                contributors_1.cntrb_id AS canonical_id
-                                               FROM augur_data.contributors contributors_1
-                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
-                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
-                                      GROUP BY pull_requests.pr_augur_contributor_id, pull_requests.repo_id, pull_requests.pr_created_at, contributors.cntrb_full_name, contributors.cntrb_login
-                                    UNION ALL
-                                     SELECT message.cntrb_id AS id,
-                                        message.msg_timestamp AS created_at,
-                                        pull_requests.repo_id,
-                                        'pull_request_comment'::text AS action,
-                                        contributors.cntrb_full_name AS full_name,
-                                        contributors.cntrb_login AS login
-                                       FROM augur_data.pull_requests,
-                                        augur_data.pull_request_message_ref,
-                                        ((augur_data.message
-                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
-                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
-                                                contributors_1.cntrb_canonical AS canonical_email,
-                                                contributors_1.data_collection_date,
-                                                contributors_1.cntrb_id AS canonical_id
-                                               FROM augur_data.contributors contributors_1
-                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
-                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
-                                      WHERE ((pull_request_message_ref.pull_request_id = pull_requests.pull_request_id) AND (pull_request_message_ref.msg_id = message.msg_id))
-                                      GROUP BY message.cntrb_id, pull_requests.repo_id, message.msg_timestamp, contributors.cntrb_full_name, contributors.cntrb_login
-                                    UNION ALL
-                                     SELECT issues.reporter_id AS id,
-                                        message.msg_timestamp AS created_at,
-                                        issues.repo_id,
-                                        'issue_comment'::text AS action,
-                                        contributors.cntrb_full_name AS full_name,
-                                        contributors.cntrb_login AS login
-                                       FROM augur_data.issues,
-                                        augur_data.issue_message_ref,
-                                        ((augur_data.message
-                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
-                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
-                                                contributors_1.cntrb_canonical AS canonical_email,
-                                                contributors_1.data_collection_date,
-                                                contributors_1.cntrb_id AS canonical_id
-                                               FROM augur_data.contributors contributors_1
-                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
-                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
-                                      WHERE ((issue_message_ref.msg_id = message.msg_id) AND (issues.issue_id = issue_message_ref.issue_id) AND (issues.pull_request_id = NULL::bigint))
-                                      GROUP BY issues.reporter_id, issues.repo_id, message.msg_timestamp, contributors.cntrb_full_name, contributors.cntrb_login) a,
-                                augur_data.repo
-                              WHERE ((a.id IS NOT NULL) AND (a.repo_id = repo.repo_id))
-                              GROUP BY a.id, a.repo_id, a.action, a.created_at, repo.repo_name, a.full_name, a.login
-                              ORDER BY a.id) b
-                      WHERE (b.rank = ANY (ARRAY[(1)::bigint, (2)::bigint, (3)::bigint, (4)::bigint, (5)::bigint, (6)::bigint, (7)::bigint]))) x;
+                DROP MATERIALIZED VIEW "augur_data"."augur_new_contributors";
 
-            ALTER MATERIALIZED VIEW "augur_data"."augur_new_contributors" OWNER TO "augur";
+                CREATE MATERIALIZED VIEW "augur_data"."augur_new_contributors"
+                AS
+                SELECT a.id AS cntrb_id,
+                    a.created_at,
+                    a.repo_id,
+                    a.action,
+                    repo.repo_name,
+                    a.login,
+                    row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at DESC) AS rank
+                   FROM ( SELECT commits.cmt_ght_author_id AS id,
+                            commits.cmt_author_timestamp AS created_at,
+                            commits.repo_id,
+                            'commit'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM (augur_data.commits
+                             LEFT JOIN augur_data.contributors ON (((contributors.cntrb_id)::text = (commits.cmt_ght_author_id)::text)))
+                          GROUP BY commits.cmt_commit_hash, commits.cmt_ght_author_id, commits.repo_id, commits.cmt_author_timestamp, 'commit'::text, contributors.cntrb_login
+                        UNION ALL
+                         SELECT issues.reporter_id AS id,
+                            issues.created_at,
+                            issues.repo_id,
+                            'issue_opened'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM (augur_data.issues
+                             LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issues.reporter_id)))
+                          WHERE (issues.pull_request IS NULL)
+                        UNION ALL
+                         SELECT pull_request_events.cntrb_id AS id,
+                            pull_request_events.created_at,
+                            pull_requests.repo_id,
+                            'pull_request_closed'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM augur_data.pull_requests,
+                            (augur_data.pull_request_events
+                             LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_events.cntrb_id)))
+                          WHERE ((pull_requests.pull_request_id = pull_request_events.pull_request_id) AND (pull_requests.pr_merged_at IS NULL) AND ((pull_request_events.action)::text = 'closed'::text))
+                        UNION ALL
+                         SELECT pull_request_events.cntrb_id AS id,
+                            pull_request_events.created_at,
+                            pull_requests.repo_id,
+                            'pull_request_merged'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM augur_data.pull_requests,
+                            (augur_data.pull_request_events
+                             LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_events.cntrb_id)))
+                          WHERE ((pull_requests.pull_request_id = pull_request_events.pull_request_id) AND ((pull_request_events.action)::text = 'merged'::text))
+                        UNION ALL
+                         SELECT issue_events.cntrb_id AS id,
+                            issue_events.created_at,
+                            issues.repo_id,
+                            'issue_closed'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM augur_data.issues,
+                            (augur_data.issue_events
+                             LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issue_events.cntrb_id)))
+                          WHERE ((issues.issue_id = issue_events.issue_id) AND (issues.pull_request IS NULL) AND ((issue_events.action)::text = 'closed'::text))
+                        UNION ALL
+                         SELECT pull_request_reviews.cntrb_id AS id,
+                            pull_request_reviews.pr_review_submitted_at AS created_at,
+                            pull_requests.repo_id,
+                            ('pull_request_review_'::text || (pull_request_reviews.pr_review_state)::text) AS action,
+                            contributors.cntrb_login AS login
+                           FROM augur_data.pull_requests,
+                            (augur_data.pull_request_reviews
+                             LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = pull_request_reviews.cntrb_id)))
+                          WHERE (pull_requests.pull_request_id = pull_request_reviews.pull_request_id)
+                        UNION ALL
+                         SELECT pull_requests.pr_augur_contributor_id AS id,
+                            pull_requests.pr_created_at AS created_at,
+                            pull_requests.repo_id,
+                            'pull_request_open'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM (augur_data.pull_requests
+                             LEFT JOIN augur_data.contributors ON ((pull_requests.pr_augur_contributor_id = contributors.cntrb_id)))
+                        UNION ALL
+                         SELECT message.cntrb_id AS id,
+                            message.msg_timestamp AS created_at,
+                            pull_requests.repo_id,
+                            'pull_request_comment'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM augur_data.pull_requests,
+                            augur_data.pull_request_message_ref,
+                            (augur_data.message
+                             LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                          WHERE ((pull_request_message_ref.pull_request_id = pull_requests.pull_request_id) AND (pull_request_message_ref.msg_id = message.msg_id))
+                        UNION ALL
+                         SELECT issues.reporter_id AS id,
+                            message.msg_timestamp AS created_at,
+                            issues.repo_id,
+                            'issue_comment'::text AS action,
+                            contributors.cntrb_login AS login
+                           FROM augur_data.issues,
+                            augur_data.issue_message_ref,
+                            (augur_data.message
+                             LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                          WHERE ((issue_message_ref.msg_id = message.msg_id) AND (issues.issue_id = issue_message_ref.issue_id) AND (issues.closed_at <> message.msg_timestamp))) a,
+                    augur_data.repo
+                  WHERE (a.repo_id = repo.repo_id)
+                  ORDER BY a.created_at DESC;
 
-            CREATE UNIQUE INDEX "augur_new_contributors_cntrb_id_repo_id_month_login_year_ra_idx" ON "augur_data"."augur_new_contributors" USING btree (
-              "cntrb_id" "pg_catalog"."uuid_ops" ASC NULLS LAST,
-              "repo_id" "pg_catalog"."int8_ops" ASC NULLS LAST,
-              "month" "pg_catalog"."float8_ops" ASC NULLS LAST,
-              "login" COLLATE "pg_catalog"."default" "pg_catalog"."text_ops" ASC NULLS LAST,
-              "year" "pg_catalog"."float8_ops" ASC NULLS LAST,
-              "rank" "pg_catalog"."int8_ops" ASC NULLS LAST
-            );
+                ALTER MATERIALIZED VIEW "augur_data"."augur_new_contributors" OWNER TO "augur";
 
+                CREATE UNIQUE INDEX "augur_new_contributors_cntrb_id_repo_id_month_login_year_ra_idx" ON "augur_data"."augur_new_contributors" USING btree (
+                  "cntrb_id" "pg_catalog"."uuid_ops" ASC NULLS LAST,
+                  "repo_id" "pg_catalog"."int8_ops" ASC NULLS LAST,
+                  "month" "pg_catalog"."float8_ops" ASC NULLS LAST,
+                  "login" COLLATE "pg_catalog"."default" "pg_catalog"."text_ops" ASC NULLS LAST,
+                  "year" "pg_catalog"."float8_ops" ASC NULLS LAST,
+                  "rank" "pg_catalog"."int8_ops" ASC NULLS LAST
+                );
             ----
           create materialized view augur_data.explorer_contributor_actions as 
           SELECT a.id AS cntrb_id,

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -33,28 +33,28 @@ def add_fix_keys_25(upgrade=True):
 
       conn = op.get_bind() 
       conn.execute(text("""CREATE UNIQUE INDEX ON augur_data.api_get_all_repo_prs(repo_id);"""))
-      conn.commit()
+      conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.api_get_all_repos_commits(repo_id); """)) 
-      conn.commit()
+      conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.api_get_all_repos_issues(repo_id); """)) 
-      conn.commit()
+      conn.execute(text("""COMMIT;"""))
 
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.explorer_commits_and_committers_daily_count( repo_id, cmt_committer_date); """)) 
-      conn.commit()
+      conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.explorer_entry_list(repo_id); """)) 
-      conn.commit()
+      conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()
       conn.execute(text("""
@@ -274,15 +274,15 @@ def add_fix_keys_25(upgrade=True):
              update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';
              CREATE  UNIQUE INDEX ON augur_data.explorer_contributor_actions(cntrb_id,created_at,repo_id, action, repo_name,login, rank);"""))
 
-      conn.commit()
+      conn.execute(text("""COMMIT;"""))
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, created_at, repo_id, month, login, year, rank); """)) 
-      conn.commit()
-      
+      conn.execute(text("""COMMIT;"""))
+
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, month, year, repo_id, login, rank); """)) 
-      conn.commit()
+      conn.execute(text("""COMMIT;"""))
 

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -63,10 +63,8 @@ def add_fix_keys_25(upgrade=True):
           drop MATERIALIZED VIEW if exists augur_data.explorer_libyear_all;
           drop MATERIALIZED VIEW if exists augur_data.explorer_libyear_detail;
           drop MATERIALIZED VIEW if exists augur_data.explorer_libyear_summary; 
-          drop MATERIALIZED VIEW if exists augur_data.explorer_contributor_actions; """))
+          drop MATERIALIZED VIEW if exists augur_data.explorer_contributor_actions; 
 
-      conn = op.get_bind()
-      conn.execute(text("""
           create materialized view augur_data.explorer_contributor_actions as 
           SELECT a.id AS cntrb_id,
               a.created_at,
@@ -166,9 +164,7 @@ def add_fix_keys_25(upgrade=True):
             WHERE (a.repo_id = repo.repo_id)
             ORDER BY a.created_at DESC;
             
-             update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';"""))
+             update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';
+             CREATE  UNIQUE INDEX ON augur_data.explorer_contributor_actions(cntrb_id,created_at,repo_id, action, repo_name,login, rank);"""))
 
-      conn = op.get_bind()
-      conn.execute(text("""
-         CREATE  UNIQUE INDEX ON augur_data.explorer_contributor_actions(cntrb_id,created_at,repo_id, action, repo_name,login, rank); """)) 
 

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -44,10 +44,6 @@ def add_fix_keys_25(upgrade=True):
 
       conn = op.get_bind()
       conn.execute(text("""
-        CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, repo_id, month, login, year, rank); """)) 
-
-      conn = op.get_bind()
-      conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.explorer_commits_and_committers_daily_count( repo_id, cmt_committer_date); """)) 
 
       conn = op.get_bind()
@@ -65,6 +61,189 @@ def add_fix_keys_25(upgrade=True):
           drop MATERIALIZED VIEW if exists augur_data.explorer_libyear_summary; 
           drop MATERIALIZED VIEW if exists augur_data.explorer_contributor_actions; 
 
+
+            ----
+            DROP MATERIALIZED VIEW if exists "augur_data"."augur_new_contributors";
+
+            CREATE MATERIALIZED VIEW "augur_data"."augur_new_contributors"
+            AS
+            SELECT x.cntrb_id,
+                x.created_at,
+                x.month,
+                x.year,
+                x.repo_id,
+                x.repo_name,
+                x.full_name,
+                x.login,
+                x.rank
+               FROM ( SELECT b.cntrb_id,
+                        b.created_at,
+                        b.month,
+                        b.year,
+                        b.repo_id,
+                        b.repo_name,
+                        b.full_name,
+                        b.login,
+                        b.action,
+                        b.rank
+                       FROM ( SELECT a.id AS cntrb_id,
+                                a.created_at,
+                                date_part('month'::text, (a.created_at)::date) AS month,
+                                date_part('year'::text, (a.created_at)::date) AS year,
+                                a.repo_id,
+                                repo.repo_name,
+                                a.full_name,
+                                a.login,
+                                a.action,
+                                row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at) AS rank
+                               FROM ( SELECT canonical_full_names.canonical_id AS id,
+                                        issues.created_at,
+                                        issues.repo_id,
+                                        'issue_opened'::text AS action,
+                                        contributors.cntrb_full_name AS full_name,
+                                        contributors.cntrb_login AS login
+                                       FROM ((augur_data.issues
+                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issues.reporter_id)))
+                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                contributors_1.cntrb_canonical AS canonical_email,
+                                                contributors_1.data_collection_date,
+                                                contributors_1.cntrb_id AS canonical_id
+                                               FROM augur_data.contributors contributors_1
+                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                      WHERE (issues.pull_request IS NULL)
+                                      GROUP BY canonical_full_names.canonical_id, issues.repo_id, issues.created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                    UNION ALL
+                                     SELECT canonical_full_names.canonical_id AS id,
+                                        to_timestamp((commits.cmt_author_date)::text, 'YYYY-MM-DD'::text) AS created_at,
+                                        commits.repo_id,
+                                        'commit'::text AS action,
+                                        contributors.cntrb_full_name AS full_name,
+                                        contributors.cntrb_login AS login
+                                       FROM ((augur_data.commits
+                                         LEFT JOIN augur_data.contributors ON (((contributors.cntrb_email)::text = (commits.cmt_author_email)::text)))
+                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                contributors_1.cntrb_canonical AS canonical_email,
+                                                contributors_1.data_collection_date,
+                                                contributors_1.cntrb_id AS canonical_id
+                                               FROM augur_data.contributors contributors_1
+                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                      GROUP BY commits.repo_id, canonical_full_names.canonical_email, canonical_full_names.canonical_id, commits.cmt_author_date, contributors.cntrb_full_name, contributors.cntrb_login
+                                    UNION ALL
+                                     SELECT message.cntrb_id AS id,
+                                        commit_comment_ref.created_at,
+                                        commits.repo_id,
+                                        'commit_comment'::text AS action,
+                                        contributors.cntrb_full_name AS full_name,
+                                        contributors.cntrb_login AS login
+                                       FROM augur_data.commit_comment_ref,
+                                        augur_data.commits,
+                                        ((augur_data.message
+                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                contributors_1.cntrb_canonical AS canonical_email,
+                                                contributors_1.data_collection_date,
+                                                contributors_1.cntrb_id AS canonical_id
+                                               FROM augur_data.contributors contributors_1
+                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                      WHERE ((commits.cmt_id = commit_comment_ref.cmt_id) AND (commit_comment_ref.msg_id = message.msg_id))
+                                      GROUP BY message.cntrb_id, commits.repo_id, commit_comment_ref.created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                    UNION ALL
+                                     SELECT issue_events.cntrb_id AS id,
+                                        issue_events.created_at,
+                                        issues.repo_id,
+                                        'issue_closed'::text AS action,
+                                        contributors.cntrb_full_name AS full_name,
+                                        contributors.cntrb_login AS login
+                                       FROM augur_data.issues,
+                                        ((augur_data.issue_events
+                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issue_events.cntrb_id)))
+                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                contributors_1.cntrb_canonical AS canonical_email,
+                                                contributors_1.data_collection_date,
+                                                contributors_1.cntrb_id AS canonical_id
+                                               FROM augur_data.contributors contributors_1
+                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                      WHERE ((issues.issue_id = issue_events.issue_id) AND (issues.pull_request IS NULL) AND (issue_events.cntrb_id IS NOT NULL) AND ((issue_events.action)::text = 'closed'::text))
+                                      GROUP BY issue_events.cntrb_id, issues.repo_id, issue_events.created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                    UNION ALL
+                                     SELECT pull_requests.pr_augur_contributor_id AS id,
+                                        pull_requests.pr_created_at AS created_at,
+                                        pull_requests.repo_id,
+                                        'open_pull_request'::text AS action,
+                                        contributors.cntrb_full_name AS full_name,
+                                        contributors.cntrb_login AS login
+                                       FROM ((augur_data.pull_requests
+                                         LEFT JOIN augur_data.contributors ON ((pull_requests.pr_augur_contributor_id = contributors.cntrb_id)))
+                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                contributors_1.cntrb_canonical AS canonical_email,
+                                                contributors_1.data_collection_date,
+                                                contributors_1.cntrb_id AS canonical_id
+                                               FROM augur_data.contributors contributors_1
+                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                      GROUP BY pull_requests.pr_augur_contributor_id, pull_requests.repo_id, pull_requests.pr_created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                    UNION ALL
+                                     SELECT message.cntrb_id AS id,
+                                        message.msg_timestamp AS created_at,
+                                        pull_requests.repo_id,
+                                        'pull_request_comment'::text AS action,
+                                        contributors.cntrb_full_name AS full_name,
+                                        contributors.cntrb_login AS login
+                                       FROM augur_data.pull_requests,
+                                        augur_data.pull_request_message_ref,
+                                        ((augur_data.message
+                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                contributors_1.cntrb_canonical AS canonical_email,
+                                                contributors_1.data_collection_date,
+                                                contributors_1.cntrb_id AS canonical_id
+                                               FROM augur_data.contributors contributors_1
+                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                      WHERE ((pull_request_message_ref.pull_request_id = pull_requests.pull_request_id) AND (pull_request_message_ref.msg_id = message.msg_id))
+                                      GROUP BY message.cntrb_id, pull_requests.repo_id, message.msg_timestamp, contributors.cntrb_full_name, contributors.cntrb_login
+                                    UNION ALL
+                                     SELECT issues.reporter_id AS id,
+                                        message.msg_timestamp AS created_at,
+                                        issues.repo_id,
+                                        'issue_comment'::text AS action,
+                                        contributors.cntrb_full_name AS full_name,
+                                        contributors.cntrb_login AS login
+                                       FROM augur_data.issues,
+                                        augur_data.issue_message_ref,
+                                        ((augur_data.message
+                                         LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                                         LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                contributors_1.cntrb_canonical AS canonical_email,
+                                                contributors_1.data_collection_date,
+                                                contributors_1.cntrb_id AS canonical_id
+                                               FROM augur_data.contributors contributors_1
+                                              WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                              ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                      WHERE ((issue_message_ref.msg_id = message.msg_id) AND (issues.issue_id = issue_message_ref.issue_id) AND (issues.pull_request_id = NULL::bigint))
+                                      GROUP BY issues.reporter_id, issues.repo_id, message.msg_timestamp, contributors.cntrb_full_name, contributors.cntrb_login) a,
+                                augur_data.repo
+                              WHERE ((a.id IS NOT NULL) AND (a.repo_id = repo.repo_id))
+                              GROUP BY a.id, a.repo_id, a.action, a.created_at, repo.repo_name, a.full_name, a.login
+                              ORDER BY a.id) b
+                      WHERE (b.rank = ANY (ARRAY[(1)::bigint, (2)::bigint, (3)::bigint, (4)::bigint, (5)::bigint, (6)::bigint, (7)::bigint]))) x;
+
+            ALTER MATERIALIZED VIEW "augur_data"."augur_new_contributors" OWNER TO "augur";
+
+            CREATE UNIQUE INDEX "augur_new_contributors_cntrb_id_repo_id_month_login_year_ra_idx" ON "augur_data"."augur_new_contributors" USING btree (
+              "cntrb_id" "pg_catalog"."uuid_ops" ASC NULLS LAST,
+              "repo_id" "pg_catalog"."int8_ops" ASC NULLS LAST,
+              "month" "pg_catalog"."float8_ops" ASC NULLS LAST,
+              "login" COLLATE "pg_catalog"."default" "pg_catalog"."text_ops" ASC NULLS LAST,
+              "year" "pg_catalog"."float8_ops" ASC NULLS LAST,
+              "rank" "pg_catalog"."int8_ops" ASC NULLS LAST
+            );
+
+            ----
           create materialized view augur_data.explorer_contributor_actions as 
           SELECT a.id AS cntrb_id,
               a.created_at,
@@ -166,5 +345,9 @@ def add_fix_keys_25(upgrade=True):
             
              update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';
              CREATE  UNIQUE INDEX ON augur_data.explorer_contributor_actions(cntrb_id,created_at,repo_id, action, repo_name,login, rank);"""))
+
+      conn = op.get_bind()
+      conn.execute(text("""
+        CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, repo_id, month, login, year, rank); """)) 
 
 

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -1,4 +1,4 @@
-"""a unique index on a materialized view allows it to be refreshed concurrently, preventing blocking behavior
+""" THIS WILL TAKE LONGER ON A LARGE SET OF REPOSITORIES : a unique index on a materialized view allows it to be refreshed concurrently, preventing blocking behavior
 
 Revision ID: 25
 Revises: 24

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -275,6 +275,178 @@ def add_fix_keys_25(upgrade=True):
 
       conn.execute(text("""COMMIT;"""))
 
+
+      conn.execute(text(""" drop materialized view if exists augur_data.explorer_new_contributors;
+                    create materialized view augur_data.explorer_new_contributors
+                    AS
+                    SELECT x.cntrb_id,
+                        x.created_at,
+                        x.month,
+                        x.year,
+                        x.repo_id,
+                        x.repo_name,
+                        x.full_name,
+                        x.login,
+                        x.rank
+                       FROM ( SELECT b.cntrb_id,
+                                b.created_at,
+                                b.month,
+                                b.year,
+                                b.repo_id,
+                                b.repo_name,
+                                b.full_name,
+                                b.login,
+                                b.action,
+                                b.rank
+                               FROM ( SELECT a.id AS cntrb_id,
+                                        a.created_at,
+                                        date_part('month'::text, (a.created_at)::date) AS month,
+                                        date_part('year'::text, (a.created_at)::date) AS year,
+                                        a.repo_id,
+                                        repo.repo_name,
+                                        a.full_name,
+                                        a.login,
+                                        a.action,
+                                        row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at) AS rank
+                                       FROM ( SELECT canonical_full_names.canonical_id AS id,
+                                                issues.created_at,
+                                                issues.repo_id,
+                                                'issue_opened'::text AS action,
+                                                contributors.cntrb_full_name AS full_name,
+                                                contributors.cntrb_login AS login
+                                               FROM ((augur_data.issues
+                                                 LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issues.reporter_id)))
+                                                 LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                        contributors_1.cntrb_canonical AS canonical_email,
+                                                        contributors_1.data_collection_date,
+                                                        contributors_1.cntrb_id AS canonical_id
+                                                       FROM augur_data.contributors contributors_1
+                                                      WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                                      ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                              WHERE (issues.pull_request IS NULL)
+                                              GROUP BY canonical_full_names.canonical_id, issues.repo_id, issues.created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                            UNION ALL
+                                             SELECT canonical_full_names.canonical_id AS id,
+                                                to_timestamp((commits.cmt_author_date)::text, 'YYYY-MM-DD'::text) AS created_at,
+                                                commits.repo_id,
+                                                'commit'::text AS action,
+                                                contributors.cntrb_full_name AS full_name,
+                                                contributors.cntrb_login AS login
+                                               FROM ((augur_data.commits
+                                                 LEFT JOIN augur_data.contributors ON (((contributors.cntrb_canonical)::text = (commits.cmt_author_email)::text)))
+                                                 LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                        contributors_1.cntrb_canonical AS canonical_email,
+                                                        contributors_1.data_collection_date,
+                                                        contributors_1.cntrb_id AS canonical_id
+                                                       FROM augur_data.contributors contributors_1
+                                                      WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                                      ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                              GROUP BY commits.repo_id, canonical_full_names.canonical_email, canonical_full_names.canonical_id, commits.cmt_author_date, contributors.cntrb_full_name, contributors.cntrb_login
+                                            UNION ALL
+                                             SELECT message.cntrb_id AS id,
+                                                commit_comment_ref.created_at,
+                                                commits.repo_id,
+                                                'commit_comment'::text AS action,
+                                                contributors.cntrb_full_name AS full_name,
+                                                contributors.cntrb_login AS login
+                                               FROM augur_data.commit_comment_ref,
+                                                augur_data.commits,
+                                                ((augur_data.message
+                                                 LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                                                 LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                        contributors_1.cntrb_canonical AS canonical_email,
+                                                        contributors_1.data_collection_date,
+                                                        contributors_1.cntrb_id AS canonical_id
+                                                       FROM augur_data.contributors contributors_1
+                                                      WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                                      ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                              WHERE ((commits.cmt_id = commit_comment_ref.cmt_id) AND (commit_comment_ref.msg_id = message.msg_id))
+                                              GROUP BY message.cntrb_id, commits.repo_id, commit_comment_ref.created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                            UNION ALL
+                                             SELECT issue_events.cntrb_id AS id,
+                                                issue_events.created_at,
+                                                issues.repo_id,
+                                                'issue_closed'::text AS action,
+                                                contributors.cntrb_full_name AS full_name,
+                                                contributors.cntrb_login AS login
+                                               FROM augur_data.issues,
+                                                ((augur_data.issue_events
+                                                 LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = issue_events.cntrb_id)))
+                                                 LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                        contributors_1.cntrb_canonical AS canonical_email,
+                                                        contributors_1.data_collection_date,
+                                                        contributors_1.cntrb_id AS canonical_id
+                                                       FROM augur_data.contributors contributors_1
+                                                      WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                                      ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                              WHERE ((issues.issue_id = issue_events.issue_id) AND (issues.pull_request IS NULL) AND (issue_events.cntrb_id IS NOT NULL) AND ((issue_events.action)::text = 'closed'::text))
+                                              GROUP BY issue_events.cntrb_id, issues.repo_id, issue_events.created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                            UNION ALL
+                                             SELECT pull_requests.pr_augur_contributor_id AS id,
+                                                pull_requests.pr_created_at AS created_at,
+                                                pull_requests.repo_id,
+                                                'open_pull_request'::text AS action,
+                                                contributors.cntrb_full_name AS full_name,
+                                                contributors.cntrb_login AS login
+                                               FROM ((augur_data.pull_requests
+                                                 LEFT JOIN augur_data.contributors ON ((pull_requests.pr_augur_contributor_id = contributors.cntrb_id)))
+                                                 LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                        contributors_1.cntrb_canonical AS canonical_email,
+                                                        contributors_1.data_collection_date,
+                                                        contributors_1.cntrb_id AS canonical_id
+                                                       FROM augur_data.contributors contributors_1
+                                                      WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                                      ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                              GROUP BY pull_requests.pr_augur_contributor_id, pull_requests.repo_id, pull_requests.pr_created_at, contributors.cntrb_full_name, contributors.cntrb_login
+                                            UNION ALL
+                                             SELECT message.cntrb_id AS id,
+                                                message.msg_timestamp AS created_at,
+                                                pull_requests.repo_id,
+                                                'pull_request_comment'::text AS action,
+                                                contributors.cntrb_full_name AS full_name,
+                                                contributors.cntrb_login AS login
+                                               FROM augur_data.pull_requests,
+                                                augur_data.pull_request_message_ref,
+                                                ((augur_data.message
+                                                 LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                                                 LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                        contributors_1.cntrb_canonical AS canonical_email,
+                                                        contributors_1.data_collection_date,
+                                                        contributors_1.cntrb_id AS canonical_id
+                                                       FROM augur_data.contributors contributors_1
+                                                      WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                                      ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                              WHERE ((pull_request_message_ref.pull_request_id = pull_requests.pull_request_id) AND (pull_request_message_ref.msg_id = message.msg_id))
+                                              GROUP BY message.cntrb_id, pull_requests.repo_id, message.msg_timestamp, contributors.cntrb_full_name, contributors.cntrb_login
+                                            UNION ALL
+                                             SELECT issues.reporter_id AS id,
+                                                message.msg_timestamp AS created_at,
+                                                issues.repo_id,
+                                                'issue_comment'::text AS action,
+                                                contributors.cntrb_full_name AS full_name,
+                                                contributors.cntrb_login AS login
+                                               FROM augur_data.issues,
+                                                augur_data.issue_message_ref,
+                                                ((augur_data.message
+                                                 LEFT JOIN augur_data.contributors ON ((contributors.cntrb_id = message.cntrb_id)))
+                                                 LEFT JOIN ( SELECT DISTINCT ON (contributors_1.cntrb_canonical) contributors_1.cntrb_full_name,
+                                                        contributors_1.cntrb_canonical AS canonical_email,
+                                                        contributors_1.data_collection_date,
+                                                        contributors_1.cntrb_id AS canonical_id
+                                                       FROM augur_data.contributors contributors_1
+                                                      WHERE ((contributors_1.cntrb_canonical)::text = (contributors_1.cntrb_email)::text)
+                                                      ORDER BY contributors_1.cntrb_canonical) canonical_full_names ON (((canonical_full_names.canonical_email)::text = (contributors.cntrb_canonical)::text)))
+                                              WHERE ((issue_message_ref.msg_id = message.msg_id) AND (issues.issue_id = issue_message_ref.issue_id) AND (issues.pull_request_id = NULL::bigint))
+                                              GROUP BY issues.reporter_id, issues.repo_id, message.msg_timestamp, contributors.cntrb_full_name, contributors.cntrb_login) a,
+                                        augur_data.repo
+                                      WHERE ((a.id IS NOT NULL) AND (a.repo_id = repo.repo_id))
+                                      GROUP BY a.id, a.repo_id, a.action, a.created_at, repo.repo_name, a.full_name, a.login
+                                      ORDER BY a.id) b
+                              WHERE (b.rank = ANY (ARRAY[(1)::bigint, (2)::bigint, (3)::bigint, (4)::bigint, (5)::bigint, (6)::bigint, (7)::bigint]))) x;
+
+                    ALTER MATERIALIZED VIEW augur_data.explorer_new_contributors OWNER TO augur;"""))
+      conn.execute(text("""COMMIT;"""))
+
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, created_at, repo_id, repo_name, login, rank); """)) 
@@ -288,6 +460,6 @@ def add_fix_keys_25(upgrade=True):
 
       conn = op.get_bind()
       conn.execute(text("""
-        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, month, year, repo_id, repo_name, login, rank); """)) 
+        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, month, year, repo_id, full_name, repo_name, login, rank); """)) 
       conn.execute(text("""COMMIT;"""))
 

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -33,26 +33,28 @@ def add_fix_keys_25(upgrade=True):
 
       conn = op.get_bind() 
       conn.execute(text("""CREATE UNIQUE INDEX ON augur_data.api_get_all_repo_prs(repo_id);"""))
+      conn.commit()
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.api_get_all_repos_commits(repo_id); """)) 
+      conn.commit()
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.api_get_all_repos_issues(repo_id); """)) 
+      conn.commit()
+
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.explorer_commits_and_committers_daily_count( repo_id, cmt_committer_date); """)) 
-
-      conn = op.get_bind()
-      conn.execute(text("""
-        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, month, year, repo_id, login, rank); """)) 
+      conn.commit()
 
       conn = op.get_bind()
       conn.execute(text("""
         CREATE  UNIQUE INDEX ON augur_data.explorer_entry_list(repo_id); """)) 
+      conn.commit()
 
       conn = op.get_bind()
       conn.execute(text("""
@@ -169,14 +171,6 @@ def add_fix_keys_25(upgrade=True):
 
                 ALTER MATERIALIZED VIEW "augur_data"."augur_new_contributors" OWNER TO "augur";
 
-                CREATE UNIQUE INDEX "augur_new_contributors_cntrb_id_repo_id_month_login_year_ra_idx" ON "augur_data"."augur_new_contributors" USING btree (
-                  "cntrb_id" "pg_catalog"."uuid_ops" ASC NULLS LAST,
-                  "repo_id" "pg_catalog"."int8_ops" ASC NULLS LAST,
-                  "month" "pg_catalog"."float8_ops" ASC NULLS LAST,
-                  "login" COLLATE "pg_catalog"."default" "pg_catalog"."text_ops" ASC NULLS LAST,
-                  "year" "pg_catalog"."float8_ops" ASC NULLS LAST,
-                  "rank" "pg_catalog"."int8_ops" ASC NULLS LAST
-                );
             ----
           create materialized view augur_data.explorer_contributor_actions as 
           SELECT a.id AS cntrb_id,
@@ -280,8 +274,15 @@ def add_fix_keys_25(upgrade=True):
              update augur_operations.config set value='1' where setting_name = 'refresh_materialized_views_interval_in_days';
              CREATE  UNIQUE INDEX ON augur_data.explorer_contributor_actions(cntrb_id,created_at,repo_id, action, repo_name,login, rank);"""))
 
+      conn.commit()
+
       conn = op.get_bind()
       conn.execute(text("""
-        CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, repo_id, month, login, year, rank); """)) 
-
+        CREATE  UNIQUE INDEX ON augur_data.augur_new_contributors( cntrb_id, created_at, repo_id, month, login, year, rank); """)) 
+      conn.commit()
+      
+      conn = op.get_bind()
+      conn.execute(text("""
+        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, month, year, repo_id, login, rank); """)) 
+      conn.commit()
 

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -307,7 +307,7 @@ def add_fix_keys_25(upgrade=True):
                                         a.full_name,
                                         a.login,
                                         a.action,
-                                        row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at) AS rank
+                                        row_number() OVER (PARTITION BY a.id, a.repo_id ORDER BY a.created_at desc) AS rank
                                        FROM ( SELECT canonical_full_names.canonical_id AS id,
                                                 issues.created_at,
                                                 issues.repo_id,

--- a/augur/application/schema/alembic/versions/25_unique_on_mataview.py
+++ b/augur/application/schema/alembic/versions/25_unique_on_mataview.py
@@ -283,6 +283,6 @@ def add_fix_keys_25(upgrade=True):
 
       conn = op.get_bind()
       conn.execute(text("""
-        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, repo_id, repo_name, login, rank); """)) 
+        CREATE  UNIQUE INDEX ON augur_data.explorer_new_contributors(cntrb_id, created_at, month, year, repo_id, repo_name, login, rank); """)) 
       conn.execute(text("""COMMIT;"""))
 

--- a/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -26,11 +26,34 @@ def contributor_breadth_model() -> None:
     tool_version = '0.0.1'
     data_source = 'GitHub API'
 
-
+    # This version of the query pulls contributors who have not had any data collected yet
+    # To the top of the list
     cntrb_login_query = s.sql.text("""
-        SELECT DISTINCT gh_login, cntrb_id 
-        FROM augur_data.contributors 
-        WHERE gh_login IS NOT NULL
+            SELECT DISTINCT
+                gh_login,
+                cntrb_id 
+            FROM
+                (
+                SELECT DISTINCT
+                    gh_login,
+                    cntrb_id,
+                    data_collection_date 
+                FROM
+                    (
+                    SELECT DISTINCT
+                        contributors.gh_login,
+                        contributors.cntrb_id,
+                        contributor_repo.data_collection_date :: DATE 
+                    FROM
+                        contributor_repo
+                        RIGHT OUTER JOIN contributors ON contributors.cntrb_id = contributor_repo.cntrb_id 
+                        AND contributors.gh_login IS NOT NULL 
+                    ORDER BY
+                        contributor_repo.data_collection_date :: DATE NULLS FIRST 
+                    ) A 
+                ORDER BY
+                data_collection_date DESC NULLS FIRST 
+                ) b
     """)
 
     result = engine.execute(cntrb_login_query)

--- a/augur/tasks/db/refresh_materialized_views.py
+++ b/augur/tasks/db/refresh_materialized_views.py
@@ -17,6 +17,7 @@ def refresh_materialized_views():
     from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(refresh_materialized_views.__name__)
+    self.logger = logging.getLogger(refresh_materialized_views.__name__)
 
     mv1_refresh = s.sql.text("""    
                 REFRESH MATERIALIZED VIEW concurrently augur_data.api_get_all_repo_prs with data;

--- a/augur/tasks/db/refresh_materialized_views.py
+++ b/augur/tasks/db/refresh_materialized_views.py
@@ -6,6 +6,7 @@ from celery import group, chain, chord, signature
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
+from augur.application.logs import AugurLogger
 
 
 @celery.task
@@ -15,18 +16,115 @@ def refresh_materialized_views():
 
     logger = logging.getLogger(refresh_materialized_views.__name__)
 
-    refresh_view_query = s.sql.text("""    
+    mv1_refresh = s.sql.text("""    
                 REFRESH MATERIALIZED VIEW concurrently augur_data.api_get_all_repo_prs with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.api_get_all_repos_commits with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.api_get_all_repos_issues with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.augur_new_contributors with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_commits_and_committers_daily_count with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_new_contributors with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_entry_list with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_new_contributors with data;
-                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_contributor_actions with data;
+                COMMIT; 
     """)
 
-    with DatabaseSession(logger, engine) as session:
+    mv2_refresh = s.sql.text("""    
+                REFRESH MATERIALIZED VIEW concurrently augur_data.api_get_all_repos_commits with data;
+                COMMIT; 
+    """)
 
-        session.execute_sql(refresh_view_query)
+    mv3_refresh = s.sql.text("""    
+                REFRESH MATERIALIZED VIEW concurrently augur_data.api_get_all_repos_issues with data;
+                COMMIT; 
+    """)
+
+    mv4_refresh = s.sql.text("""    
+                REFRESH MATERIALIZED VIEW concurrently augur_data.augur_new_contributors with data;
+                COMMIT; 
+    """)
+    mv5_refresh = s.sql.text("""    
+                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_commits_and_committers_daily_count with data;
+                COMMIT; 
+    """)
+
+    mv6_refresh = s.sql.text("""    
+                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_new_contributors with data;
+                COMMIT; 
+    """)
+
+    mv7_refresh = s.sql.text("""    
+                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_entry_list with data;
+                COMMIT; 
+    """)
+
+    mv_8_refresh = s.sql.text("""    
+
+                REFRESH MATERIALIZED VIEW concurrently augur_data.explorer_contributor_actions with data;
+                COMMIT; 
+    """)
+
+
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv1_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv1_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv2_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv3_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv4_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv5_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv6_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv7_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+    try: 
+        with DatabaseSession(logger, engine) as session:
+            session.execute_sql(mv8_refresh)
+    except Exception as e: 
+        AugurLogger.logger.info(f"error is {e}")
+        pass 
+
+
+
+
+
+
+

--- a/augur/tasks/db/refresh_materialized_views.py
+++ b/augur/tasks/db/refresh_materialized_views.py
@@ -12,7 +12,7 @@ from augur.application.logs import AugurLogger
 @celery.task
 def refresh_materialized_views():
 
-    self.logger = AugurLogger("data_collection_jobs").get_logger()
+    #self.logger = AugurLogger("data_collection_jobs").get_logger()
 
     from augur.tasks.init.celery_app import engine
 

--- a/augur/tasks/db/refresh_materialized_views.py
+++ b/augur/tasks/db/refresh_materialized_views.py
@@ -12,6 +12,8 @@ from augur.application.logs import AugurLogger
 @celery.task
 def refresh_materialized_views():
 
+    self.logger = AugurLogger("data_collection_jobs").get_logger()
+
     from augur.tasks.init.celery_app import engine
 
     logger = logging.getLogger(refresh_materialized_views.__name__)
@@ -62,7 +64,7 @@ def refresh_materialized_views():
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv1_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
 
@@ -70,56 +72,56 @@ def refresh_materialized_views():
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv1_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
     try: 
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv2_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
     try: 
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv3_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
     try: 
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv4_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
     try: 
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv5_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
     try: 
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv6_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
     try: 
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv7_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
     try: 
         with DatabaseSession(logger, engine) as session:
             session.execute_sql(mv8_refresh)
     except Exception as e: 
-        AugurLogger.logger.info(f"error is {e}")
+        self.logger.info(f"error is {e}")
         pass 
 
 

--- a/augur/tasks/github/util/github_api_key_handler.py
+++ b/augur/tasks/github/util/github_api_key_handler.py
@@ -76,8 +76,8 @@ class GithubApiKeyHandler():
         #select.order_by(func.random())
         where = [WorkerOauth.access_token != self.config_key, WorkerOauth.platform == 'github']
 
-        #return [key_tuple[0] for key_tuple in self.session.query(select).filter(*where).order_by(func.random()).all()]
-        return [key_tuple[0] for key_tuple in self.session.query(select).filter(*where).all()]
+        return [key_tuple[0] for key_tuple in self.session.query(select).filter(*where).order_by(func.random()).all()]
+        #return [key_tuple[0] for key_tuple in self.session.query(select).filter(*where).all()]
 
 
     def get_api_keys(self) -> List[str]:

--- a/augur/tasks/util/redis_list.py
+++ b/augur/tasks/util/redis_list.py
@@ -170,8 +170,8 @@ class RedisList(MutableSequence):
         if index is None:
             # This will get a random index from the list and remove it, 
             # decreasing the likelihood of everyone using the same key all the time
-            redis.rpop(self.redis_list_key)
-            #redis.spop(self.redis_list_key)
+            #redis.rpop(self.redis_list_key)
+            redis.spop(self.redis_list_key)
 
         else:
             # calls __delitem__


### PR DESCRIPTION
**Description**
- some of the alembic logic and keys needed updating for the materialized views
- also made slight change to the contributor_breadth_worker logic to explicitly get users without any contributor_repo records at all put at the top of the list in the initial query sort order. 
