### PR TITLE
Use Bulk Inserts in Facade Collection Instead of Single Inserts

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -1126,6 +1126,8 @@ class Commit(Base):
         Index("committer_raw_email", "cmt_committer_raw_email"),
         Index("repo_id,commit", "repo_id", "cmt_commit_hash"),
 
+        UniqueConstraint("repo_id","cmt_commit_hash","cmt_filename", "cmt_committer_date", name="cmt_unique_bulk"),
+
         {
             "schema": "augur_data",
             "comment": "Commits.\nEach row represents changes to one FILE within a single commit. So you will encounter multiple rows per commit hash in many cases. ",

--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -1126,8 +1126,6 @@ class Commit(Base):
         Index("committer_raw_email", "cmt_committer_raw_email"),
         Index("repo_id,commit", "repo_id", "cmt_commit_hash"),
 
-        UniqueConstraint("repo_id","cmt_commit_hash","cmt_filename", "cmt_committer_date", name="cmt_unique_bulk"),
-
         {
             "schema": "augur_data",
             "comment": "Commits.\nEach row represents changes to one FILE within a single commit. So you will encounter multiple rows per commit hash in many cases. ",

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -281,7 +281,11 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
             #logger.info(f"Got to analysis!")
             commitRecord = analyze_commit(session, repo_id, repo_loc, commitTuple)
             if commitRecord:
-                pendingCommitRecordsToInsert.append(commitRecord)
+                if len(pendingCommitRecordsToInsert) > 10000:
+                    pendingCommitRecordsToInsert.append(commitRecord)
+                else:
+                    session.insert_data(pendingCommitRecordsToInsert, Commit,["repo_id","cmt_commit_hash","cmt_filename", "cmt_committer_date"],on_conflict_update=False)
+                    pendingCommitRecordsToInsert = []
 
     try:
         session.insert_data(pendingCommitRecordsToInsert, Commit,["repo_id","cmt_commit_hash","cmt_filename", "cmt_committer_date"],on_conflict_update=False)

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -125,16 +125,9 @@ def trim_commits_facade_task(repo_git):
 
         # If there's a commit still there, the previous run was interrupted and
         # the commit data may be incomplete. It should be trimmed, just in case.
-        for commit in working_commits:
-            trim_commit(session, repo_id,commit['working_commit'])
-
-            # Remove the working commit.
-            remove_commit = s.sql.text("""DELETE FROM working_commits
-                WHERE repos_id = :repo_id AND 
-                working_commit = :commit""").bindparams(repo_id=repo_id,commit=commit['working_commit'])
-            session.execute_sql(remove_commit)
-            session.log_activity('Debug',f"Removed working commit: {commit['working_commit']}")
-
+        commits_to_trim = [commit['working_commit'] for commit in working_commits]
+        
+        trim_commits(session,repo_id,commits_to_trim)
         # Start the main analysis
 
         update_analysis_log(repo_id,'Collecting data')
@@ -194,8 +187,8 @@ def trim_commits_post_analysis_facade_task(repo_git):
 
 
 
-        for commit in trimmed_commits:
-            trim_commit(session,repo_id,commit)
+        #for commit in trimmed_commits:
+        trim_commits(session,repo_id,trimmed_commits)
         
 
         update_analysis_log(repo_id,'Commit trimming complete')

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -289,14 +289,12 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
         
 
 
-    # Remove the working commit.
-    remove_commit = s.sql.text("""DELETE FROM working_commits 
-    	WHERE repos_id = :repo_id AND working_commit IN :hashes
-    	""").bindparams(repo_id=repo_id,hashes=tuple(queue))
-    session.execute_sql(remove_commit)  
-    #session.log_activity('Debug',f"Completed and removed working commit: {commit}")
-
-	# If multithreading, clean up the local database
+        # Remove the working commit.
+        remove_commit = s.sql.text("""DELETE FROM working_commits 
+        	WHERE repos_id = :repo_id AND working_commit IN :hashes
+        	""").bindparams(repo_id=repo_id,hashes=tuple(queue))
+        session.execute_sql(remove_commit)  
+    
     logger.info("Analysis complete")
     return
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -279,7 +279,7 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
             #logger.debug(commitRecord)
             if len(commitRecords):
                 pendingCommitRecordsToInsert.extend(commitRecords)
-                if len(pendingCommitRecordsToInsert) >= 10000:
+                if len(pendingCommitRecordsToInsert) >= 1000:
                     facade_bulk_insert_commits(session,pendingCommitRecordsToInsert)
                     pendingCommitRecordsToInsert = []
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -25,7 +25,7 @@ import sqlalchemy as s
 
 from sqlalchemy import or_, and_, update, insert
 
-from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import update_repo_log, trim_commit, store_working_author, trim_author
+from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import update_repo_log, trim_commits, store_working_author, trim_author
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path, get_parent_commits_set, get_existing_commits_set
 from augur.tasks.git.util.facade_worker.facade_worker.analyzecommit import analyze_commit
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_facade_weight_time_factor, get_repo_commit_count, update_facade_scheduling_fields, get_facade_weight_with_commit_count
@@ -280,12 +280,13 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
 
             #logger.info(f"Got to analysis!")
             commitRecord = analyze_commit(session, repo_id, repo_loc, commitTuple)
+            #logger.debug(commitRecord)
             if commitRecord:
-                if len(pendingCommitRecordsToInsert) > 10000:
+                if len(pendingCommitRecordsToInsert) < 10000:
                     pendingCommitRecordsToInsert.append(commitRecord)
                 else:
 
-                    session.excute(
+                    session.execute(
                         insert(Commit),
                         pendingCommitRecordsToInsert,
                     )
@@ -294,7 +295,7 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
                     pendingCommitRecordsToInsert = []
 
         try:
-            session.excute(
+            session.execute(
                     insert(Commit),
                     pendingCommitRecordsToInsert,
                 )

--- a/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
@@ -159,7 +159,7 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 	removed = 0
 	whitespace = 0
 
-	recordToInsert = None
+	recordsToInsert = []
 
 	# Go get the contributors (committers) for this repo here: 
 	# curl https://api.github.com/repos/chaoss/augur/contributors
@@ -259,10 +259,10 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 
 				if not header:
 
-					recordToInsert = generate_commit_record(repo_id,commit,filename,
+					recordsToInsert.append(generate_commit_record(repo_id,commit,filename,
 						author_name,author_email,author_date,author_timestamp,
 						committer_name,committer_email,committer_date,committer_timestamp,
-						added,removed,whitespace)
+						added,removed,whitespace))
 
 				header = False
 
@@ -318,10 +318,10 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 					whitespaceCheck.append(line[1:].strip())
 
 	# Store the last stats from the git log
-	recordToInsert = generate_commit_record(repo_id,commit,filename,
+	recordsToInsert.append(generate_commit_record(repo_id,commit,filename,
 		author_name,author_email,author_date,author_timestamp,
 		committer_name,committer_email,committer_date,committer_timestamp,
-		added,removed,whitespace)
+		added,removed,whitespace))
 
 
-	return recordToInsert
+	return recordsToInsert

--- a/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
@@ -118,10 +118,6 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 		author_email = strip_extra_amp(author_email)
 		committer_email = strip_extra_amp(committer_email)
 
-		#replace incomprehensible dates with epoch.
-		#2021-10-11 11:57:46 -0500
-		placeholder_date = "1970-01-01 00:00:15 -0500"
-
 
 		#session.logger.info(f"Timestamp: {author_timestamp}")
 		commit_record = {

--- a/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
@@ -103,7 +103,7 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 		else:
 			return email
 
-	def store_commit(repos_id,commit,filename,
+	def generate_commit_record(repos_id,commit,filename,
 		author_name,author_email,author_date,author_timestamp,
 		committer_name,committer_email,committer_date,committer_timestamp,
 		added,removed, whitespace):
@@ -126,68 +126,28 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 		#session.logger.info(f"Timestamp: {author_timestamp}")
 		commit_record = {
 			'repo_id' : repos_id,
-			'commit' : str(commit),
-			'filename' : filename,
-			'author_name' : str(author_name),
-			'author_email_raw' : author_email,
-			'author_email' : discover_alias(author_email),
-			'author_date' : author_date,
-			'author_timestamp' : author_timestamp if len(author_timestamp.replace(" ", "")) != 0 else placeholder_date,
-			'committer_name' : committer_name,
-			'committer_email_raw' : committer_email,
-			'committer_email' : discover_alias(committer_email),
-			'committer_date' : committer_date if len(committer_date.replace(" ", "")) != 0 else placeholder_date,
-			'committer_timestamp' : committer_timestamp if len(committer_timestamp.replace(" ","")) != 0 else placeholder_date,
-			'added' : added,
-			'removed' : removed,
-			'whitespace' : whitespace,
-			'committer_date' : committer_date if len(committer_date.replace(" ","")) != 0 else placeholder_date,
+			'cmt_commit_hash' : str(commit),
+			'cmt_filename' : filename,
+			'cmt_author_name' : str(author_name),
+			'cmt_author_raw_email' : author_email,
+			'cmt_author_email' : discover_alias(author_email),
+			'cmt_author_date' : author_date,
+			'cmt_author_timestamp' : author_timestamp if len(author_timestamp.replace(" ", "")) != 0 else placeholder_date,
+			'cmt_committer_name' : committer_name,
+			'cmt_committer_raw_email' : committer_email,
+			'cmt_committer_email' : discover_alias(committer_email),
+			'cmt_committer_date' : committer_date if len(committer_date.replace(" ", "")) != 0 else placeholder_date,
+			'cmt_committer_timestamp' : committer_timestamp if len(committer_timestamp.replace(" ","")) != 0 else placeholder_date,
+			'cmt_added' : added,
+			'cmt_removed' : removed,
+			'cmt_whitespace' : whitespace,
+			'cmt_date_attempted' : committer_date if len(committer_date.replace(" ","")) != 0 else placeholder_date,
 			'tool_source' : "Facade",
 			'tool_version' : "0.42",
 			'data_source' : "git"
 		}
 
-		#TODO: replace with a postgres on conflict do nothing. - IM 10/11/22
-		store = s.sql.text("""INSERT INTO commits (repo_id,cmt_commit_hash,cmt_filename,
-			cmt_author_name,cmt_author_raw_email,cmt_author_email,cmt_author_date,cmt_author_timestamp,
-			cmt_committer_name,cmt_committer_raw_email,cmt_committer_email,cmt_committer_date,cmt_committer_timestamp,
-			cmt_added,cmt_removed,cmt_whitespace, cmt_date_attempted, tool_source, tool_version, data_source)
-			VALUES (:repo_id,:commit,:filename,:author_name,:author_email_raw,:author_email,:author_date,:author_timestamp,
-			:committer_name,:committer_email_raw,:committer_email,:committer_date,:committer_timestamp,
-			:added,:removed,:whitespace,:committer_date,:tool_source,:tool_version,:data_source)
-			""").bindparams(**commit_record)
-
-		try:
-			session.execute_sql(store)
-		except DataError as e:
-			session.logger.error(f"Ran into bad data when trying to insert commit with values: \n {commit_record} \n Error: {e}")
-
-			#Check for improper utc timezone offset
-			#UTC timezone offset should be betwen -14:00 and +14:00
-
-			if "time zone displacement" in f"{e}":
-				commit_record['author_timestamp'] = placeholder_date
-				commit_record['committer_timestamp'] = placeholder_date
-
-				store = s.sql.text("""INSERT INTO commits (repo_id,cmt_commit_hash,cmt_filename,
-					cmt_author_name,cmt_author_raw_email,cmt_author_email,cmt_author_date,cmt_author_timestamp,
-					cmt_committer_name,cmt_committer_raw_email,cmt_committer_email,cmt_committer_date,cmt_committer_timestamp,
-					cmt_added,cmt_removed,cmt_whitespace, cmt_date_attempted, tool_source, tool_version, data_source)
-					VALUES (:repo_id,:commit,:filename,:author_name,:author_email_raw,:author_email,:author_date,:author_timestamp,
-					:committer_name,:committer_email_raw,:committer_email,:committer_date,:committer_timestamp,
-					:added,:removed,:whitespace,:committer_date,:tool_source,:tool_version,:data_source)
-					""").bindparams(**commit_record)
-				
-				session.execute_sql(store)
-			else:
-				raise e
-		except Exception as e:
-		
-			session.logger.error(f"Ran into issue when trying to insert commit with values: \n {commit_record} \n Error: {e}")
-			raise e
-
-
-		#session.log_activity('Debug',f"Stored commit: {commit}")
+		return commit_record
 
 
 ### The real function starts here ###
@@ -198,6 +158,8 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 	added = 0
 	removed = 0
 	whitespace = 0
+
+	recordToInsert = None
 
 	# Go get the contributors (committers) for this repo here: 
 	# curl https://api.github.com/repos/chaoss/augur/contributors
@@ -297,7 +259,7 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 
 				if not header:
 
-					store_commit(repo_id,commit,filename,
+					recordToInsert = generate_commit_record(repo_id,commit,filename,
 						author_name,author_email,author_date,author_timestamp,
 						committer_name,committer_email,committer_date,committer_timestamp,
 						added,removed,whitespace)
@@ -356,19 +318,10 @@ def analyze_commit(session, repo_id, repo_loc, commit):
 					whitespaceCheck.append(line[1:].strip())
 
 	# Store the last stats from the git log
-	store_commit(repo_id,commit,filename,
+	recordToInsert = generate_commit_record(repo_id,commit,filename,
 		author_name,author_email,author_date,author_timestamp,
 		committer_name,committer_email,committer_date,committer_timestamp,
 		added,removed,whitespace)
 
-	# Remove the working commit.
-	try: 
-		remove_commit = s.sql.text("""DELETE FROM working_commits 
-			WHERE repos_id = :repo_id AND working_commit = :hash
-			""").bindparams(repo_id=repo_id,hash=commit)
-		session.execute_sql(remove_commit)
 
-		#session.log_activity('Debug',f"Completed and removed working commit: {commit}")
-	except:
-		session.log_activity('Info', f"Working Commit: {commit}")
-	# If multithreading, clean up the local database
+	return recordToInsert

--- a/augur/tasks/git/util/facade_worker/facade_worker/facade00mainprogram.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/facade00mainprogram.py
@@ -30,7 +30,7 @@ import traceback
 import sys, platform, imp, time, datetime, html.parser, subprocess, os, getopt, xlsxwriter, configparser, logging
 from multiprocessing import Process, Queue
 from .config import FacadeSession as FacadeSession
-from .utilitymethods import trim_commit, store_working_author, trim_author   
+from .utilitymethods import trim_commits, store_working_author, trim_author   
 from .analyzecommit import analyze_commit
 from .postanalysiscleanup import git_repo_cleanup
 from .repofetch import git_repo_initialize, check_for_repo_updates, force_repo_updates, force_repo_analysis, git_repo_updates

--- a/augur/tasks/git/util/facade_worker/facade_worker/rebuildcache.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/rebuildcache.py
@@ -37,7 +37,7 @@ import getopt
 import xlsxwriter
 import configparser
 import sqlalchemy as s
-from .utilitymethods import update_repo_log, trim_commit, store_working_author, trim_author
+from .utilitymethods import update_repo_log, trim_commits, store_working_author, trim_author
 # if platform.python_implementation() == 'PyPy':
 #   import pymysql
 # else:

--- a/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
@@ -38,7 +38,7 @@ import xlsxwriter
 import configparser
 import pathlib
 import sqlalchemy as s
-from .utilitymethods import update_repo_log, trim_commit, store_working_author, trim_author, get_absolute_repo_path
+from .utilitymethods import update_repo_log, trim_commits, store_working_author, trim_author, get_absolute_repo_path
 from augur.application.db.models.augur_data import *
 from augur.application.db.models.augur_operations import CollectionStatus
 from augur.application.db.util import execute_session_query, convert_orm_list_to_dict_list

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -238,7 +238,7 @@ def facade_bulk_insert_commits(session,records):
 
 				session.execute(
 					s.insert(Commit),
-					records,
+					[commit_record],
 				)
 				session.commit()
 			else:

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -62,21 +62,22 @@ def update_repo_log(session, repos_id,status):
 
 def trim_commits(session, repo_id,commits):
 
-# Quickly remove a given commit
+	# Quickly remove a given commit
 
-	remove_commit = s.sql.text("""DELETE FROM commits
-		WHERE repo_id=:repo_id
-		AND cmt_commit_hash IN :hashes""").bindparams(repo_id=repo_id,hashes=tuple(commits))
-
-
-	session.execute_sql(remove_commit)
-
-	# Remove the working commit.
-	remove_commit = s.sql.text("""DELETE FROM working_commits
-	    WHERE repos_id = :repo_id AND 
-	    working_commit IN :hashes""").bindparams(repo_id=repo_id,commit=tuple(commits))
+	if len(commits):
+		remove_commit = s.sql.text("""DELETE FROM commits
+			WHERE repo_id=:repo_id
+			AND cmt_commit_hash IN :hashes""").bindparams(repo_id=repo_id,hashes=tuple(commits))
 	
-	session.execute_sql(remove_commit)
+	
+		session.execute_sql(remove_commit)
+	
+		# Remove the working commit.
+		remove_commit = s.sql.text("""DELETE FROM working_commits
+		    WHERE repos_id = :repo_id AND 
+		    working_commit IN :hashes""").bindparams(repo_id=repo_id,commit=tuple(commits))
+		
+		session.execute_sql(remove_commit)
 
 	for commit in commits:
 		session.log_activity('Debug',f"Trimmed commit: {commit}")

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -76,7 +76,7 @@ def trim_commits(session, repo_id,commits):
 		# Remove the working commit.
 		remove_commit = s.sql.text("""DELETE FROM working_commits
 		    WHERE repos_id = :repo_id AND 
-		    working_commit IN :hashes""").bindparams(repo_id=repo_id,commit=tuple(commits))
+		    working_commit IN :hashes""").bindparams(repo_id=repo_id,hashes=tuple(commits))
 		
 		session.execute_sql(remove_commit)
 

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -220,6 +220,9 @@ def facade_bulk_insert_commits(session,records):
 
 	if len(records) == 1:
 		commit_record = records[0]
+		#replace incomprehensible dates with epoch.
+		#2021-10-11 11:57:46 -0500
+		placeholder_date = "1970-01-01 00:00:15 -0500"
 		try:
 			session.execute(
 					s.insert(Commit),

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -214,3 +214,54 @@ def update_facade_scheduling_fields(session, repo_git, weight, commit_count):
 
 	session.execute(update_query)
 	session.commit()
+
+def facade_bulk_insert_commits(session,records):
+
+	if len(records) == 1:
+		commit_record = records[0]
+		try:
+			session.execute(
+					insert(Commit),
+					records,
+				)
+			session.commit()
+		except DataError as e:
+			session.logger.error(f"Ran into bad data when trying to insert commit with values: \n {commit_record} \n Error: {e}")
+
+			#Check for improper utc timezone offset
+			#UTC timezone offset should be betwen -14:00 and +14:00
+
+			if "time zone displacement" in f"{e}":
+				commit_record['author_timestamp'] = placeholder_date
+				commit_record['committer_timestamp'] = placeholder_date
+
+				session.execute(
+					insert(Commit),
+					records,
+				)
+				session.commit()
+			else:
+				raise e
+		except Exception as e:
+        
+            session.logger.error(f"Ran into issue when trying to insert commit: {commit_record} \n Error: {e}")
+            raise e
+			
+	else:
+		try:
+			session.execute(
+					insert(Commit),
+					records,
+				)
+			session.commit()
+		except Exception as e:
+		
+			session.logger.error(f"Ran into issue when trying to insert commits \n Error: {e}")
+
+			#split list into halves and retry insert until we isolate offending record
+			firsthalfRecords = records[:len(records)//2]
+			secondhalfRecords = records[len(records)//2:]
+
+			facade_bulk_insert_commits(session,firsthalfRecords)
+			facade_bulk_insert_commits(session,secondhalfRecords)
+

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -38,6 +38,7 @@ import getopt
 import xlsxwriter
 import configparser
 import sqlalchemy as s
+from sqlalchemy.exc import IntegrityError, DataError
 from .config import get_database_args_from_env
 from augur.application.db.models import *
 from .config import FacadeSession as FacadeSession
@@ -221,7 +222,7 @@ def facade_bulk_insert_commits(session,records):
 		commit_record = records[0]
 		try:
 			session.execute(
-					insert(Commit),
+					s.insert(Commit),
 					records,
 				)
 			session.commit()
@@ -236,7 +237,7 @@ def facade_bulk_insert_commits(session,records):
 				commit_record['committer_timestamp'] = placeholder_date
 
 				session.execute(
-					insert(Commit),
+					s.insert(Commit),
 					records,
 				)
 				session.commit()
@@ -248,7 +249,7 @@ def facade_bulk_insert_commits(session,records):
 	else:
 		try:
 			session.execute(
-					insert(Commit),
+					s.insert(Commit),
 					records,
 				)
 			session.commit()

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -243,10 +243,8 @@ def facade_bulk_insert_commits(session,records):
 			else:
 				raise e
 		except Exception as e:
-        
-            session.logger.error(f"Ran into issue when trying to insert commit: {commit_record} \n Error: {e}")
-            raise e
-			
+			session.logger.error(f"Ran into issue when trying to insert commit: {commit_record} \n Error: {e}")
+			raise e
 	else:
 		try:
 			session.execute(


### PR DESCRIPTION
**Description**
- Change trim_commits phase of facade to trim commits in bulk instead of one at a time. Before, commits were deleted one at a time.
- Change analyze_commits_in_parallel phase of facade to insert commits in bulk instead of one at a time. Before, more database transactions were used than desirable.
- Implement a stagger insert that inserts a block of facade records when the amount of objects in memory exceeds 10000. 


**Signed commits**
- [x] Yes, I signed my commits.

