### PR TITLE
Fix tables on user settings page clipping past end of column

### DIFF
--- a/augur/static/css/stylesheet.css
+++ b/augur/static/css/stylesheet.css
@@ -125,6 +125,10 @@ body {
     overflow: auto;
 }
 
+.display-table th {
+    word-wrap: normal;
+}
+
 .paginationActive {
     background-color: var(--color-accent-dark);
     border-color: var(--color-accent-dark);

--- a/augur/templates/settings.j2
+++ b/augur/templates/settings.j2
@@ -132,7 +132,7 @@
                                     {"title" : "Favorite"},
                                     {"title" : ""}]
                                     -%}
-                                    <div class="display-table rounded w3-animate-opacity">
+                                    <div class="display-table table-responsive rounded w3-animate-opacity">
                                         <table class="table table-striped table-bordered">
                                             <!-- Table header start -->
                                             <thead>
@@ -219,7 +219,7 @@
                                     {"title" : "Connected"},
                                     {"title" : ""}]
                                     -%}
-                                    <div class="display-table rounded w3-animate-opacity">
+                                    <div class="display-table table-responsive rounded w3-animate-opacity">
                                         <table class="table table-striped table-bordered">
                                             <!-- Table header start -->
                                             <thead>
@@ -258,7 +258,7 @@
                                     {"title" : "Client Secret"},
                                     {"title" : ""}]
                                     -%}
-                                    <div class="display-table rounded w3-animate-opacity">
+                                    <div class="display-table table-responsive rounded w3-animate-opacity">
                                         <table class="table table-striped table-bordered">
                                             <!-- Table header start -->
                                             <thead>


### PR DESCRIPTION
Signed-off-by: Ulincsys <ulincsys@gmail.com>

**Description**
- Include table-responsive class on table container divs
    - Enables these tables to become scrollable if the content is too long

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->
