### PR TITLE
Implement ability to add gitlab repos from frontend

### DIFF
--- a/augur/api/routes/dei.py
+++ b/augur/api/routes/dei.py
@@ -52,7 +52,7 @@ def dei_track_repo(application: ClientApplication):
         return jsonify({"status": "Repo already exists"})
     
     frontend_repo_group: RepoGroup = session.query(RepoGroup).filter(RepoGroup.rg_name == FRONTEND_REPO_GROUP_NAME).first()
-    repo_id = Repo.insert(session, repo_url, frontend_repo_group.repo_group_id, "API.DEI", repo_type="")
+    repo_id = Repo.insert_github_repo(session, repo_url, frontend_repo_group.repo_group_id, "API.DEI", repo_type="")
     if not repo_id:
         return jsonify({"status": "Error adding repo"})
     

--- a/augur/api/routes/user.py
+++ b/augur/api/routes/user.py
@@ -227,7 +227,7 @@ def add_user_repo():
     repo = request.args.get("repo_url")
     group_name = request.args.get("group_name")
 
-    result = current_user.add_repo(group_name, repo)
+    result = current_user.add_github_repo(group_name, repo)
 
     return jsonify(result[1])
 
@@ -260,7 +260,7 @@ def add_user_org():
     org = request.args.get("org_url")
     group_name = request.args.get("group_name")
 
-    result = current_user.add_org(group_name, org)
+    result = current_user.add_github_org(group_name, org)
 
     return jsonify(result[1])
 

--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -102,7 +102,18 @@ def av_add_user_repo():
                 if rg_obj:
                     # add the orgs repos to the group
                     add_existing_org_to_group(session, current_user.user_id, group, rg_obj.repo_group_id)
-            
+
+            # matches https://gitlab.com/{org}/{repo}/ or http://gitlab.com/{org}/{repo}
+            elif Repo.parse_gitlab_repo_url(url)[0]:
+
+                org_name, repo_name = Repo.parse_github_repo_url(url)
+                repo_git = f"https://gitlab.com/{org_name}/{repo_name}"
+
+                # TODO: gitlab ensure the whole repo git is inserted so it can be found here
+                repo_obj = Repo.get_by_repo_git(session, repo_git)
+                if repo_obj:
+                    add_existing_repo_to_group(session, current_user.user_id, group, repo_obj.repo_id)
+                
             else:
                 invalid_urls.append(url)
 

--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -1035,7 +1035,7 @@ class Repo(Base):
         return result.groups()[0]
 
     @staticmethod
-    def insert_githlab_repo(session, url: str, repo_group_id: int, tool_source, repo_type):
+    def insert_gitlab_repo(session, url: str, repo_group_id: int, tool_source):
         """Add a repo to the repo table.
 
         Args:
@@ -1066,7 +1066,7 @@ class Repo(Base):
             "repo_git": url,
             "repo_path": f"gitlab.com/{owner}/",
             "repo_name": repo,
-            "repo_type": repo_type,
+            "repo_type": None,
             "tool_source": tool_source,
             "tool_version": "1.0",
             "data_source": "Git"

--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -943,7 +943,7 @@ class Repo(Base):
         """
         from augur.tasks.github.util.github_paginator import hit_api
 
-        REPO_ENDPOINT = "https://gitlab.com/api/v4/projects/{}/{}"
+        REPO_ENDPOINT = "https://gitlab.com/api/v4/projects/{}/"
 
         owner, repo = Repo.parse_gitlab_repo_url(url)
         if not owner or not repo:
