### PR TITLE
Fix Wrong Base Classes for Celery Tasks

### DIFF
--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -3,7 +3,7 @@ import traceback
 from augur.application.db.session import DatabaseSession
 from augur.tasks.git.dependency_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
-from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask, AugurCoreRepoCollectionTask
+from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask, AugurCoreRepoCollectionTask, AugurSecondaryRepoCollectionTask
 from augur.application.db.util import execute_session_query
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path
 from augur.application.config import AugurConfig
@@ -33,7 +33,7 @@ def process_dependency_metrics(repo_git):
         generate_deps_data(session,repo.repo_id,absolute_repo_path)
 
 
-@celery.task(base=AugurCoreRepoCollectionTask)
+@celery.task(base=AugurSecondaryRepoCollectionTask)
 def process_ossf_dependency_metrics(repo_git):
     from augur.tasks.init.celery_app import engine
     

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -397,7 +397,7 @@ def clone_repos():
 #    with FacadeSession(logger) as session:
 #        check_for_repo_updates(session, repo_git)
 
-@celery.task
+@celery.task(base=AugurFacadeRepoCollectionTask)
 def git_update_commit_count_weight(repo_git):
 
     from augur.tasks.init.celery_app import engine
@@ -410,7 +410,7 @@ def git_update_commit_count_weight(repo_git):
         update_facade_scheduling_fields(session, repo_git, facade_weight, commit_count)
 
 
-@celery.task
+@celery.task(base=AugurFacadeRepoCollectionTask)
 def git_repo_updates_facade_task(repo_git):
 
     logger = logging.getLogger(git_repo_updates_facade_task.__name__)

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api, retrieve_dict_from_endpoint
 from augur.tasks.github.util.github_task_session import GithubTaskSession, GithubTaskManifest
 from augur.tasks.github.util.util import get_owner_repo
@@ -198,7 +199,7 @@ def link_commits_to_contributor(session,contributorQueue):
 
 
 # Update the contributors table from the data facade has gathered.
-@celery.task
+@celery.task(base=AugurFacadeRepoCollectionTask)
 def insert_facade_contributors(repo_id):
 
     from augur.tasks.init.celery_app import engine


### PR DESCRIPTION
**Description**
There was a syntax issue previously where some celery tasks had the wrong base class. This can happen because a task was moved and not properly updated with the right base class.


**Signed commits**
- [x] Yes, I signed my commits.
