### PR TITLE
Use Reviewdog to Annotate PRs with Pylint and Spellcheck 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,19 @@
+name: "run-linting-checks"
+on:
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  run-pylint:
+    name: runner / pylint
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dciborow/action-pylint@0.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          level: warning
+          glob_pattern: "**/*.py"
+          filter_mode: "file"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,3 +17,15 @@ jobs:
           level: warning
           glob_pattern: "**/*.py"
           filter_mode: "file"
+
+  misspell:
+    name: runner / misspell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Highlight any misspellings in changes.
+        uses: actions/checkout@v4
+      - name: misspell
+        uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          locale: "US"


### PR DESCRIPTION
**Description**
- Add GitHub workflow to run reviewdog and annotate with relevant linters and checkers 
- When a PR is created into either dev or main, pylint checks are ran and annotated on that PR for review
- The only files considered are the ones that contain changes to not be overwhelming

**Notes for Reviewers**
I decided on Pylint because it's not that strict of a linter. We should consider how strict we are willing to be on linting and checking in general in the future as reviewdog supports many tools. Some good linting alternatives are listed in the readme for the [reviewdog repo](https://github.com/reviewdog/reviewdog)

We can also automatically force new PRs to follow PEP8 but that might be overkill. 


**Signed commits**
- [x] Yes, I signed my commits.