@@ -1046,7 +1046,7 @@ class Repo(Base):
             If repo row exists then it will update the repo_group_id if param repo_group_id is not a default. If it does not exist is will simply insert the repo.
         """
 
-        if not isinstance(url, str) or not isinstance(repo_group_id, int) or not isinstance(tool_source, str) or not isinstance(repo_type, str):
+        if not isinstance(url, str) or not isinstance(repo_group_id, int) or not isinstance(tool_source, str):
             return None
 
         if not RepoGroup.is_valid_repo_group_id(session, repo_group_id):

--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -953,6 +953,30 @@ class Repo(Base):
         repo = capturing_groups[1]
 
         return owner, repo
+    
+    @staticmethod
+    def parse_gitlab_repo_url(url: str) -> tuple:
+        """ Gets the owner and repo from a gitlab url.
+
+        Args:
+            url: Gitlab url
+
+        Returns:
+            Tuple of owner and repo. Or a tuple of None and None if the url is invalid.
+        """
+        
+        result = re.search(r"https?:\/\/gitlab\.com\/([A-Za-z0-9 \- _]+)\/([A-Za-z0-9 \- _ \.]+)(.git)?\/?$", url)
+
+        if not result:
+            return None, None
+
+        capturing_groups = result.groups()
+
+
+        owner = capturing_groups[0]
+        repo = capturing_groups[1]
+
+        return owner, repo
 
     @staticmethod
     def parse_github_org_url(url):

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -784,7 +784,7 @@ class UserRepo(Base):
         return data[0]["group_id"] == group_id and data[0]["repo_id"] == repo_id
     
     @staticmethod
-    def add_gitlab_repo(session, url: List[str], user_id: int, group_name=None, group_id=None, from_org_list=False, repo_type=None, repo_group_id=None) -> dict:
+    def add_gitlab_repo(session, url: List[str], user_id: int, group_name=None, group_id=None, from_org_list=False, repo_group_id=None) -> dict:
         """Add repo to the user repo table
 
         Args:
@@ -807,9 +807,6 @@ class UserRepo(Base):
         if not group_name and not group_id:
             return False, {"status": "Need group name or group id to add a repo"}
 
-        if from_org_list and not repo_type:
-            return False, {"status": "Repo type must be passed if the repo is from an organization's list of repos"}
-
         if group_id is None:
 
             group_id = UserGroup.convert_group_name_to_id(session, user_id, group_name)
@@ -821,8 +818,6 @@ class UserRepo(Base):
             if not result[0]:
                 return False, {"status": result[1]["status"], "repo_url": url}
 
-            repo_type = result[1]["repo_type"]
-
         # if no repo_group_id is passed then assign the repo to the frontend repo group
         if repo_group_id is None:
 
@@ -833,7 +828,7 @@ class UserRepo(Base):
             repo_group_id = frontend_repo_group.repo_group_id
 
 
-        repo_id = Repo.insert_gitlab_repo(session, url, repo_group_id, "Frontend", repo_type)
+        repo_id = Repo.insert_gitlab_repo(session, url, repo_group_id, "Frontend")
         if not repo_id:
             return False, {"status": "Repo insertion failed", "repo_url": url}
 

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -463,10 +463,10 @@ class User(Base):
     
     def add_gitlab_repo(self, group_name, repo_url):
         
-        from augur.tasks.gitlab.gitlab_task_session import GitLabTaskSession
+        from augur.tasks.gitlab.gitlab_task_session import GitlabTaskSession
         from augur.tasks.github.util.github_api_key_handler import NoValidKeysError
         try:
-            with GitLabTaskSession(logger) as session:
+            with GitlabTaskSession(logger) as session:
                 result = UserRepo.add_gitlab_repo(session, repo_url, self.user_id, group_name)
         except NoValidKeysError:
             return False, {"status": "No valid keys"}

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -449,17 +449,30 @@ class User(Base):
 
         return result
 
-    def add_repo(self, group_name, repo_url):
+    def add_github_repo(self, group_name, repo_url):
 
         from augur.tasks.github.util.github_task_session import GithubTaskSession
         from augur.tasks.github.util.github_api_key_handler import NoValidKeysError
         try:
             with GithubTaskSession(logger) as session:
-                result = UserRepo.add(session, repo_url, self.user_id, group_name)
+                result = UserRepo.add_github_repo(session, repo_url, self.user_id, group_name)
         except NoValidKeysError:
             return False, {"status": "No valid keys"}
 
         return result
+    
+    def add_gitlab_repo(self, group_name, repo_url):
+        
+        from augur.tasks.gitlab.gitlab_task_session import GitLabTaskSession
+        from augur.tasks.github.util.github_api_key_handler import NoValidKeysError
+        try:
+            with GitLabTaskSession(logger) as session:
+                result = UserRepo.add_gitlab_repo(session, repo_url, self.user_id, group_name)
+        except NoValidKeysError:
+            return False, {"status": "No valid keys"}
+
+        return result
+
 
     def remove_repo(self, group_name, repo_id):
 
@@ -468,7 +481,7 @@ class User(Base):
 
         return result
 
-    def add_org(self, group_name, org_url):
+    def add_github_org(self, group_name, org_url):
 
         from augur.tasks.github.util.github_task_session import GithubTaskSession
         from augur.tasks.github.util.github_api_key_handler import NoValidKeysError
