### PR TITLE
Allow 404 Repos to Automatically be Re-collected 

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -19,7 +19,8 @@ from urllib.parse import urlparse
 from datetime import datetime
 
 from augur import instance_id
-from augur.tasks.start_tasks import augur_collection_monitor, CollectionState, create_collection_status_records
+from augur.tasks.util.collection_state import CollectionState
+from augur.tasks.start_tasks import augur_collection_monitor, create_collection_status_records
 from augur.tasks.git.facade_tasks import clone_repos
 from augur.tasks.data_analysis.contributor_breadth_worker.contributor_breadth_worker import contributor_breadth_model
 from augur.tasks.init.redis_connection import redis_connection 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -31,7 +31,8 @@ from augur.tasks.git.util.facade_worker.facade_worker.analyzecommit import analy
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_facade_weight_time_factor, get_repo_commit_count, update_facade_scheduling_fields, get_facade_weight_with_commit_count, facade_bulk_insert_commits
 
 from augur.tasks.github.facade_github.tasks import *
-from augur.tasks.util.collection_util import CollectionState, get_collection_status_repo_git_from_filter
+from augur.tasks.util.collection_state import CollectionState
+from augur.tasks.util.collection_util import get_collection_status_repo_git_from_filter
 from augur.tasks.git.util.facade_worker.facade_worker.repofetch import GitCloneError, git_repo_initialize
 
 

