### PR TITLE
Add sql to update closed issue cntrbs with closed issue event data

### DIFF
--- a/augur/tasks/github/events/tasks.py
+++ b/augur/tasks/github/events/tasks.py
@@ -1,6 +1,7 @@
 import time
 import logging
 import traceback
+import sqlalchemy as s
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
@@ -180,6 +181,7 @@ def process_events(events, task_name, repo_id, logger, augur_db):
     issue_event_natural_keys = ["issue_id", "issue_event_src_id"]
     augur_db.insert_data(issue_event_dicts, IssueEvent, issue_event_natural_keys)
 
+    update_issue_closed_cntrbs_from_events(augur_db.engine, repo_id)
 
 # TODO: Should we skip an event if there is no contributor to resolve it o
 def process_github_event_contributors(logger, event, tool_source, tool_version, data_source):
@@ -194,3 +196,30 @@ def process_github_event_contributors(logger, event, tool_source, tool_version, 
         return event, None
     
     return event, event_cntrb
+
+
+def update_issue_closed_cntrbs_from_events(engine, repo_id):
+
+    get_ranked_issues = s.text(f"""
+        WITH RankedIssues AS (
+            SELECT repo_id, issue_id, cntrb_id, 
+                ROW_NUMBER() OVER(PARTITION BY issue_id ORDER BY created_at DESC) AS rn
+            FROM issue_events 
+            WHERE "action" = 'closed'
+        )
+                                            
+        SELECT issue_id, cntrb_id from RankedIssues where rn=1 and repo_id={repo_id}
+    """)
+    result = engine.execute(get_ranked_issues).fetchall()
+
+    update_data = [{'issue_id': row['issue_id'], 'cntrb_id': row['cntrb_id'], 'repo_id': repo_id} for row in result]
+    with engine.connect() as connection:
+        update_stmt = s.text("""
+            UPDATE issues
+            SET cntrb_id = :cntrb_id
+            WHERE issue_id = :issue_id
+            AND repo_id = :repo_id
+        """)
+        connection.execute(update_stmt, update_data)
+
+


### PR DESCRIPTION
**Description**
- Added sql queries to populate issue closed contributors with issue event data
- This will not completely fix #2524 but it should get all of the closed contributors on smaller repos and a lot on larger repos

**Signed commits**
- [X] Yes, I signed my commits.