@@ -771,7 +784,7 @@ class UserRepo(Base):
         return data[0]["group_id"] == group_id and data[0]["repo_id"] == repo_id
 
     @staticmethod
-    def add(session, url: List[str], user_id: int, group_name=None, group_id=None, from_org_list=False, repo_type=None, repo_group_id=None) -> dict:
+    def add_github_repo(session, url: List[str], user_id: int, group_name=None, group_id=None, from_org_list=False, repo_type=None, repo_group_id=None) -> dict:
         """Add repo to the user repo table
 
         Args:
@@ -911,7 +924,7 @@ class UserRepo(Base):
         failed_repos = []
         for repo in repos:
 
-            result = UserRepo.add(session, repo, user_id, group_id=group_id, from_org_list=True, repo_type=type, repo_group_id=repo_group_id)
+            result = UserRepo.add_github_repo(session, repo, user_id, group_id=group_id, from_org_list=True, repo_type=type, repo_group_id=repo_group_id)
 
             # keep track of all the repos that failed
             if not result[0]:

--- a/augur/tasks/frontend.py
+++ b/augur/tasks/frontend.py
@@ -30,15 +30,15 @@ def add_org_repo_list(user_id, group_name, urls):
     valid_repos = []
     for url in urls:
 
-        # matches https://github.com/{org}/ or htts://github.com/{org}
+        # matches https://github.com/{org}/ or http://github.com/{org}
         if Repo.parse_github_org_url(url):
-            added = user.add_org(group_name, url)[0]
+            added = user.add_github_org(group_name, url)[0]
             if added:
                 valid_orgs.append(url)
 
-        # matches https://github.com/{org}/{repo}/ or htts://github.com/{org}/{repo}
+        # matches https://github.com/{org}/{repo}/ or http://github.com/{org}/{repo}
         elif Repo.parse_github_repo_url(url)[0]:
-            added = user.add_repo(group_name, url)[0]
+            added = user.add_github_repo(group_name, url)[0]
             if added:
                 valid_repos.append(url)
 
@@ -46,7 +46,7 @@ def add_org_repo_list(user_id, group_name, urls):
         elif (match := parse_org_and_repo_name(url)):
             org, repo = match.groups()
             repo_url = f"https://github.com/{org}/{repo}/"
-            added = user.add_repo(group_name, repo_url)[0]
+            added = user.add_github_repo(group_name, repo_url)[0]
             if added:
                 valid_repos.append(url)
 
@@ -54,9 +54,17 @@ def add_org_repo_list(user_id, group_name, urls):
         elif (match := parse_org_name(url)):
             org = match.group(1)
             org_url = f"https://github.com/{org}/"
-            added = user.add_org(group_name, org_url)[0]
+            added = user.add_github_org(group_name, org_url)[0]
             if added:
                 valid_orgs.append(url)
+
+        # matches https://gitlab.com/{org}/{repo}/ or http://gitlab.com/{org}/{repo}
+        elif Repo.parse_gitlab_repo_url(url)[0]:
+
+            #added = user.add_github_repo(group_name, url)[0]
+            if added:
+                valid_repos.append(url)
+
         else:
             invalid_urls.append(url)
 
@@ -66,18 +74,19 @@ def add_org_repo_list(user_id, group_name, urls):
     
 
 
-
+# TODO: Change to github specific
 @celery.task
 def add_repo(user_id, group_name, repo_url):
 
     logger = logging.getLogger(add_org.__name__) 
 
     with GithubTaskSession(logger) as session:
-        result = UserRepo.add(session, repo_url, user_id, group_name)
+        result = UserRepo.add_github_repo(session, repo_url, user_id, group_name)
 
     print(repo_url, result)
 
 
+# TODO: Change to github specific
 @celery.task
 def add_org(user_id, group_name, org_url):
 

--- a/augur/tasks/frontend.py
+++ b/augur/tasks/frontend.py
@@ -61,7 +61,7 @@ def add_org_repo_list(user_id, group_name, urls):
         # matches https://gitlab.com/{org}/{repo}/ or http://gitlab.com/{org}/{repo}
         elif Repo.parse_gitlab_repo_url(url)[0]:
 
-            #added = user.add_github_repo(group_name, url)[0]
+            added = user.add_gitlab_repo(group_name, url)[0]
             if added:
                 valid_repos.append(url)
 
@@ -93,6 +93,6 @@ def add_org(user_id, group_name, org_url):
     logger = logging.getLogger(add_org.__name__) 
 
     with GithubTaskSession(logger) as session:
-            result = UserRepo.add_org_repos(session, org_url, user_id, group_name)
+            result = UserRepo.add_github_org_repos(session, org_url, user_id, group_name)
 
     print(org_url, result)

--- a/augur/tasks/gitlab/gitlab_api_key_handler.py
+++ b/augur/tasks/gitlab/gitlab_api_key_handler.py
@@ -14,8 +14,8 @@ class NoValidKeysError(Exception):
     pass
 
 
-class GithubApiKeyHandler():
-    """Handles Github API key retrieval from the database and redis
+class GitlabApiKeyHandler():
+    """Handles Gitlab API key retrieval from the database and redis
 
     Attributes:
         session (DatabaseSession): Database connection
@@ -32,7 +32,7 @@ class GithubApiKeyHandler():
         self.logger = session.logger
         self.config = AugurConfig(self.logger, session)
 
-        self.oauth_redis_key = "github_oauth_keys_list"
+        self.oauth_redis_key = "gitlab_oauth_keys_list"
 
         self.redis_key_list = RedisList(self.oauth_redis_key)
 
@@ -40,7 +40,7 @@ class GithubApiKeyHandler():
 
         self.keys = self.get_api_keys()
 
-        self.logger.info(f"Retrieved {len(self.keys)} github api keys for use")
+        self.logger.info(f"Retrieved {len(self.keys)} gitlab api keys for use")
 
     def get_random_key(self):
         """Retrieves a random key from the list of keys
