### PR TITLE
[docs] Update firefox version to match requirement of firefox-geckodriver

### DIFF
--- a/docs/source/getting-started/new-install.rst
+++ b/docs/source/getting-started/new-install.rst
@@ -44,7 +44,7 @@ Executable
    sudo snap install go --classic && #required: Go Needs to be version 1.19.x or higher. Snap is the package manager that gets you to the right version. Classic enables it to actually be installed at the correct version.
    sudo apt install nginx && # required for hosting
    sudo add-apt-repository ppa:mozillateam/firefox-next &&
-   sudo apt install firefox=115.0~b2+build1-0ubuntu0.22.04.1 &&
+   sudo apt install firefox=121.0~b7+build1-0ubuntu0.22.04.1 &&
    sudo apt install firefox-geckodriver
 
    # You will almost certainly need to reboot after this. 


### PR DESCRIPTION
**Description**
This fixes the issue that the installation guide can no longer be followed verbatim.

Here is what `apt-cache` tells me on my machine:
```
$ sudo apt-cache policy firefox
firefox:
  Installed: 121.0~b7+build1-0ubuntu0.22.04.1
  Candidate: 1:1snap1-0ubuntu2
  Version table:
     1:1snap1-0ubuntu2 500
        500 http://mirrors.digitalocean.com/ubuntu jammy/main amd64 Packages
 *** 121.0~b7+build1-0ubuntu0.22.04.1 500
        500 https://ppa.launchpadcontent.net/mozillateam/firefox-next/ubuntu jammy/main amd64 Packages
        100 /var/lib/dpkg/status
```

**Notes for Reviewers**
I discovered this new version by first failing to install the said version of `firefox`. Then, when trying to first install `firefox-geckodriver`, I discovered this version.

**Signed commits**
- [x] Yes, I signed my commits.