### PR TITLE
Fix null cntrb id errors in issue closed cntrb update

### DIFF
--- a/augur/tasks/github/events/tasks.py
+++ b/augur/tasks/github/events/tasks.py
@@ -208,7 +208,7 @@ def update_issue_closed_cntrbs_from_events(engine, repo_id):
             WHERE "action" = 'closed'
         )
                                             
-        SELECT issue_id, cntrb_id from RankedIssues where rn=1 and repo_id={repo_id}
+        SELECT issue_id, cntrb_id from RankedIssues where rn=1 and repo_id={repo_id} and cntrb_id is not NULL
     """)
     result = engine.execute(get_ranked_issues).fetchall()
 


### PR DESCRIPTION
**Description**
- The issue events that are providing the issue closed cntrb for the issues table can have NULL cntrb ids. So when we retrieve the issue closed cntrb we get back NULL, and when we try to bind NULL to the update query it fails and throws an error. Now we are filtering out rows that have a NULL cntrb id since they are not useful and are causing an error

This is the error in the logs
```2023-10-18 15:34:01 linda collect_events[636720] ERROR Could not collect events for https://github.com/pentaho/pentaho-hdfs-vfs
 Reason: (sqlalchemy.exc.InvalidRequestError) A value is required for bind parameter 'cntrb_id'```