@@ -58,6 +58,7 @@ class GithubApiKeyHandler():
             Github API key from config table
         """
 
+        # TODO: Change to get the gitlab api key
         return self.config.get_value("Keys", "github_api_key")
 
     def get_api_keys_from_database(self) -> List[str]:
@@ -74,6 +75,7 @@ class GithubApiKeyHandler():
         select = WorkerOauth.access_token
         # randomizing the order at db time
         #select.order_by(func.random())
+        # TODO: Change to get gitlab api keys
         where = [WorkerOauth.access_token != self.config_key, WorkerOauth.platform == 'github']
 
         return [key_tuple[0] for key_tuple in self.session.query(select).filter(*where).order_by(func.random()).all()]
@@ -148,6 +150,7 @@ class GithubApiKeyHandler():
 
         return valid_keys
 
+    # TODO: Change to use gitlab rate limit api
     def is_bad_api_key(self, client: httpx.Client, oauth_key: str) -> bool:
         """Determines if a Github API is bad
 

--- a/augur/tasks/gitlab/gitlab_api_key_handler.py
+++ b/augur/tasks/gitlab/gitlab_api_key_handler.py
@@ -158,7 +158,7 @@ class GitlabApiKeyHandler():
             True if key is bad. False if the key is good
         """
 
-        url = "https://api.github.com/rate_limit"
+        url = "https://gitlab.com/api/v4/user"
 
         headers = {'Authorization': f'Bearer {oauth_key}'}
 

--- a/augur/tasks/gitlab/gitlab_random_key_auth.py
+++ b/augur/tasks/gitlab/gitlab_random_key_auth.py
@@ -14,14 +14,13 @@ class GitlabRandomKeyAuth(RandomKeyAuth):
         """Creates a GitlabRandomKeyAuth object and initializes the RandomKeyAuth parent class"""
 
     
-        # gets the github api keys from the database via the GithubApiKeyHandler
-        github_api_keys = GitlabApiKeyHandler(session).keys
-        #github_api_keys = random.sample(github_api_keys, len(github_api_keys))
+        # gets the gitlab api keys from the database via the GitlabApiKeyHandler
+        gitlab_api_keys = GitlabApiKeyHandler(session).keys
 
-        if not github_api_keys:
+        if not gitlab_api_keys:
             print("Failed to find github api keys. This is usually because your key has expired")
 
         header_name = "Authorization"
         key_format = "Bearer {0}"
 
-        super().__init__(github_api_keys, header_name, session.logger, key_format)
+        super().__init__(gitlab_api_keys, header_name, session.logger, key_format)

--- a/augur/tasks/gitlab/gitlab_random_key_auth.py
+++ b/augur/tasks/gitlab/gitlab_random_key_auth.py
@@ -21,8 +21,7 @@ class GitlabRandomKeyAuth(RandomKeyAuth):
         if not github_api_keys:
             print("Failed to find github api keys. This is usually because your key has expired")
 
-        # TODO: Change to set key headers how gitlab expects
         header_name = "Authorization"
-        key_format = "token {0}"
+        key_format = "Bearer {0}"
 
         super().__init__(github_api_keys, header_name, session.logger, key_format)

--- a/augur/tasks/gitlab/gitlab_random_key_auth.py
+++ b/augur/tasks/gitlab/gitlab_random_key_auth.py
@@ -1,0 +1,28 @@
+"""Defines the GitlabRandomKeyAuth class"""
+
+from augur.tasks.util.random_key_auth import RandomKeyAuth
+from augur.tasks.gitlab.gitlab_api_key_handler import GitlabApiKeyHandler
+from augur.application.db.session import DatabaseSession
+
+
+class GitlabRandomKeyAuth(RandomKeyAuth):
+    """Defines a github specific RandomKeyAuth class so 
+    github collections can have a class randomly selects an api key for each request    
+    """
+
+    def __init__(self, session: DatabaseSession, logger):
+        """Creates a GitlabRandomKeyAuth object and initializes the RandomKeyAuth parent class"""
+
+    
+        # gets the github api keys from the database via the GithubApiKeyHandler
+        github_api_keys = GitlabApiKeyHandler(session).keys
+        #github_api_keys = random.sample(github_api_keys, len(github_api_keys))
+
+        if not github_api_keys:
+            print("Failed to find github api keys. This is usually because your key has expired")
+
+        # TODO: Change to set key headers how gitlab expects
+        header_name = "Authorization"
+        key_format = "token {0}"
+
+        super().__init__(github_api_keys, header_name, session.logger, key_format)

--- a/augur/tasks/gitlab/gitlab_task_session.py
+++ b/augur/tasks/gitlab/gitlab_task_session.py
@@ -1,0 +1,44 @@
+from logging import Logger
+
+from augur.tasks.gitlab.gitlab_random_key_auth import GitlabRandomKeyAuth
+from augur.application.db.session import DatabaseSession
+
+class GitlabTaskManifest:
+
+    def __init__(self, logger):
+
+        from augur.tasks.init.celery_app import engine
+        from augur.application.db.session import DatabaseSession
+
+        self.augur_db = DatabaseSession(logger, engine)
+        self.key_auth = GitlabRandomKeyAuth(self.augur_db.session, logger)
+        self.logger = logger
+        self.platform_id = 2
+
+    def __enter__(self):
+
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+
+        self.augur_db.close()
+
+
+class GithubTaskSession(DatabaseSession):
+    """ORM session used in gitlab tasks.
+        This class adds the platform_id and the gitlab key authentication class,
+        to the already existing DatabaseSession so there is a central location to access
+        api keys and a single platform_id reference
+
+    Attributes:
+        oauths (GitlabRandomKeyAuth): Class that handles randomly assigning gitlab api keys to httpx requests
+        platform_id (int): The id that refers to the Gitlab platform
+    """
+
+    def __init__(self, logger: Logger, engine=None):
+
+        super().__init__(logger, engine=engine)
+
+        self.oauths = GitlabRandomKeyAuth(self, logger)
+        self.platform_id = 2
+        

--- a/augur/tasks/gitlab/gitlab_task_session.py
+++ b/augur/tasks/gitlab/gitlab_task_session.py
@@ -23,8 +23,7 @@ class GitlabTaskManifest:
 
         self.augur_db.close()
 
-
-class GithubTaskSession(DatabaseSession):
+class GitlabTaskSession(DatabaseSession):
     """ORM session used in gitlab tasks.
         This class adds the platform_id and the gitlab key authentication class,
         to the already existing DatabaseSession so there is a central location to access

