### PR TITLE
Remove Unneeded 'git commit' Call in Github Action Script Because it Returns Non-Zero Bash Code

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -19,9 +19,6 @@ jobs:
           git config user.email 'actions@users.noreply.github.com'
           git checkout dev
           git merge main
-          git add -A
-          timestamp=$(date -u)
-          git commit -m "update dev: ${timestamp}"
           echo "Done with merge"
       - name: Push to dev
         uses: CasperWA/push-protected@v2


### PR DESCRIPTION
**Description**
The `git commit` call in the script was causing problems with the script because GitHub actions counts any non-zero bash code as a failure condition. The `git commit` call returns a non-zero bash code because there is nothing to commit. 

**Notes for Reviewers**
Hopefully this is the last one. 

**Signed commits**
- [x] Yes, I signed my commits.