--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -104,11 +104,11 @@ def ping_github_for_repo_move(augur_db, key_auth, repo, logger,collection_hook='
 
     collectionRecord = execute_session_query(statusQuery,'one')
     if collection_hook == 'core':
-        collectionRecord.core_status = CollectionState.PENDING.value
+        collectionRecord.core_status = CollectionState.STANDBY.value
         collectionRecord.core_task_id = None
         collectionRecord.core_data_last_collected = datetime.today().strftime('%Y-%m-%dT%H:%M:%SZ')
     elif collection_hook == 'secondary':
-        collectionRecord.secondary_status = CollectionState.PENDING.value
+        collectionRecord.secondary_status = CollectionState.STANDBY.value
         collectionRecord.secondary_task_id = None
         collectionRecord.secondary_data_last_collected = datetime.today().strftime('%Y-%m-%dT%H:%M:%SZ')
 

--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -6,14 +6,9 @@ from augur.tasks.github.util.util import get_owner_repo
 from augur.tasks.github.util.util import parse_json_response
 import logging
 from datetime import datetime
-from enum import Enum
+from augur.tasks.utl.collection_state import CollectionState
 from augur.application.db.util import execute_session_query
 
-class CollectionState(Enum):
-    SUCCESS = "Success"
-    PENDING = "Pending"
-    ERROR = "Error"
-    COLLECTING = "Collecting"
 
 
 def update_repo_with_dict(current_dict,new_dict,logger,db):
@@ -114,6 +109,6 @@ def ping_github_for_repo_move(augur_db, key_auth, repo, logger,collection_hook='
 
     augur_db.session.commit()
 
-    raise Exception("ERROR: Repo has moved! Marked repo as pending and stopped collection")
+    raise Exception("ERROR: Repo has moved! Marked repo as standby and stopped collection")
 
     

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -85,7 +85,7 @@ BACKEND_URL = f'{redis_conn_string}{redis_db_number+1}'
 #Classes for tasks that take a repo_git as an argument.
 class AugurCoreRepoCollectionTask(celery.Task):
 
-    def augur_handle_task_failure(self,exc,task_id,repo_git,logger_name,collection_hook='core'):
+    def augur_handle_task_failure(self,exc,task_id,repo_git,logger_name,collection_hook='core',after_fail=CollectionState.ERROR.value):
         from augur.tasks.init.celery_app import engine
 
         logger = AugurLogger(logger_name).get_logger()
@@ -104,7 +104,7 @@ class AugurCoreRepoCollectionTask(celery.Task):
             prevStatus = getattr(repoStatus, f"{collection_hook}_status")
 
             if prevStatus == CollectionState.COLLECTING.value or prevStatus == CollectionState.INITIALIZING.value:
-                setattr(repoStatus, f"{collection_hook}_status", CollectionState.ERROR.value)
+                setattr(repoStatus, f"{collection_hook}_status", after_fail)
                 setattr(repoStatus, f"{collection_hook}_task_id", None)
                 session.commit()
 
@@ -128,6 +128,15 @@ class AugurMlRepoCollectionTask(AugurCoreRepoCollectionTask):
     def on_failure(self,exc,task_id,args,kwargs,einfo):
         repo_git = args[0]
         self.augur_handle_task_failure(exc,task_id,repo_git, "ml_task_failure", collection_hook='ml')
+
+#Create task subclasses that set their status to standby instead of error so that they can be retried.
+class AugurCoreRepoCollectionStandbyTask(AugurCoreRepoCollectionTask):
+    def on_failure(self,exc,task_id,args,kwargs,einfo):
+        repo_git = args[0]
+        self.augur_handle_task_failure(exc, task_id, 
+            repo_git, "core_task_failure",after_fail=CollectionState.STANDBY.value)
+        
+#TODO: Make certain tasks such as detect_github_repo_move able to softly fail and be retried later.
 
 #task_cls='augur.tasks.init.celery_app:AugurCoreRepoCollectionTask'
 celery_app = Celery('tasks', broker=BROKER_URL, backend=BACKEND_URL, include=tasks)

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -129,14 +129,6 @@ class AugurMlRepoCollectionTask(AugurCoreRepoCollectionTask):
         repo_git = args[0]
         self.augur_handle_task_failure(exc,task_id,repo_git, "ml_task_failure", collection_hook='ml')
 
-#Create task subclasses that set their status to standby instead of error so that they can be retried.
-class AugurCoreRepoCollectionStandbyTask(AugurCoreRepoCollectionTask):
-    def on_failure(self,exc,task_id,args,kwargs,einfo):
-        repo_git = args[0]
-        self.augur_handle_task_failure(exc, task_id, 
-            repo_git, "core_task_failure",after_fail=CollectionState.STANDBY.value)
-        
-#TODO: Make certain tasks such as detect_github_repo_move able to softly fail and be retried later.
 
 #task_cls='augur.tasks.init.celery_app:AugurCoreRepoCollectionTask'
 celery_app = Celery('tasks', broker=BROKER_URL, backend=BACKEND_URL, include=tasks)

--- a/augur/tasks/util/collection_state.py
+++ b/augur/tasks/util/collection_state.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+class CollectionState(Enum):
+    SUCCESS = "Success"
+    PENDING = "Pending"
+    ERROR = "Error"
+    COLLECTING = "Collecting"
+    INITIALIZING = "Initializing"
+    UPDATE = "Update"
+    FAILED_CLONE = "Failed Clone"
+    STANDBY = "Standby"

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -24,18 +24,8 @@ from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.application.db.session import DatabaseSession
 from augur.tasks.util.worker_util import calculate_date_weight_from_timestamps
+from augur.tasks.util.collection_state import CollectionState
 
-
-# class syntax
-class CollectionState(Enum):
-    SUCCESS = "Success"
-    PENDING = "Pending"
-    ERROR = "Error"
-    COLLECTING = "Collecting"
-    INITIALIZING = "Initializing"
-    UPDATE = "Update"
-    FAILED_CLONE = "Failed Clone"
-    STANDBY = "Standby"
 
 def get_list_of_all_users(session):
     #Get a list of all users.

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -35,6 +35,7 @@ class CollectionState(Enum):
     INITIALIZING = "Initializing"
     UPDATE = "Update"
     FAILED_CLONE = "Failed Clone"
+    STANDBY = "Standby"
 
 def get_list_of_all_users(session):
     #Get a list of all users.


### PR DESCRIPTION
**Description**
- Add a new `CollectionState` enum value called 'Standby' that pauses collection on the repo until midnight. This lets us automatically retry repositories that have hit a 404 without crowding out other tasks.
- Fix some import issues where `CollectionState` was being defined multiple times. I have moved this class to its own file in an attempt to make sure that we only define enums once. 
- Add periodic task to set repos to pending daily

**Signed commits**
- [x] Yes, I signed my commits.