--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -62,7 +62,7 @@ class RepoLoadController:
 
 
         # if the repo doesn't exist it adds it
-        repo_id = Repo.insert(self.session, url, repo_group_id, "CLI", repo_type)
+        repo_id = Repo.insert_github_repo(self.session, url, repo_group_id, "CLI", repo_type)
 
         if not repo_id:
             logger.warning(f"Invalid repo group id specified for {url}, skipping.")

--- a/tests/test_applicaton/test_db/test_models/test_augur_data/test_repo.py
+++ b/tests/test_applicaton/test_db/test_models/test_augur_data/test_repo.py
@@ -77,20 +77,20 @@ def test_insert_repo(test_db_engine):
 
         with DatabaseSession(logger, test_db_engine) as session:
             
-            assert Repo.insert(session, data["repo_urls"][0], data["rg_id"], data["tool_source"]) is not None
-            assert Repo.insert(session, data["repo_urls"][1], data["rg_id"], data["tool_source"]) is not None
+            assert Repo.insert_github_repo(session, data["repo_urls"][0], data["rg_id"], data["tool_source"]) is not None
+            assert Repo.insert_github_repo(session, data["repo_urls"][1], data["rg_id"], data["tool_source"]) is not None
 
             # invalid rg_id
-            assert Repo.insert(session, data["repo_urls"][0], 12, data["tool_source"]) is None
+            assert Repo.insert_github_repo(session, data["repo_urls"][0], 12, data["tool_source"]) is None
 
             # invalid type for repo url
-            assert Repo.insert(session, 1, data["rg_id"], data["tool_source"]) is None
+            assert Repo.insert_github_repo(session, 1, data["rg_id"], data["tool_source"]) is None
 
             # invalid type for rg_id
-            assert Repo.insert(session, data["repo_urls"][1], "1", data["tool_source"]) is None
+            assert Repo.insert_github_repo(session, data["repo_urls"][1], "1", data["tool_source"]) is None
 
             # invalid type for tool_source
-            assert Repo.insert(session, data["repo_urls"][1], data["rg_id"], 52) is None
+            assert Repo.insert_github_repo(session, data["repo_urls"][1], data["rg_id"], 52) is None
 
         with test_db_engine.connect() as connection:
 

--- a/tests/test_applicaton/test_db/test_models/test_augur_operations/test_user_repo.py
+++ b/tests/test_applicaton/test_db/test_models/test_augur_operations/test_user_repo.py
@@ -124,7 +124,7 @@ def test_add_frontend_repos_with_invalid_repo(test_db_engine):
 
         with GithubTaskSession(logger, test_db_engine) as session:
 
-            result = UserRepo.add(session, url, data["user_id"], data["user_group_name"])
+            result = UserRepo.add_github_repo(session, url, data["user_id"], data["user_group_name"])
 
             assert result[1]["status"] == "Invalid repo"
 
@@ -163,11 +163,11 @@ def test_add_frontend_repos_with_duplicates(test_db_engine):
 
         with GithubTaskSession(logger, test_db_engine) as session:
 
-            result = UserRepo.add(session, url, data["user_id"], data["user_group_name"])
-            result2 = UserRepo.add(session, url, data["user_id"], data["user_group_name"])
+            result = UserRepo.add_github_repo(session, url, data["user_id"], data["user_group_name"])
+            result2 = UserRepo.add_github_repo(session, url, data["user_id"], data["user_group_name"])
 
             # add repo with invalid group name
-            result3 = UserRepo.add(session, url, data["user_id"], "Invalid group name")
+            result3 = UserRepo.add_github_repo(session, url, data["user_id"], "Invalid group name")
 
             assert result[1]["status"] == "Repo Added"
             assert result2[1]["status"] == "Repo Added"
@@ -263,11 +263,11 @@ def test_add_frontend_org_with_invalid_org(test_db_engine):
         with GithubTaskSession(logger, test_db_engine) as session:
 
             url = f"https://github.com/{data['org_name']}/"
-            result = UserRepo.add_org_repos(session, url, data["user_id"], data["user_group_name"])
+            result = UserRepo.add_github_org_repos(session, url, data["user_id"], data["user_group_name"])
             assert result[1]["status"] == "Invalid owner url"
 
             # test with invalid group name
-            result = UserRepo.add_org_repos(session, url, data["user_id"], "Invalid group name")
+            result = UserRepo.add_github_org_repos(session, url, data["user_id"], "Invalid group name")
             assert result[1]["status"] == "Invalid group name"
 
         with test_db_engine.connect() as connection:
@@ -305,7 +305,7 @@ def test_add_frontend_org_with_valid_org(test_db_engine):
         with GithubTaskSession(logger, test_db_engine) as session:
 
             url = "https://github.com/{}/".format(data["org_name"])
-            result = UserRepo.add_org_repos(session, url, data["user_id"], data["user_group_name"])
+            result = UserRepo.add_github_org_repos(session, url, data["user_id"], data["user_group_name"])
             assert result[1]["status"] == "Org repos added"
 
         with test_db_engine.connect() as connection:


### PR DESCRIPTION
**Description**
- Adds the ability to add Gitlab repos from the frontend. This includes changes to insert the record into the database, and changes to ensure that the Gitlab repos are ignored. The collection status record is also created, but currently the issue_pr_sum, commit_count, and weights are incorrect since that logic still needs to be implemented with the gitlab api

**Signed commits**
- [X] Yes, I signed my commits.
