### PR TITLE
Clean up unused imports and start defining collection database engine in db folder

### DIFF
--- a/augur/api/gunicorn_conf.py
+++ b/augur/api/gunicorn_conf.py
@@ -1,10 +1,8 @@
 # from augur import ROOT_AUGUR_DIRECTORY
 import multiprocessing
 import logging
-import os
 from pathlib import Path
 from glob import glob
-import shutil
 
 from augur.application.db.session import DatabaseSession
 from augur.application.config import AugurConfig

--- a/augur/api/metrics/contributor.py
+++ b/augur/api/metrics/contributor.py
@@ -7,7 +7,6 @@ import datetime
 import sqlalchemy as s
 import pandas as pd
 from augur.api.util import register_metric
-import uuid 
 
 from ..server import engine
 

--- a/augur/api/routes/application.py
+++ b/augur/api/routes/application.py
@@ -4,26 +4,12 @@ Creates routes for user functionality
 """
 
 import logging
-import requests
-import os
-import base64
-import time
-import secrets
-import pandas as pd
-from flask import request, Response, jsonify, session
-from flask_login import login_user, logout_user, current_user, login_required
-from werkzeug.security import check_password_hash
-from sqlalchemy.sql import text
+from flask import request, jsonify
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.exc import NoResultFound
-from augur.application.db.session import DatabaseSession
-from augur.tasks.github.util.github_task_session import GithubTaskSession
-from augur.util.repo_load_controller import RepoLoadController
 from augur.api.util import api_key_required, ssl_required
 
-from augur.application.db.models import User, UserRepo, UserGroup, UserSessionToken, ClientApplication, RefreshToken
+from augur.application.db.models import User, ClientApplication
 from augur.application.config import get_development_flag
-from augur.tasks.init.redis_connection import redis_connection as redis
 from ..server import app, engine
 
 logger = logging.getLogger(__name__)

--- a/augur/api/routes/config.py
+++ b/augur/api/routes/config.py
@@ -3,9 +3,7 @@
 Creates routes for config functionality
 """
 import logging
-import requests
-import os
-from flask import request, jsonify, Response
+from flask import request, jsonify
 import sqlalchemy as s
 
 # Disable the requirement for SSL by setting env["AUGUR_DEV"] = True

--- a/augur/api/routes/dei.py
+++ b/augur/api/routes/dei.py
@@ -2,25 +2,20 @@
 Creates routes for DEI badging functionality
 """
 
-import logging, subprocess, inspect
+import logging, subprocess
 
-from flask import request, Response, jsonify, render_template, send_file
+from flask import request, jsonify, render_template, send_file
 from pathlib import Path
 
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.orm.exc import NoResultFound
 
 from augur.api.util import api_key_required, ssl_required
-from augur.util.repo_load_controller import RepoLoadController
 
-from augur.application.db.models import User, ClientApplication, CollectionStatus, Repo, RepoGroup, BadgingDEI
+from augur.application.db.models import ClientApplication, CollectionStatus, Repo, RepoGroup, BadgingDEI
 from augur.application.db.session import DatabaseSession
-from augur.application.config import AugurConfig
 
 from augur.tasks.util.collection_util import CollectionRequest,AugurTaskRoutine, get_enabled_phase_names_from_config, core_task_success_util
 from augur.tasks.start_tasks import prelim_phase, primary_repo_collect_phase
-from augur.tasks.github.util.github_task_session import GithubTaskSession
-from augur.tasks.init.redis_connection import redis_connection as redis
 from augur.tasks.github.util.util import get_repo_weight_by_issue
 
 from ..server import app, engine

--- a/augur/api/routes/user.py
+++ b/augur/api/routes/user.py
@@ -6,7 +6,7 @@ from augur.api.routes import AUGUR_API_VERSION
 
 import logging
 import secrets
-from flask import request, jsonify, session
+from flask import request, jsonify
 from flask_login import login_user, logout_user, current_user, login_required
 from werkzeug.security import check_password_hash
 from sqlalchemy.orm import sessionmaker

--- a/augur/api/server.py
+++ b/augur/api/server.py
@@ -4,15 +4,13 @@
 import glob
 import sys
 import inspect
-import types
 import json
 import os
 import base64
-import logging
 import importlib
 import graphene
 
-from typing import Optional, List, Any, Tuple
+from typing import List, Any
 
 from pathlib import Path
 
@@ -21,7 +19,6 @@ from flask_cors import CORS
 import pandas as pd
 from beaker.util import parse_cache_config_options
 from beaker.cache import CacheManager, Cache
-from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 from flask_graphql import GraphQLView
 from graphene_sqlalchemy import SQLAlchemyObjectType

--- a/augur/api/util.py
+++ b/augur/api/util.py
@@ -4,9 +4,6 @@ Provides shared functions that do not fit in a class of their own
 """
 import os
 import re
-import inspect
-import types
-import sys
 import beaker
 
 from flask import request, jsonify
@@ -16,7 +13,7 @@ from functools import wraps
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.exc import NoResultFound
 from augur.application.config import get_development_flag
-from augur.application.db.models import User, UserRepo, UserGroup, UserSessionToken, ClientApplication, RefreshToken
+from augur.application.db.models import ClientApplication
 
 Session = sessionmaker(bind=engine)
 development = get_development_flag()

--- a/augur/api/view/api.py
+++ b/augur/api/view/api.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, render_template_string, request, abort, jsonify, redirect, url_for, session, flash
+from flask import request, jsonify, redirect, url_for, flash
 import re
 from flask_login import current_user, login_required
 from augur.application.db.models import Repo, RepoGroup, UserGroup, UserRepo

--- a/augur/api/view/augur_view.py
+++ b/augur/api/view/augur_view.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, redirect, url_for, session, request, jsonify
+from flask import render_template, redirect, url_for, session, request, jsonify
 from flask_login import LoginManager
 from io import StringIO
 from .utils import *

--- a/augur/api/view/init.py
+++ b/augur/api/view/init.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from .server import Environment
 from augur.application.logs import AugurLogger
-import logging, secrets, yaml
+import secrets, yaml
 
 env = Environment()
 

--- a/augur/api/view/routes.py
+++ b/augur/api/view/routes.py
@@ -3,7 +3,7 @@ Defines the api routes for the augur views
 """
 import logging
 import math
-from flask import render_template, request, redirect, url_for, session, flash, requestJson
+from flask import render_template, request, redirect, url_for, session, flash
 from .utils import *
 from flask_login import login_user, logout_user, current_user, login_required
 

--- a/augur/api/view/routes.py
+++ b/augur/api/view/routes.py
@@ -3,14 +3,12 @@ Defines the api routes for the augur views
 """
 import logging
 import math
-from flask import Flask, render_template, render_template_string, request, abort, jsonify, redirect, url_for, session, flash
-from sqlalchemy.orm.exc import NoResultFound
+from flask import render_template, request, redirect, url_for, session, flash, requestJson
 from .utils import *
 from flask_login import login_user, logout_user, current_user, login_required
 
 from augur.application.db.models import User, Repo, ClientApplication
 from .server import LoginException
-from augur.tasks.init.redis_connection import redis_connection as redis
 from augur.application.util import *
 from augur.application.config import AugurConfig
 from ..server import app, db_session

--- a/augur/api/view/utils.py
+++ b/augur/api/view/utils.py
@@ -3,22 +3,14 @@ Defines utility functions used by the augur api views
 """
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
-from flask import render_template, flash, url_for, Flask
+from flask import render_template, flash, url_for
 from .init import init_logging
 from .init import *
-from ..server import app, db_session
+from ..server import db_session
 from augur.application.config import AugurConfig
-import urllib.request, urllib.error, json, os, math, yaml, urllib3, time, logging, re, math
+import urllib.error, math, yaml, urllib3, time, math
 
-from augur.application.db.session import DatabaseSession
-from augur.application.db.engine import DatabaseEngine
-from augur.application.db.models import User, Repo, RepoGroup, UserGroup, UserRepo
-from sqlalchemy import Column, Table, Integer, MetaData, or_
-from sqlalchemy.sql.operators import ilike_op, distinct_op
-from sqlalchemy.sql.functions import coalesce
-from augur.application.db.models.base import Base
 
-from sqlalchemy.orm import Query
 
 init_logging()
 

--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -10,28 +10,21 @@ import click
 import logging
 import psutil
 import signal
-import sys
 from redis.exceptions import ConnectionError as RedisConnectionError
-from celery import chain, signature, group
 import uuid
 import traceback
 from urllib.parse import urlparse
-from datetime import datetime
 
-from augur import instance_id
-from augur.tasks.util.collection_state import CollectionState
 from augur.tasks.start_tasks import augur_collection_monitor, create_collection_status_records
 from augur.tasks.git.facade_tasks import clone_repos
 from augur.tasks.data_analysis.contributor_breadth_worker.contributor_breadth_worker import contributor_breadth_model
 from augur.tasks.init.redis_connection import redis_connection 
-from augur.application.db.models import Repo, CollectionStatus, UserRepo
+from augur.application.db.models import UserRepo
 from augur.application.db.session import DatabaseSession
-from augur.application.db.util import execute_session_query
 from augur.application.logs import AugurLogger
 from augur.application.config import AugurConfig
 from augur.application.cli import test_connection, test_db_connection 
 import sqlalchemy as s
-from sqlalchemy import or_, and_
 
 
 logger = AugurLogger("augur", reset_logfiles=True).get_logger()

--- a/augur/application/cli/config.py
+++ b/augur/application/cli/config.py
@@ -7,9 +7,7 @@ import click
 import json
 import logging
 
-from augur.application.db.models import Config
 from augur.application.db.session import DatabaseSession
-from augur.application.logs import AugurLogger
 from augur.application.config import AugurConfig
 from augur.application.cli import test_connection, test_db_connection 
 from augur.util.inspect_without_import import get_phase_names_without_import

--- a/augur/application/cli/db.py
+++ b/augur/application/cli/db.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MIT
-from os import walk, chdir, environ, chmod, path
+from os import environ, chmod, path
 import os
 import logging
 from sys import exit
 import stat
-from collections import OrderedDict
 from subprocess import call
 import random
 import string
@@ -12,7 +11,6 @@ import csv
 import click
 import sqlalchemy as s
 import pandas as pd
-import requests
 import json
 import sqlalchemy as s
 import re
@@ -20,7 +18,6 @@ import re
 from augur.application.cli import test_connection, test_db_connection 
 
 from augur.application.db.session import DatabaseSession
-from augur.application.logs import AugurLogger
 from augur.application.db.engine import DatabaseEngine
 from sqlalchemy import update
 from datetime import datetime

--- a/augur/application/cli/db.py
+++ b/augur/application/cli/db.py
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: MIT
-from os import environ, chmod, path
-import os
+from os import environ, chmod, path, getenv, stat
 import logging
 from sys import exit
-import stat
 from subprocess import call
 import random
 import string
@@ -12,7 +10,6 @@ import click
 import sqlalchemy as s
 import pandas as pd
 import json
-import sqlalchemy as s
 import re
 
 from augur.application.cli import test_connection, test_db_connection 
@@ -277,7 +274,7 @@ def get_api_key():
     short_help="Check the ~/.pgpass file for Augur's database credentials",
 )
 def check_pgpass():
-    augur_db_env_var = os.getenv("AUGUR_DB")
+    augur_db_env_var = getenv("AUGUR_DB")
     if augur_db_env_var:
 
         # gets the user, passowrd, host, port, and database_name out of environment variable
@@ -379,7 +376,7 @@ def run_psql_command_in_database(target_type, target):
         logger.error("Invalid target type. Exiting...")
         exit(1)
 
-    augur_db_environment_var = os.getenv("AUGUR_DB")
+    augur_db_environment_var = getenv("AUGUR_DB")
 
     # db_json_file_location = os.getcwd() + "/db.config.json"
     # db_json_exists = os.path.exists(db_json_file_location)
@@ -425,7 +422,7 @@ def check_pgpass_credentials(config):
         open(pgpass_file_path, "w+")
         chmod(pgpass_file_path, stat.S_IWRITE | stat.S_IREAD)
 
-    pgpass_file_mask = oct(os.stat(pgpass_file_path).st_mode & 0o777)
+    pgpass_file_mask = oct(stat(pgpass_file_path).st_mode & 0o777)
 
     if pgpass_file_mask != "0o600":
         print("Updating ~/.pgpass file permissions.")

--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -1,5 +1,5 @@
 import sqlalchemy as s
-from sqlalchemy import or_, and_, update
+from sqlalchemy import and_, update
 import json
 from typing import List, Any, Optional
 import os

--- a/augur/application/db/__init__.py
+++ b/augur/application/db/__init__.py
@@ -1,0 +1,20 @@
+from sqlalchemy.pool import StaticPool
+
+from augur.application.db.engine import create_database_engine, get_database_string
+
+engine = None
+
+def get_engine():
+    global engine
+    if engine is None:
+        url = get_database_string()
+        engine = create_database_engine(url=url, poolclass=StaticPool)  
+        
+    return engine
+
+
+def dispose_database_engine():
+    global engine
+    if engine:
+        engine.dispose()
+        engine = None

--- a/augur/application/db/__init__.py
+++ b/augur/application/db/__init__.py
@@ -9,7 +9,7 @@ def get_engine():
     if engine is None:
         url = get_database_string()
         engine = create_database_engine(url=url, poolclass=StaticPool)  
-        
+    
     return engine
 
 

--- a/augur/application/db/engine.py
+++ b/augur/application/db/engine.py
@@ -2,14 +2,10 @@
 import os
 import json
 import sys
-import logging
-import inspect
 import re
 import subprocess
 
 from sqlalchemy import create_engine, event
-from sqlalchemy.engine.base import Engine
-from sqlalchemy.pool import NullPool
 from augur.application.db.util import catch_operational_error
 
 

--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -24,12 +24,10 @@ from sqlalchemy.sql import text
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 import logging
 import re
-from typing import List, Any, Dict
 import json
 
 
 from augur.application.db.models.base import Base
-from augur.application import requires_db_session
 from augur.application.db.util import execute_session_query
 DEFAULT_REPO_GROUP_ID = 1
 

--- a/augur/application/db/session.py
+++ b/augur/application/db/session.py
@@ -1,9 +1,5 @@
-import os
-import re
 import time
-import sys
 import random
-import logging
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import OperationalError
@@ -12,8 +8,7 @@ from typing import Optional, List, Union
 from psycopg2.errors import DeadlockDetected
 
 # from augur.tasks.util.random_key_auth import RandomKeyAuth
-from augur.application.db.engine import EngineConnection
-from augur.tasks.util.worker_util import remove_duplicate_dicts, remove_duplicates_by_uniques
+from augur.tasks.util.worker_util import remove_duplicates_by_uniques
 
 
 def remove_null_characters_from_string(string):

--- a/augur/application/log_analysis/http/http_server.py
+++ b/augur/application/log_analysis/http/http_server.py
@@ -1,7 +1,6 @@
 import http.server
 import socketserver
 import logging
-import cgi
 import json
 from pathlib import Path
 import re

--- a/augur/application/logs.py
+++ b/augur/application/logs.py
@@ -3,17 +3,11 @@ from __future__ import annotations
 import logging
 import logging.config
 import logging.handlers
-from logging import FileHandler, StreamHandler, Formatter
-from multiprocessing import Process, Queue, Event, current_process
-from inspect import getmembers, isfunction
-from time import sleep
+from logging import FileHandler
 import os
 from pathlib import Path
-import atexit
 import shutil
 import coloredlogs
-from copy import deepcopy
-import typing
 from sqlalchemy.orm import Session
 
 from augur.application.db.models import Config 

--- a/augur/application/schema/alembic/env.py
+++ b/augur/application/schema/alembic/env.py
@@ -1,13 +1,10 @@
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
 
 from alembic import context
 from augur.application.db.models.base import Base
-from augur.application.db.engine import DatabaseEngine, get_database_string
+from augur.application.db.engine import get_database_string
 from sqlalchemy import create_engine, event
-from sqlalchemy.pool import NullPool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/augur/application/schema/alembic/versions/18_schedule_any_old_facade_repositories_to.py
+++ b/augur/application/schema/alembic/versions/18_schedule_any_old_facade_repositories_to.py
@@ -6,8 +6,6 @@ Create Date: 2023-05-02 17:35:18.891913
 
 """
 from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import text
 import pathlib
 import shutil

--- a/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
+++ b/augur/application/schema/alembic/versions/19_add_extra_celery_options_to_the_config_.py
@@ -6,7 +6,6 @@ Create Date: 2023-05-15 12:03:57.171011
 
 """
 from alembic import op
-import sqlalchemy as sa
 from augur.application.db.session import DatabaseSession
 from augur.application.config import *
 from sqlalchemy.sql import text

--- a/augur/application/schema/alembic/versions/3_oauth_and_user_groups.py
+++ b/augur/application/schema/alembic/versions/3_oauth_and_user_groups.py
@@ -10,7 +10,6 @@ import logging
 from alembic import op
 import sqlalchemy as sa
 from augur.application.db.session import DatabaseSession
-from augur.application.db.models.augur_operations import UserGroup, UserRepo
 
 CLI_USER_ID = 1
 

--- a/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
+++ b/augur/application/schema/alembic/versions/7_no_null_repo_path_and_repo_name.py
@@ -6,10 +6,7 @@ Create Date: 2023-02-23 10:14:08.787528
 
 """
 from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import text
-import re
 from augur.application.db.models import Repo
 
 

--- a/augur/tasks/data_analysis/__init__.py
+++ b/augur/tasks/data_analysis/__init__.py
@@ -1,9 +1,5 @@
-from augur.application.db.session import DatabaseSession
 from augur.application.db import get_engine
-from augur.application.db.models import Repo 
-from augur.application.db.util import execute_session_query
-from celery import group, chain, chord, signature
-from augur.tasks.init.celery_app import celery_app as celery
+from celery import chain
 import logging 
 
 def machine_learning_phase(repo_git):

--- a/augur/tasks/data_analysis/__init__.py
+++ b/augur/tasks/data_analysis/__init__.py
@@ -1,4 +1,5 @@
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.application.db.models import Repo 
 from augur.application.db.util import execute_session_query
 from celery import group, chain, chord, signature
@@ -12,7 +13,6 @@ def machine_learning_phase(repo_git):
     from augur.tasks.data_analysis.message_insights.tasks import message_insight_task
     from augur.tasks.data_analysis.pull_request_analysis_worker.tasks import pull_request_analysis_task
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(machine_learning_phase.__name__)

--- a/augur/tasks/data_analysis/__init__.py
+++ b/augur/tasks/data_analysis/__init__.py
@@ -12,7 +12,8 @@ def machine_learning_phase(repo_git):
     from augur.tasks.data_analysis.message_insights.tasks import message_insight_task
     from augur.tasks.data_analysis.pull_request_analysis_worker.tasks import pull_request_analysis_task
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(machine_learning_phase.__name__)
 

--- a/augur/tasks/data_analysis/clustering_worker/tasks.py
+++ b/augur/tasks/data_analysis/clustering_worker/tasks.py
@@ -35,7 +35,8 @@ stemmer = nltk.stem.snowball.SnowballStemmer("english")
 def clustering_task(repo_git):
 
     logger = logging.getLogger(clustering_model.__name__)
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:
         clustering_model(repo_git, logger, engine, session)

--- a/augur/tasks/data_analysis/clustering_worker/tasks.py
+++ b/augur/tasks/data_analysis/clustering_worker/tasks.py
@@ -21,6 +21,7 @@ from collections import Counter
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.application.config import AugurConfig
 from augur.application.db.models import Repo, RepoClusterMessage, RepoTopic, TopicWord
 from augur.application.db.util import execute_session_query
@@ -35,7 +36,6 @@ stemmer = nltk.stem.snowball.SnowballStemmer("english")
 def clustering_task(repo_git):
 
     logger = logging.getLogger(clustering_model.__name__)
-    from augur.application.db import get_engine
     engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:

--- a/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -1,6 +1,5 @@
 #SPDX-License-Identifier: MIT
-import logging, json
-import pandas as pd
+import logging
 import sqlalchemy as s
 from datetime import datetime
 

--- a/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -18,7 +18,8 @@ from augur.application.db.models import ContributorRepo
 @celery.task
 def contributor_breadth_model() -> None:
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(contributor_breadth_model.__name__)
 

--- a/augur/tasks/data_analysis/discourse_analysis/tasks.py
+++ b/augur/tasks/data_analysis/discourse_analysis/tasks.py
@@ -9,6 +9,7 @@ from collections import Counter
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.application.db.models import Repo, DiscourseInsight
 from augur.application.db.util import execute_session_query
 from augur.tasks.init.celery_app import AugurMlRepoCollectionTask
@@ -36,7 +37,6 @@ DISCOURSE_ANALYSIS_DIR = f"{ROOT_AUGUR_DIRECTORY}/tasks/data_analysis/discourse_
 def discourse_analysis_task(repo_git):
 
     logger = logging.getLogger(discourse_analysis_task.__name__)
-    from augur.application.db import get_engine
     engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:

--- a/augur/tasks/data_analysis/discourse_analysis/tasks.py
+++ b/augur/tasks/data_analysis/discourse_analysis/tasks.py
@@ -36,7 +36,8 @@ DISCOURSE_ANALYSIS_DIR = f"{ROOT_AUGUR_DIRECTORY}/tasks/data_analysis/discourse_
 def discourse_analysis_task(repo_git):
 
     logger = logging.getLogger(discourse_analysis_task.__name__)
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:
         discourse_analysis_model(repo_git, logger, engine)

--- a/augur/tasks/data_analysis/insight_worker/tasks.py
+++ b/augur/tasks/data_analysis/insight_worker/tasks.py
@@ -27,7 +27,8 @@ warnings.filterwarnings('ignore')
 def insight_task(repo_git):
 
     logger = logging.getLogger(insight_task.__name__)
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:
         insight_model(repo_git, logger, engine, session)

--- a/augur/tasks/data_analysis/insight_worker/tasks.py
+++ b/augur/tasks/data_analysis/insight_worker/tasks.py
@@ -1,11 +1,7 @@
 # SPDX-License-Identifier: MIT
-from multiprocessing import Process, Queue
-from urllib.parse import urlparse
 import requests
 import pandas as pd
 import sqlalchemy as s
-from sqlalchemy.ext.automap import automap_base
-from sqlalchemy import MetaData, and_
 import logging, json
 import numpy as np
 import scipy.stats

--- a/augur/tasks/data_analysis/message_insights/message_novelty.py
+++ b/augur/tasks/data_analysis/message_insights/message_novelty.py
@@ -1,20 +1,8 @@
 #SPDX-License-Identifier: MIT
 ## Added  imports
-import re
-import unicodedata
-import nltk
-import string
-from nltk.tokenize import word_tokenize 
-from nltk.stem.snowball import SnowballStemmer
-from bs4 import BeautifulSoup
-import matplotlib.pyplot as plt
-from datetime import date
 
 ##
-import logging
-import multiprocessing
 import os
-import traceback 
 from datetime import datetime, timedelta
 
 import numpy as np
@@ -22,7 +10,6 @@ import pandas as pd
 from gensim.models.doc2vec import Doc2Vec, TaggedDocument
 from keras.layers import Dense, Input
 from keras.models import Model, load_model
-from scipy.spatial.distance import cosine
 from skimage.filters import threshold_otsu
 from sklearn import utils as skl_utils
 

--- a/augur/tasks/data_analysis/message_insights/preprocess_text.py
+++ b/augur/tasks/data_analysis/message_insights/preprocess_text.py
@@ -5,7 +5,6 @@ import string
 import unicodedata
 
 import nltk
-import pandas as pd
 from bs4 import BeautifulSoup
 from nltk.stem.snowball import SnowballStemmer
 from nltk.tokenize import word_tokenize

--- a/augur/tasks/data_analysis/message_insights/tasks.py
+++ b/augur/tasks/data_analysis/message_insights/tasks.py
@@ -26,7 +26,8 @@ ROOT_AUGUR_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.d
 def message_insight_task(repo_git):
 
     logger = logging.getLogger(message_insight_task.__name__)
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:
         message_insight_model(repo_git, logger, engine, session)

--- a/augur/tasks/data_analysis/message_insights/tasks.py
+++ b/augur/tasks/data_analysis/message_insights/tasks.py
@@ -13,6 +13,7 @@ from augur.tasks.data_analysis.message_insights.message_sentiment import get_sen
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.application.config import AugurConfig
 from augur.application.db.models import Repo, MessageAnalysis, MessageAnalysisSummary
 from augur.application.db.util import execute_session_query
@@ -26,7 +27,6 @@ ROOT_AUGUR_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.d
 def message_insight_task(repo_git):
 
     logger = logging.getLogger(message_insight_task.__name__)
-    from augur.application.db import get_engine
     engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:

--- a/augur/tasks/data_analysis/pull_request_analysis_worker/tasks.py
+++ b/augur/tasks/data_analysis/pull_request_analysis_worker/tasks.py
@@ -26,7 +26,8 @@ ROOT_AUGUR_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.d
 def pull_request_analysis_task(repo_git):
 
     logger = logging.getLogger(pull_request_analysis_task.__name__)
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:
         pull_request_analysis_model(repo_git, logger, engine)

--- a/augur/tasks/data_analysis/pull_request_analysis_worker/tasks.py
+++ b/augur/tasks/data_analysis/pull_request_analysis_worker/tasks.py
@@ -10,6 +10,7 @@ from augur.tasks.data_analysis.message_insights.message_sentiment import get_sen
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.application.config import AugurConfig
 from augur.application.db.models import Repo, PullRequestAnalysis
 from augur.application.db.util import execute_session_query
@@ -26,7 +27,6 @@ ROOT_AUGUR_DIRECTORY = os.path.dirname(os.path.dirname(os.path.dirname(os.path.d
 def pull_request_analysis_task(repo_git):
 
     logger = logging.getLogger(pull_request_analysis_task.__name__)
-    from augur.application.db import get_engine
     engine = get_engine()
 
     with DatabaseSession(logger, engine) as session:

--- a/augur/tasks/db/refresh_materialized_views.py
+++ b/augur/tasks/db/refresh_materialized_views.py
@@ -14,7 +14,8 @@ def refresh_materialized_views():
 
     #self.logger = AugurLogger("data_collection_jobs").get_logger()
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(refresh_materialized_views.__name__)
     #self.logger = logging.getLogger(refresh_materialized_views.__name__)

--- a/augur/tasks/db/refresh_materialized_views.py
+++ b/augur/tasks/db/refresh_materialized_views.py
@@ -6,6 +6,7 @@ from celery import group, chain, chord, signature
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.application.logs import AugurLogger
 
 
@@ -14,7 +15,6 @@ def refresh_materialized_views():
 
     #self.logger = AugurLogger("data_collection_jobs").get_logger()
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(refresh_materialized_views.__name__)

--- a/augur/tasks/db/refresh_materialized_views.py
+++ b/augur/tasks/db/refresh_materialized_views.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 import logging
 import sqlalchemy as s
-from celery import signature
-from celery import group, chain, chord, signature
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
 from augur.application.db import get_engine
-from augur.application.logs import AugurLogger
 
 
 @celery.task

--- a/augur/tasks/git/dependency_libyear_tasks/core.py
+++ b/augur/tasks/git/dependency_libyear_tasks/core.py
@@ -1,15 +1,7 @@
 from datetime import datetime
-import logging
-import requests
-import re
-import os, subprocess
-import traceback
-import sqlalchemy as s
 from augur.application.db.models import *
-from augur.application.db.session import DatabaseSession
 from augur.application.config import AugurConfig
 from augur.application.db.util import execute_session_query
-from urllib.parse import quote
 from augur.tasks.git.dependency_libyear_tasks.libyear_util.util import get_deps_libyear_data
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path
 

--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/npm_libyear_utils.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/npm_libyear_utils.py
@@ -1,4 +1,3 @@
-import os, re
 import requests
 
 def get_NPM_data(package):

--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_libyear_util.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_libyear_util.py
@@ -1,4 +1,3 @@
-from distutils import version
 import requests
 import dateutil.parser
 # from packaging import version

--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_parser.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_parser.py
@@ -1,10 +1,6 @@
 import re, os
 import json
-from typing import Dict
 import toml 
-import dateutil.parser
-from augur.tasks.git.dependency_libyear_tasks.libyear_util.pypi_libyear_util import sort_dependency_requirement,get_pypi_data,get_latest_version,get_release_date
-from augur.tasks.git.dependency_libyear_tasks.libyear_util.pypi_libyear_util import get_libyear
 import logging
 import yaml
 

--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
@@ -1,6 +1,4 @@
-from distutils.version import LooseVersion
 import dateutil.parser
-from distutils import version
 import os
 from augur.tasks.git.dependency_libyear_tasks.libyear_util.pypi_parser import parse_conda, parse_pipfile,parse_pipfile_lock,parse_poetry,parse_poetry_lock,parse_requirement_txt,parse_setup_py
 from augur.tasks.git.dependency_libyear_tasks.libyear_util.npm_parser import parse_package_json

--- a/augur/tasks/git/dependency_libyear_tasks/tasks.py
+++ b/augur/tasks/git/dependency_libyear_tasks/tasks.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from augur.application.db.session import DatabaseSession
 from augur.application.db import get_engine
 from augur.tasks.git.dependency_libyear_tasks.core import *

--- a/augur/tasks/git/dependency_libyear_tasks/tasks.py
+++ b/augur/tasks/git/dependency_libyear_tasks/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.tasks.git.dependency_libyear_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask
@@ -10,7 +11,6 @@ from augur.application.db.util import execute_session_query
 def process_libyear_dependency_metrics(repo_git):
     #raise NotImplementedError
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(process_libyear_dependency_metrics.__name__)

--- a/augur/tasks/git/dependency_libyear_tasks/tasks.py
+++ b/augur/tasks/git/dependency_libyear_tasks/tasks.py
@@ -10,7 +10,8 @@ from augur.application.db.util import execute_session_query
 def process_libyear_dependency_metrics(repo_git):
     #raise NotImplementedError
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(process_libyear_dependency_metrics.__name__)
 

--- a/augur/tasks/git/dependency_tasks/core.py
+++ b/augur/tasks/git/dependency_tasks/core.py
@@ -1,16 +1,7 @@
 from datetime import datetime
-import logging
-import requests
-import json
 import os
-import subprocess
-import re
-import traceback
 from augur.application.db.models import *
-from augur.application.db.session import DatabaseSession
-from augur.application.config import AugurConfig
 from augur.tasks.github.util.github_api_key_handler import GithubApiKeyHandler
-from augur.application.db.util import execute_session_query
 from augur.tasks.git.dependency_tasks.dependency_util import dependency_calculator as dep_calc
 from augur.tasks.util.worker_util import parse_json_from_subprocess_call
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/c_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/c_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/cpp_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/cpp_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/csharp_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/csharp_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/go_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/go_deps.py
@@ -1,4 +1,4 @@
-import sys, re
+import re
 from pathlib import Path
 
 def get_files(path):

--- a/augur/tasks/git/dependency_tasks/dependency_util/java_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/java_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/javascript_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/javascript_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/php_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/php_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/python_deps.py
@@ -1,7 +1,5 @@
-import sys
 import re
 from pathlib import Path
-import codecs
 import ast
 
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/ruby_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/ruby_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/rust_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/rust_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/dependency_util/vb_deps.py
+++ b/augur/tasks/git/dependency_tasks/dependency_util/vb_deps.py
@@ -1,4 +1,3 @@
-import sys
 import re
 from pathlib import Path
 

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -13,7 +13,8 @@ from augur.application.config import AugurConfig
 def process_dependency_metrics(repo_git):
     #raise NotImplementedError
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(process_dependency_metrics.__name__)
 
@@ -35,7 +36,8 @@ def process_dependency_metrics(repo_git):
 
 @celery.task(base=AugurSecondaryRepoCollectionTask)
 def process_ossf_dependency_metrics(repo_git):
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
     
     logger = logging.getLogger(process_ossf_dependency_metrics.__name__)
 

--- a/augur/tasks/git/dependency_tasks/tasks.py
+++ b/augur/tasks/git/dependency_tasks/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.tasks.git.dependency_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask, AugurCoreRepoCollectionTask, AugurSecondaryRepoCollectionTask
@@ -13,7 +14,6 @@ from augur.application.config import AugurConfig
 def process_dependency_metrics(repo_git):
     #raise NotImplementedError
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(process_dependency_metrics.__name__)
@@ -36,7 +36,7 @@ def process_dependency_metrics(repo_git):
 
 @celery.task(base=AugurSecondaryRepoCollectionTask)
 def process_ossf_dependency_metrics(repo_git):
-    from augur.application.db import get_engine
+
     engine = get_engine()
     
     logger = logging.getLogger(process_ossf_dependency_metrics.__name__)

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -39,6 +39,7 @@ from augur.tasks.git.util.facade_worker.facade_worker.repofetch import GitCloneE
 from augur.tasks.util.worker_util import create_grouped_task_load
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.application.db import get_engine
 from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask
 
 
@@ -391,7 +392,6 @@ def clone_repos():
 #@celery.task
 #def check_for_repo_updates_facade_task(repo_git):
 #
-#    from augur.application.db import get_engine
 #    engine = get_engine()
 #
 #    logger = logging.getLogger(check_for_repo_updates_facade_task.__name__)
@@ -402,7 +402,6 @@ def clone_repos():
 @celery.task(base=AugurFacadeRepoCollectionTask)
 def git_update_commit_count_weight(repo_git):
 
-    from augur.application.db import get_engine
     engine = get_engine()
     logger = logging.getLogger(git_update_commit_count_weight.__name__)
     

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -391,7 +391,8 @@ def clone_repos():
 #@celery.task
 #def check_for_repo_updates_facade_task(repo_git):
 #
-#    from augur.tasks.init.celery_app import engine
+#    from augur.application.db import get_engine
+#    engine = get_engine()
 #
 #    logger = logging.getLogger(check_for_repo_updates_facade_task.__name__)
 #
@@ -401,7 +402,8 @@ def clone_repos():
 @celery.task(base=AugurFacadeRepoCollectionTask)
 def git_update_commit_count_weight(repo_git):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
     logger = logging.getLogger(git_update_commit_count_weight.__name__)
     
     with FacadeSession(logger) as session:

--- a/augur/tasks/git/scc_value_tasks/core.py
+++ b/augur/tasks/git/scc_value_tasks/core.py
@@ -1,16 +1,6 @@
 from datetime import datetime
-import logging
-import requests
-import json
 import os
-import subprocess
-import re
-import traceback
 from augur.application.db.models import *
-from augur.application.db.session import DatabaseSession
-from augur.application.config import AugurConfig
-from augur.tasks.github.util.github_api_key_handler import GithubApiKeyHandler
-from augur.application.db.util import execute_session_query
 from augur.tasks.util.worker_util import parse_json_from_subprocess_call
 
 def value_model(session,repo_git,repo_id, path):

--- a/augur/tasks/git/scc_value_tasks/tasks.py
+++ b/augur/tasks/git/scc_value_tasks/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import traceback
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.tasks.git.scc_value_tasks.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask, AugurCoreRepoCollectionTask
@@ -12,7 +13,6 @@ from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_
 @celery.task(base=AugurFacadeRepoCollectionTask)
 def process_scc_value_metrics(repo_git):
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(process_scc_value_metrics.__name__)

--- a/augur/tasks/git/scc_value_tasks/tasks.py
+++ b/augur/tasks/git/scc_value_tasks/tasks.py
@@ -12,7 +12,8 @@ from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_
 @celery.task(base=AugurFacadeRepoCollectionTask)
 def process_scc_value_metrics(repo_git):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(process_scc_value_metrics.__name__)
 

--- a/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
@@ -25,20 +25,9 @@
 # and checks for any parents of HEAD that aren't already accounted for in the
 # repos. It also rebuilds analysis data, checks any changed affiliations and
 # aliases, and caches data for display.
-import sys
-import platform
-import imp
-import time
-import datetime
-import html.parser
 import subprocess
 import os
-import getopt
-import xlsxwriter
-import configparser
-import traceback 
 import sqlalchemy as s
-from sqlalchemy.exc import IntegrityError, DataError
 
 def analyze_commit(session, repo_id, repo_loc, commit):
 

--- a/augur/tasks/git/util/facade_worker/facade_worker/config.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/config.py
@@ -112,7 +112,8 @@ class FacadeSession(GithubTaskSession):
     """
     def __init__(self,logger: Logger):
 
-        from augur.tasks.init.celery_app import engine
+        from augur.application.db import get_engine
+        engine = get_engine()
         #self.cfg = FacadeConfig(logger)
         self.repos_processed = 0
         super().__init__(logger=logger, engine=engine)

--- a/augur/tasks/git/util/facade_worker/facade_worker/config.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/config.py
@@ -24,17 +24,8 @@
 # repos. It also rebuilds analysis data, checks any changed affiliations and
 # aliases, and caches data for display.
 import sys
-import platform
-import imp
 import time
-import datetime
-import html.parser
-import subprocess
 import os
-import getopt
-import xlsxwriter
-import configparser
-import psycopg2
 import json
 import logging
 import random
@@ -44,7 +35,6 @@ from sqlalchemy.exc import OperationalError
 from psycopg2.errors import DeadlockDetected
 
 from augur.tasks.github.util.github_task_session import *
-from augur.application.logs import AugurLogger
 from augur.application.config import AugurConfig
 from logging import Logger
 

--- a/augur/tasks/git/util/facade_worker/facade_worker/excel_generators/example.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/excel_generators/example.py
@@ -23,7 +23,6 @@
 # places to be modified when creating a derivative script are marked with #-->
 
 import sys
-import MySQLdb
 import imp
 import time
 import datetime

--- a/augur/tasks/git/util/facade_worker/facade_worker/facade00mainprogram.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/facade00mainprogram.py
@@ -26,24 +26,14 @@
 # repos. It also rebuilds analysis data, checks any changed affiliations and
 # aliases, and caches data for display.
 from __future__ import annotations
-import traceback
-import sys, platform, imp, time, datetime, html.parser, subprocess, os, getopt, xlsxwriter, configparser, logging
-from multiprocessing import Process, Queue
+import html.parser
 from .config import FacadeSession as FacadeSession
-from .utilitymethods import trim_commits, store_working_author, trim_author   
-from .analyzecommit import analyze_commit
-from .postanalysiscleanup import git_repo_cleanup
-from .repofetch import git_repo_initialize, check_for_repo_updates, force_repo_updates, force_repo_analysis, git_repo_updates
 #.facade06analyze analysis moved to facade_tasks.py - IM 10/12/22
-from .rebuildcache import nuke_affiliations, fill_empty_affiliations, invalidate_caches, rebuild_unknown_affiliation_and_web_caches
 
 #from contributor_interfaceable.facade08contributorinterfaceable import ContributorInterfaceable
 
 from augur.tasks.github.facade_github.contributor_interfaceable.contributor_interface import *
 
-from augur.tasks.github.util.github_task_session import GithubTaskSession
-from logging import Logger
-from sqlalchemy.sql.elements import TextClause
 
 
 

--- a/augur/tasks/git/util/facade_worker/facade_worker/postanalysiscleanup.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/postanalysiscleanup.py
@@ -25,17 +25,7 @@
 # and checks for any parents of HEAD that aren't already accounted for in the
 # repos. It also rebuilds analysis data, checks any changed affiliations and
 # aliases, and caches data for display.
-import sys
-import platform
-import imp
-import time
-import datetime
-import html.parser
 import subprocess
-import os
-import getopt
-import xlsxwriter
-import configparser
 import sqlalchemy as s
 from augur.application.db.util import execute_session_query
 from .utilitymethods import get_absolute_repo_path
@@ -60,7 +50,7 @@ def git_repo_cleanup(session,repo_git):
 
 		# Remove the files on disk
 
-		absolute_path = get_absolute_repo_path(session.repo_base_directory, row.repo_id, row.repo_path,repo.repo_name)
+		absolute_path = get_absolute_repo_path(session.repo_base_directory, row.repo_id, row.repo_path,row.repo_name)
 
 		cmd = ("rm -rf %s"
 			% (absolute_path))

--- a/augur/tasks/git/util/facade_worker/facade_worker/rebuildcache.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/rebuildcache.py
@@ -25,19 +25,8 @@
 # and checks for any parents of HEAD that aren't already accounted for in the
 # repos. It also rebuilds analysis data, checks any changed affiliations and
 # aliases, and caches data for display.
-import sys
-import platform
-import imp
-import time
-import datetime
-import html.parser
-import subprocess
-import os
-import getopt
-import xlsxwriter
-import configparser
 import sqlalchemy as s
-from .utilitymethods import update_repo_log, trim_commits, store_working_author, trim_author
+from .utilitymethods import store_working_author, trim_author
 # if platform.python_implementation() == 'PyPy':
 #   import pymysql
 # else:

--- a/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
@@ -25,20 +25,12 @@
 # and checks for any parents of HEAD that aren't already accounted for in the
 # repos. It also rebuilds analysis data, checks any changed affiliations and
 # aliases, and caches data for display.
-import sys
-import platform
-import imp
-import time
-import datetime
 import html.parser
 import subprocess
 import os
-import getopt
-import xlsxwriter
-import configparser
 import pathlib
 import sqlalchemy as s
-from .utilitymethods import update_repo_log, trim_commits, store_working_author, trim_author, get_absolute_repo_path
+from .utilitymethods import update_repo_log, get_absolute_repo_path
 from augur.application.db.models.augur_data import *
 from augur.application.db.models.augur_operations import CollectionStatus
 from augur.application.db.util import execute_session_query, convert_orm_list_to_dict_list

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -25,21 +25,11 @@
 # and checks for any parents of HEAD that aren't already accounted for in the
 # repos. It also rebuilds analysis data, checks any changed affiliations and
 # aliases, and caches data for display.
-import sys
-import platform
-import imp
-import time
-import datetime
-import html.parser
 import subprocess
 from subprocess import check_output
 import os
-import getopt
-import xlsxwriter
-import configparser
 import sqlalchemy as s
-from sqlalchemy.exc import IntegrityError, DataError
-from .config import get_database_args_from_env
+from sqlalchemy.exc import DataError
 from augur.application.db.models import *
 from .config import FacadeSession as FacadeSession
 from augur.tasks.util.worker_util import calculate_date_weight_from_timestamps

--- a/augur/tasks/github/contributors/tasks.py
+++ b/augur/tasks/github/contributors/tasks.py
@@ -108,7 +108,8 @@ def retrieve_dict_data(url: str, key_auth, logger):
 @celery.task(base=AugurCoreRepoCollectionTask)
 def grab_comitters(repo_git,platform="github"):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(grab_comitters.__name__)
     with DatabaseSession(logger,engine) as session:

--- a/augur/tasks/github/contributors/tasks.py
+++ b/augur/tasks/github/contributors/tasks.py
@@ -1,15 +1,13 @@
 import time
 import logging
 
-
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db import get_engine
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
+from augur.tasks.github.util.github_paginator import hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
-from augur.tasks.util.worker_util import wait_child_tasks
 from augur.tasks.github.facade_github.tasks import *
-from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
+from augur.application.db.models import Contributor, Repo
 from augur.application.db.util import execute_session_query
 
 

--- a/augur/tasks/github/contributors/tasks.py
+++ b/augur/tasks/github/contributors/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 
 from augur.tasks.init.celery_app import celery_app as celery
+from augur.application.db import get_engine
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
@@ -108,7 +109,6 @@ def retrieve_dict_data(url: str, key_auth, logger):
 @celery.task(base=AugurCoreRepoCollectionTask)
 def grab_comitters(repo_git,platform="github"):
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(grab_comitters.__name__)

--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -1,10 +1,8 @@
 from augur.tasks.github.util.github_task_session import *
 from augur.application.db.models import *
-from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.tasks.github.util.github_paginator import hit_api
 from augur.tasks.github.util.util import get_owner_repo
 from augur.tasks.github.util.util import parse_json_response
-import logging
 from datetime import datetime
 from augur.tasks.util.collection_state import CollectionState
 from augur.application.db.util import execute_session_query

--- a/augur/tasks/github/detect_move/tasks.py
+++ b/augur/tasks/github/detect_move/tasks.py
@@ -1,9 +1,10 @@
+import logging
+
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.github.detect_move.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask, AugurSecondaryRepoCollectionTask
 from augur.application.db.util import execute_session_query
-import traceback
 
 
 

--- a/augur/tasks/github/events/tasks.py
+++ b/augur/tasks/github/events/tasks.py
@@ -1,4 +1,3 @@
-import time
 import logging
 import traceback
 import sqlalchemy as s
@@ -6,12 +5,11 @@ import sqlalchemy as s
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
+from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
-from augur.application.db.session import DatabaseSession
 from augur.tasks.github.util.util import get_owner_repo
 from augur.tasks.util.worker_util import remove_duplicate_dicts
-from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
+from augur.application.db.models import PullRequest, PullRequestEvent, Issue, IssueEvent, Contributor, Repo
 from augur.application.db.util import execute_session_query
 
 platform_id = 1

--- a/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
+++ b/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
@@ -1,19 +1,9 @@
-from requests.api import head
 from augur.tasks.github.util.github_task_session import *
-import logging
-from logging import FileHandler, Formatter, StreamHandler, log
-from psycopg2.errors import UniqueViolation
-from random import randint
 import json
-import multiprocessing
 import time
-import numpy as np
 import sqlalchemy as s
-import math
-import traceback
 from augur.application.db.models import *
-from augur.tasks.util.AugurUUID import AugurUUID, GithubUUID, UnresolvableUUID
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api, process_dict_response, retrieve_dict_from_endpoint
+from augur.tasks.github.util.github_paginator import hit_api, process_dict_response, retrieve_dict_from_endpoint
 # Debugger
 import traceback
 from augur.tasks.github.util.github_paginator import GithubApiResult

--- a/augur/tasks/github/facade_github/core.py
+++ b/augur/tasks/github/facade_github/core.py
@@ -1,14 +1,9 @@
 from augur.tasks.github.facade_github.contributor_interfaceable.contributor_interface import * 
 from augur.tasks.github.util.util import get_owner_repo
-from numpy.lib.utils import source
 from augur.tasks.github.util.github_task_session import *
 from augur.tasks.github.util.github_paginator import *
 from augur.application.db.models import *
-import sqlalchemy as s
-import time
-import math
-import traceback
-from augur.tasks.util.AugurUUID import AugurUUID, GithubUUID, UnresolvableUUID
+from augur.tasks.util.AugurUUID import GithubUUID
 
 
 

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -1,20 +1,14 @@
-import time
 import logging
 
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api, retrieve_dict_from_endpoint
-from augur.tasks.github.util.github_task_session import GithubTaskSession, GithubTaskManifest
-from augur.tasks.github.util.util import get_owner_repo
-from augur.tasks.util.worker_util import remove_duplicate_dicts
-from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
+from augur.tasks.github.util.github_paginator import retrieve_dict_from_endpoint
+from augur.tasks.github.util.github_task_session import GithubTaskManifest
+from augur.application.db.models import Contributor
 from augur.tasks.github.facade_github.core import *
-from augur.tasks.util.worker_util import create_grouped_task_load
-from celery.result import allow_join_result
 from augur.application.db.util import execute_session_query
 from augur.tasks.git.util.facade_worker.facade_worker.facade00mainprogram import *
-from sqlalchemy.orm.exc import NoResultFound
 
 
 def process_commit_metadata(logger,db,auth,contributorQueue,repo_id,platform_id):

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -202,7 +202,8 @@ def link_commits_to_contributor(session,contributorQueue):
 @celery.task(base=AugurFacadeRepoCollectionTask)
 def insert_facade_contributors(repo_id):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(insert_facade_contributors.__name__)
 

--- a/augur/tasks/github/issues/tasks.py
+++ b/augur/tasks/github/issues/tasks.py
@@ -1,21 +1,17 @@
-import time
 import logging
 import traceback
-import re
 
 from sqlalchemy.exc import IntegrityError
 
-from augur.tasks.github.util.github_api_key_handler import GithubApiKeyHandler
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
+from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
-from augur.application.db.session import DatabaseSession
 from augur.tasks.github.util.util import add_key_value_pair_to_dicts, get_owner_repo
 from augur.tasks.util.worker_util import remove_duplicate_dicts
-from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
+from augur.application.db.models import Issue, IssueLabel, IssueAssignee, Contributor, Repo
 from augur.application.config import get_development_flag
 from augur.application.db.util import execute_session_query
 

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -1,18 +1,14 @@
-import time
 import logging
 
-import traceback
 
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
+from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
-from augur.application.db.session import DatabaseSession
 from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.tasks.github.util.util import get_owner_repo
-from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Issue, IssueEvent, IssueLabel, IssueAssignee, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
-from augur.application.db.util import execute_session_query
+from augur.application.db.models import PullRequest, Message, Issue, PullRequestMessageRef, IssueMessageRef, Contributor, Repo
 
 
 

--- a/augur/tasks/github/pull_requests/commits_model/core.py
+++ b/augur/tasks/github/pull_requests/commits_model/core.py
@@ -1,9 +1,5 @@
-import logging
-from typing import Dict, List, Tuple, Optional
-import traceback
 import sqlalchemy as s
-from augur.application.db.session import DatabaseSession
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
+from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.application.db.models import *
 from augur.tasks.github.util.util import get_owner_repo
 from augur.application.db.util import execute_session_query

--- a/augur/tasks/github/pull_requests/commits_model/tasks.py
+++ b/augur/tasks/github/pull_requests/commits_model/tasks.py
@@ -1,6 +1,4 @@
 import logging 
-import traceback
-from augur.application.db.session import DatabaseSession
 from augur.tasks.github.pull_requests.commits_model.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurSecondaryRepoCollectionTask

--- a/augur/tasks/github/pull_requests/core.py
+++ b/augur/tasks/github/pull_requests/core.py
@@ -1,4 +1,3 @@
-import time
 import logging
 
 from typing import Dict, List, Tuple, Optional
@@ -7,7 +6,7 @@ from augur.application.db.data_parse import *
 from augur.application.db.session import DatabaseSession
 from augur.tasks.github.util.util import add_key_value_pair_to_dicts
 from augur.tasks.util.worker_util import remove_duplicate_dicts
-from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, PullRequestMessageRef, Contributor, Repo
+from augur.application.db.models import PullRequest, PullRequestLabel, PullRequestReviewer, PullRequestMeta, PullRequestAssignee, Contributor
 
 PLATFORM_ID = 1
 

--- a/augur/tasks/github/pull_requests/files_model/core.py
+++ b/augur/tasks/github/pull_requests/files_model/core.py
@@ -1,10 +1,5 @@
-import logging
-from typing import Dict, List, Tuple, Optional
-import traceback
 import sqlalchemy as s
-from augur.application.db.session import DatabaseSession
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
-from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection, hit_api_graphql
+from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection
 from augur.application.db.models import *
 from augur.tasks.github.util.util import get_owner_repo
 from augur.application.db.util import execute_session_query

--- a/augur/tasks/github/pull_requests/files_model/tasks.py
+++ b/augur/tasks/github/pull_requests/files_model/tasks.py
@@ -1,6 +1,4 @@
 import logging
-import traceback
-from augur.application.db.session import DatabaseSession
 from augur.tasks.github.pull_requests.files_model.core import *
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.init.celery_app import celery_app as celery

--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -1,17 +1,14 @@
-import time
 import logging
-import traceback
 
 from augur.tasks.github.pull_requests.core import extract_data_from_pr_list
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask, AugurSecondaryRepoCollectionTask
 from augur.application.db.data_parse import *
-from augur.tasks.github.util.github_paginator import GithubPaginator, hit_api
+from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
-from augur.application.db.session import DatabaseSession
 from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.tasks.github.util.util import add_key_value_pair_to_dicts, get_owner_repo
-from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestEvent, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, PullRequestMessageRef, Contributor, Repo
+from augur.application.db.models import PullRequest, Message, PullRequestReview, PullRequestLabel, PullRequestReviewer, PullRequestMeta, PullRequestAssignee, PullRequestReviewMessageRef, Contributor, Repo
 from augur.application.db.util import execute_session_query
 from ..messages.tasks import process_github_comment_contributors
 

--- a/augur/tasks/github/releases/core.py
+++ b/augur/tasks/github/releases/core.py
@@ -1,16 +1,8 @@
 #SPDX-License-Identifier: MIT
-import logging, os, sys, time, requests, json
-from datetime import datetime
-from multiprocessing import Process, Queue
-from urllib.parse import urlparse
-import pandas as pd
-import sqlalchemy as s
-from sqlalchemy import MetaData
-from sqlalchemy.ext.automap import automap_base
 from augur.tasks.github.util.github_task_session import *
 from augur.application.db.models import *
 from augur.tasks.github.util.util import get_owner_repo
-from augur.tasks.github.util.gh_graphql_entities import hit_api_graphql, request_graphql_dict
+from augur.tasks.github.util.gh_graphql_entities import request_graphql_dict
 from augur.application.db.util import execute_session_query
 
 

--- a/augur/tasks/github/releases/tasks.py
+++ b/augur/tasks/github/releases/tasks.py
@@ -1,9 +1,10 @@
+import logging
+
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.github.releases.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
-import traceback
 
 @celery.task(base=AugurCoreRepoCollectionTask)
 def collect_releases(repo_git):

--- a/augur/tasks/github/repo_info/core.py
+++ b/augur/tasks/github/repo_info/core.py
@@ -1,15 +1,10 @@
 #SPDX-License-Identifier: MIT
-import logging, os, sys, time, requests, json
-from datetime import datetime
-from multiprocessing import Process, Queue
-import pandas as pd
+import json
 import sqlalchemy as s
-import httpx
-import logging
 from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.tasks.github.util.github_paginator import hit_api
 from augur.tasks.github.util.util import get_owner_repo
-from augur.tasks.github.util.gh_graphql_entities import hit_api_graphql, request_graphql_dict
+from augur.tasks.github.util.gh_graphql_entities import request_graphql_dict
 from augur.application.db.models import *
 from augur.tasks.github.util.github_task_session import *
 from augur.application.db.models.augur_data import RepoBadging

--- a/augur/tasks/github/repo_info/tasks.py
+++ b/augur/tasks/github/repo_info/tasks.py
@@ -1,10 +1,10 @@
+import logging
+
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
-from augur.application.db.session import DatabaseSession
 from augur.tasks.github.repo_info.core import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.util import execute_session_query
-import traceback
 
 
 #Task to get regular misc github info

--- a/augur/tasks/github/traffic/tasks.py
+++ b/augur/tasks/github/traffic/tasks.py
@@ -1,7 +1,7 @@
 import time
 import logging
 
-from augur.tasks.init.celery_app import celery_app as celery, engine
+from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.data_parse import extract_needed_clone_history_data
 from augur.tasks.github.util.github_paginator import GithubPaginator
 from augur.tasks.github.util.github_task_session import GithubTaskManifest

--- a/augur/tasks/github/traffic/tasks.py
+++ b/augur/tasks/github/traffic/tasks.py
@@ -1,4 +1,3 @@
-import time
 import logging
 
 from augur.tasks.init.celery_app import celery_app as celery

--- a/augur/tasks/github/util/gh_graphql_entities.py
+++ b/augur/tasks/github/util/gh_graphql_entities.py
@@ -1,10 +1,8 @@
 from augur.tasks.github.util.github_task_session import *
-from typing import List, Optional, Union, Generator, Tuple
 #from gql import gql, Client
 #from gql.transport.aiohttp import AIOHTTPTransport
 import httpx
 import json
-from random import choice
 import collections
 import time
 import traceback

--- a/augur/tasks/github/util/github_api_key_handler.py
+++ b/augur/tasks/github/util/github_api_key_handler.py
@@ -2,7 +2,7 @@ import httpx
 import time
 import random
 
-from typing import Optional, List
+from typing import List
 
 from augur.tasks.util.redis_list import RedisList
 from augur.application.db.session import DatabaseSession

--- a/augur/tasks/github/util/github_paginator.py
+++ b/augur/tasks/github/util/github_paginator.py
@@ -4,8 +4,6 @@ import collections
 import httpx
 import time
 import json
-import asyncio
-import datetime
 import logging
 
 
@@ -587,6 +585,7 @@ def retrieve_dict_from_endpoint(logger, key_auth, url, timeout_wait=10) -> Tuple
         page_data = parse_json_response(logger, response)
 
         if isinstance(page_data, str):
+            # TODO: Define process_str_response as outside the class and fix this reference
             str_processing_result: Union[str, List[dict]] = process_str_response(logger,page_data)
 
             if isinstance(str_processing_result, dict):

--- a/augur/tasks/github/util/github_random_key_auth.py
+++ b/augur/tasks/github/util/github_random_key_auth.py
@@ -3,7 +3,6 @@
 from augur.tasks.util.random_key_auth import RandomKeyAuth
 from augur.tasks.github.util.github_api_key_handler import GithubApiKeyHandler
 from augur.application.db.session import DatabaseSession
-import random 
 
 
 class GithubRandomKeyAuth(RandomKeyAuth):

--- a/augur/tasks/github/util/github_task_session.py
+++ b/augur/tasks/github/util/github_task_session.py
@@ -8,8 +8,10 @@ class GithubTaskManifest:
 
     def __init__(self, logger):
 
-        from augur.tasks.init.celery_app import engine
+        from augur.application.db import get_engine
         from augur.application.db.session import DatabaseSession
+
+        engine = get_engine()
 
         self.augur_db = DatabaseSession(logger, engine)
         self.key_auth = GithubRandomKeyAuth(self.augur_db.session, logger)

--- a/augur/tasks/github/util/github_task_session.py
+++ b/augur/tasks/github/util/github_task_session.py
@@ -2,13 +2,12 @@ from logging import Logger
 
 from augur.tasks.github.util.github_random_key_auth import GithubRandomKeyAuth
 from augur.application.db.session import DatabaseSession
-
+from augur.application.db import get_engine
 
 class GithubTaskManifest:
 
     def __init__(self, logger):
 
-        from augur.application.db import get_engine
         from augur.application.db.session import DatabaseSession
 
         engine = get_engine()

--- a/augur/tasks/github/util/github_task_session.py
+++ b/augur/tasks/github/util/github_task_session.py
@@ -8,8 +8,6 @@ class GithubTaskManifest:
 
     def __init__(self, logger):
 
-        from augur.application.db.session import DatabaseSession
-
         engine = get_engine()
 
         self.augur_db = DatabaseSession(logger, engine)

--- a/augur/tasks/github/util/util.py
+++ b/augur/tasks/github/util/util.py
@@ -81,7 +81,9 @@ def get_repo_weight_by_issue(logger,repo_git):
 
 #Get the weight for each repo for the core collection hook
 def get_repo_weight_core(logger,repo_git):
-    from augur.tasks.init.celery_app import engine
+    
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     with DatabaseSession(logger,engine) as session:
         repo = Repo.get_by_repo_git(session, repo_git)

--- a/augur/tasks/github/util/util.py
+++ b/augur/tasks/github/util/util.py
@@ -1,6 +1,5 @@
 """Utility functions that are useful for several Github tasks"""
 from typing import Any, List, Tuple
-from httpx import Response
 import logging
 import json
 import httpx

--- a/augur/tasks/gitlab/events_task.py
+++ b/augur/tasks/gitlab/events_task.py
@@ -8,7 +8,7 @@ from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.tasks.gitlab.gitlab_api_handler import GitlabApiHandler
 from augur.tasks.gitlab.gitlab_task_session import GitlabTaskManifest
 from augur.application.db.data_parse import extract_gitlab_mr_event_data, extract_gitlab_issue_event_data
-from augur.tasks.github.util.util import get_owner_repo, add_key_value_pair_to_dicts
+from augur.tasks.github.util.util import get_owner_repo
 from augur.application.db.models import Repo, Issue, IssueEvent, PullRequest, PullRequestEvent
 from augur.application.db.util import execute_session_query
 

--- a/augur/tasks/gitlab/gitlab_api_handler.py
+++ b/augur/tasks/gitlab/gitlab_api_handler.py
@@ -6,7 +6,7 @@ import httpx
 import time
 import logging
 
-from typing import List, Optional, Union, Generator, Tuple
+from typing import List, Optional, Generator, Tuple
 from urllib.parse import urlencode, urlparse, parse_qs, urlunparse
 from enum import Enum
 

--- a/augur/tasks/gitlab/gitlab_api_key_handler.py
+++ b/augur/tasks/gitlab/gitlab_api_key_handler.py
@@ -7,7 +7,7 @@ import httpx
 import time
 import random
 
-from typing import Optional, List
+from typing import List
 
 from augur.tasks.util.redis_list import RedisList
 from augur.application.db.session import DatabaseSession

--- a/augur/tasks/gitlab/gitlab_task_session.py
+++ b/augur/tasks/gitlab/gitlab_task_session.py
@@ -20,7 +20,8 @@ class GitlabTaskManifest:
 
     def __init__(self, logger):
 
-        from augur.tasks.init.celery_app import engine
+        from augur.application.db import get_engine
+        engine = get_engine()
 
         self.augur_db = DatabaseSession(logger, engine)
         self.key_auth = GitlabRandomKeyAuth(self.augur_db.session, logger)

--- a/augur/tasks/gitlab/gitlab_task_session.py
+++ b/augur/tasks/gitlab/gitlab_task_session.py
@@ -5,6 +5,7 @@ from logging import Logger
 
 from augur.tasks.gitlab.gitlab_random_key_auth import GitlabRandomKeyAuth
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 
 class GitlabTaskManifest:
     """
@@ -20,7 +21,6 @@ class GitlabTaskManifest:
 
     def __init__(self, logger):
 
-        from augur.application.db import get_engine
         engine = get_engine()
 
         self.augur_db = DatabaseSession(logger, engine)

--- a/augur/tasks/gitlab/issues_task.py
+++ b/augur/tasks/gitlab/issues_task.py
@@ -10,7 +10,7 @@ from augur.tasks.gitlab.gitlab_api_handler import GitlabApiHandler
 from augur.tasks.gitlab.gitlab_task_session import GitlabTaskManifest
 from augur.application.db.data_parse import extract_needed_issue_data_from_gitlab_issue, extract_needed_gitlab_issue_label_data, extract_needed_gitlab_issue_assignee_data, extract_needed_gitlab_issue_message_ref_data, extract_needed_gitlab_message_data
 from augur.tasks.github.util.util import get_owner_repo, add_key_value_pair_to_dicts
-from augur.application.db.models import Issue, IssueLabel, IssueAssignee, IssueMessageRef, Message, Repo
+from augur.application.db.models import Issue, IssueLabel, IssueMessageRef, Message, Repo
 from augur.application.db.util import execute_session_query
 
 platform_id = 2

--- a/augur/tasks/gitlab/merge_request_task.py
+++ b/augur/tasks/gitlab/merge_request_task.py
@@ -6,7 +6,7 @@ from augur.tasks.gitlab.gitlab_api_handler import GitlabApiHandler
 from augur.tasks.gitlab.gitlab_task_session import GitlabTaskManifest
 from augur.application.db.data_parse import extract_needed_pr_data_from_gitlab_merge_request, extract_needed_merge_request_assignee_data, extract_needed_mr_label_data, extract_needed_mr_reviewer_data, extract_needed_mr_commit_data, extract_needed_mr_file_data, extract_needed_mr_metadata, extract_needed_gitlab_mr_message_ref_data, extract_needed_gitlab_message_data
 from augur.tasks.github.util.util import get_owner_repo, add_key_value_pair_to_dicts
-from augur.application.db.models import PullRequest, PullRequestAssignee, PullRequestLabel, PullRequestReviewer, PullRequestMeta, PullRequestCommit, PullRequestFile, PullRequestMessageRef, Repo, Message
+from augur.application.db.models import PullRequest, PullRequestLabel, PullRequestMeta, PullRequestCommit, PullRequestFile, PullRequestMessageRef, Repo, Message
 from augur.application.db.util import execute_session_query
 
 platform_id = 2

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -1,16 +1,14 @@
 """Defines the Celery app."""
-from celery.signals import worker_process_init, worker_process_shutdown, eventlet_pool_started, eventlet_pool_preshutdown, eventlet_pool_postshutdown
+from celery.signals import worker_process_init, worker_process_shutdown
 import logging
 from typing import List, Dict
 import os
 import datetime
-from enum import Enum
 import traceback
 import celery
 from celery import Celery
 from celery import current_app 
 from celery.signals import after_setup_logger
-from sqlalchemy import create_engine, event, or_, and_
 
 
 from augur.application.logs import TaskLogConfig, AugurLogger
@@ -18,9 +16,8 @@ from augur.application.db.session import DatabaseSession
 from augur.application.db.engine import DatabaseEngine
 from augur.application.db import get_engine
 from augur.application.config import AugurConfig
-from augur.application.db.engine import get_database_string
 from augur.tasks.init import get_redis_conn_values, get_rabbitmq_conn_string
-from augur.application.db.models import CollectionStatus, Repo
+from augur.application.db.models import Repo
 from augur.tasks.util.collection_state import CollectionState
 
 logger = logging.getLogger(__name__)

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -77,7 +77,9 @@ BACKEND_URL = f'{redis_conn_string}{redis_db_number+1}'
 class AugurCoreRepoCollectionTask(celery.Task):
 
     def augur_handle_task_failure(self,exc,task_id,repo_git,logger_name,collection_hook='core',after_fail=CollectionState.ERROR.value):
-        from augur.tasks.init.celery_app import engine
+            
+        from augur.application.db import get_engine
+        engine = get_engine()
 
         logger = AugurLogger(logger_name).get_logger()
 
@@ -245,23 +247,29 @@ def setup_loggers(*args,**kwargs):
     TaskLogConfig(split_tasks_into_groups(augur_tasks))
 
 
-engine = None
+#engine = None
 @worker_process_init.connect
 def init_worker(**kwargs):
 
-    global engine
+    pass
 
-    from augur.application.db.engine import DatabaseEngine
-    from sqlalchemy.pool import NullPool, StaticPool
+    # global engine
 
-    engine = DatabaseEngine(poolclass=StaticPool).engine
+    # from augur.application.db.engine import DatabaseEngine
+    # from sqlalchemy.pool import NullPool, StaticPool
+
+    # engine = DatabaseEngine(poolclass=StaticPool).engine
 
 
 @worker_process_shutdown.connect
 def shutdown_worker(**kwargs):
-    global engine
-    if engine:
-        logger.info('Closing database connectionn for worker')
-        engine.dispose()
+
+    from augur.application.db import dispose_database_engine
+    dispose_database_engine()
+
+    # global engine
+    # if engine:
+    #     logger.info('Closing database connectionn for worker')
+    #     engine.dispose()
 
 

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -16,6 +16,7 @@ from sqlalchemy import create_engine, event, or_, and_
 from augur.application.logs import TaskLogConfig, AugurLogger
 from augur.application.db.session import DatabaseSession
 from augur.application.db.engine import DatabaseEngine
+from augur.application.db import get_engine
 from augur.application.config import AugurConfig
 from augur.application.db.engine import get_database_string
 from augur.tasks.init import get_redis_conn_values, get_rabbitmq_conn_string
@@ -78,7 +79,6 @@ class AugurCoreRepoCollectionTask(celery.Task):
 
     def augur_handle_task_failure(self,exc,task_id,repo_git,logger_name,collection_hook='core',after_fail=CollectionState.ERROR.value):
             
-        from augur.application.db import get_engine
         engine = get_engine()
 
         logger = AugurLogger(logger_name).get_logger()

--- a/augur/tasks/init/celery_worker.py
+++ b/augur/tasks/init/celery_worker.py
@@ -1,4 +1,0 @@
-from celery.signals import worker_process_init, worker_process_shutdown
-
-print("Celery worker")
-

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
-from typing import List
-import time
 import logging
 import os
-from enum import Enum
-import math
-import numpy as np
-import datetime
-import random
 #from celery.result import AsyncResult
-from celery import signature
-from celery import group, chain, chord, signature
-from sqlalchemy import or_, and_,tuple_, update
+from celery import group, chain
+from sqlalchemy import and_,update
 
 
 from augur.tasks.github import *
@@ -24,8 +16,8 @@ from augur.tasks.github.pull_requests.files_model.tasks import process_pull_requ
 from augur.tasks.github.pull_requests.commits_model.tasks import process_pull_request_commits
 from augur.tasks.git.dependency_tasks.tasks import process_ossf_dependency_metrics
 from augur.tasks.github.traffic.tasks import collect_github_repo_clones_data
-from augur.tasks.gitlab.merge_request_task import collect_gitlab_merge_requests, collect_merge_request_comments, collect_merge_request_metadata, collect_merge_request_reviewers, collect_merge_request_commits, collect_merge_request_files
-from augur.tasks.gitlab.issues_task import collect_gitlab_issues, collect_gitlab_issue_comments
+from augur.tasks.gitlab.merge_request_task import collect_gitlab_merge_requests, collect_merge_request_metadata, collect_merge_request_commits, collect_merge_request_files
+from augur.tasks.gitlab.issues_task import collect_gitlab_issues
 from augur.tasks.gitlab.events_task import collect_gitlab_issue_events, collect_gitlab_merge_request_events
 from augur.tasks.git.facade_tasks import *
 from augur.tasks.db.refresh_materialized_views import *
@@ -33,8 +25,6 @@ from augur.tasks.db.refresh_materialized_views import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
 from augur.application.db import get_engine
-from logging import Logger
-from augur.tasks.util.redis_list import RedisList
 from augur.application.db.models import CollectionStatus, Repo
 from augur.tasks.util.collection_state import CollectionState
 from augur.tasks.util.collection_util import *

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -32,6 +32,7 @@ from augur.tasks.db.refresh_materialized_views import *
 # from augur.tasks.data_analysis import *
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from logging import Logger
 from augur.tasks.util.redis_list import RedisList
 from augur.application.db.models import CollectionStatus, Repo
@@ -140,11 +141,7 @@ def secondary_repo_collect_phase(repo_git):
 @celery.task
 def non_repo_domain_tasks():
 
-    from augur.application.db import get_engine
     engine = get_engine()
-
-    
-
 
     logger = logging.getLogger(non_repo_domain_tasks.__name__)
 
@@ -252,7 +249,6 @@ def build_ml_repo_collect_request(session,enabled_phase_names, days_until_collec
 @celery.task
 def augur_collection_monitor():     
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(augur_collection_monitor.__name__)
@@ -291,7 +287,6 @@ def augur_collection_monitor():
 @celery.task
 def augur_collection_update_weights():
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(augur_collection_update_weights.__name__)
@@ -339,7 +334,6 @@ def retry_errored_repos():
     """
         Periodic task to reset repositories that have errored and try again.
     """
-    from augur.application.db import get_engine
     engine = get_engine()
     logger = logging.getLogger(create_collection_status_records.__name__)
 
@@ -370,7 +364,6 @@ def create_collection_status_records():
     A special celery task that automatically retries itself and has no max retries.
     """
 
-    from augur.application.db import get_engine
     engine = get_engine()
     logger = logging.getLogger(create_collection_status_records.__name__)
 

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -140,7 +140,11 @@ def secondary_repo_collect_phase(repo_git):
 @celery.task
 def non_repo_domain_tasks():
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
+
+    
+
 
     logger = logging.getLogger(non_repo_domain_tasks.__name__)
 
@@ -248,7 +252,8 @@ def build_ml_repo_collect_request(session,enabled_phase_names, days_until_collec
 @celery.task
 def augur_collection_monitor():     
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(augur_collection_monitor.__name__)
 
@@ -286,7 +291,8 @@ def augur_collection_monitor():
 @celery.task
 def augur_collection_update_weights():
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(augur_collection_update_weights.__name__)
 
@@ -333,7 +339,8 @@ def retry_errored_repos():
     """
         Periodic task to reset repositories that have errored and try again.
     """
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
     logger = logging.getLogger(create_collection_status_records.__name__)
 
     #TODO: Isaac needs to normalize the status's to be abstract in the 
@@ -363,7 +370,8 @@ def create_collection_status_records():
     A special celery task that automatically retries itself and has no max retries.
     """
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
     logger = logging.getLogger(create_collection_status_records.__name__)
 
     with DatabaseSession(logger,engine) as session:

--- a/augur/tasks/test.py
+++ b/augur/tasks/test.py
@@ -1,9 +1,4 @@
-from celery import signature
-from celery import group, chain, chord, signature
-
-
 from augur.tasks.init.celery_app import celery_app as celery
-
 
 @celery.task()
 def successful_task():

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -23,6 +23,7 @@ from augur.tasks.github.util.gh_graphql_entities import GitHubRepo as GitHubRepo
 from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.application.db.session import DatabaseSession
+from augur.application.db import get_engine
 from augur.tasks.util.worker_util import calculate_date_weight_from_timestamps
 from augur.tasks.util.collection_state import CollectionState
 
@@ -227,7 +228,6 @@ def split_list_into_chunks(given_list, num_chunks):
 @celery.task
 def task_failed_util(request,exc,traceback):
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(task_failed_util.__name__)
@@ -284,7 +284,7 @@ def task_failed_util(request,exc,traceback):
 #This task updates the core and secondary weight with the issues and prs already passed in
 @celery.task
 def issue_pr_task_update_weight_util(issue_and_pr_nums,repo_git=None,session=None):
-    from augur.application.db import get_engine
+
     engine = get_engine()
     logger = logging.getLogger(issue_pr_task_update_weight_util.__name__)
 
@@ -301,7 +301,6 @@ def issue_pr_task_update_weight_util(issue_and_pr_nums,repo_git=None,session=Non
 @celery.task
 def core_task_success_util(repo_git):
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(core_task_success_util.__name__)
@@ -369,7 +368,6 @@ def update_issue_pr_weights(logger,session,repo_git,raw_sum):
 @celery.task
 def secondary_task_success_util(repo_git):
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(secondary_task_success_util.__name__)
@@ -399,7 +397,7 @@ def secondary_task_success_util(repo_git):
 
 #Get the weight for each repo for the secondary collection hook.
 def get_repo_weight_secondary(logger,repo_git):
-    from augur.application.db import get_engine
+
     engine = get_engine()
 
     with DatabaseSession(logger,engine) as session:
@@ -423,7 +421,6 @@ def get_repo_weight_secondary(logger,repo_git):
 @celery.task
 def facade_task_success_util(repo_git):
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(facade_task_success_util.__name__)
@@ -446,7 +443,7 @@ def facade_task_success_util(repo_git):
 
 @celery.task
 def ml_task_success_util(repo_git):
-    from augur.application.db import get_engine
+
     engine = get_engine()
 
     logger = logging.getLogger(facade_task_success_util.__name__)
@@ -472,7 +469,6 @@ def ml_task_success_util(repo_git):
 @celery.task
 def facade_clone_success_util(repo_git):
 
-    from augur.application.db import get_engine
     engine = get_engine()
 
     logger = logging.getLogger(facade_clone_success_util.__name__)

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -227,7 +227,8 @@ def split_list_into_chunks(given_list, num_chunks):
 @celery.task
 def task_failed_util(request,exc,traceback):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(task_failed_util.__name__)
 
@@ -283,7 +284,8 @@ def task_failed_util(request,exc,traceback):
 #This task updates the core and secondary weight with the issues and prs already passed in
 @celery.task
 def issue_pr_task_update_weight_util(issue_and_pr_nums,repo_git=None,session=None):
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
     logger = logging.getLogger(issue_pr_task_update_weight_util.__name__)
 
     if repo_git is None:
@@ -299,7 +301,8 @@ def issue_pr_task_update_weight_util(issue_and_pr_nums,repo_git=None,session=Non
 @celery.task
 def core_task_success_util(repo_git):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(core_task_success_util.__name__)
 
@@ -366,7 +369,8 @@ def update_issue_pr_weights(logger,session,repo_git,raw_sum):
 @celery.task
 def secondary_task_success_util(repo_git):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(secondary_task_success_util.__name__)
 
@@ -395,7 +399,8 @@ def secondary_task_success_util(repo_git):
 
 #Get the weight for each repo for the secondary collection hook.
 def get_repo_weight_secondary(logger,repo_git):
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     with DatabaseSession(logger,engine) as session:
         repo = Repo.get_by_repo_git(session, repo_git)
@@ -418,7 +423,8 @@ def get_repo_weight_secondary(logger,repo_git):
 @celery.task
 def facade_task_success_util(repo_git):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(facade_task_success_util.__name__)
 
@@ -440,7 +446,8 @@ def facade_task_success_util(repo_git):
 
 @celery.task
 def ml_task_success_util(repo_git):
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(facade_task_success_util.__name__)
 
@@ -465,7 +472,8 @@ def ml_task_success_util(repo_git):
 @celery.task
 def facade_clone_success_util(repo_git):
 
-    from augur.tasks.init.celery_app import engine
+    from augur.application.db import get_engine
+    engine = get_engine()
 
     logger = logging.getLogger(facade_clone_success_util.__name__)
 

--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -1,27 +1,17 @@
 from __future__ import annotations
-from typing import List
-import time
 import logging
 import random
-import os
-from enum import Enum
-import math
-import numpy as np
 import datetime
 #from celery.result import AsyncResult
-from celery import signature
-from celery import group, chain, chord, signature
+from celery import chain
 import sqlalchemy as s
-from sqlalchemy import or_, and_, update
+from sqlalchemy import or_, update
 from augur.application.logs import AugurLogger
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.application.db.models import CollectionStatus, Repo
 from augur.application.db.util import execute_session_query
 from augur.application.config import AugurConfig
-from augur.tasks.github.util.util import get_owner_repo, get_repo_weight_core, get_repo_weight_by_issue
-from augur.tasks.github.util.gh_graphql_entities import GitHubRepo as GitHubRepoGraphql
-from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection
-from augur.tasks.github.util.github_task_session import GithubTaskManifest
+from augur.tasks.github.util.util import get_repo_weight_core, get_repo_weight_by_issue
 from augur.application.db.session import DatabaseSession
 from augur.application.db import get_engine
 from augur.tasks.util.worker_util import calculate_date_weight_from_timestamps

--- a/augur/tasks/util/redis_list.py
+++ b/augur/tasks/util/redis_list.py
@@ -6,7 +6,6 @@ from typing import Iterable, Any, Union
 from collections.abc import MutableSequence
 from augur.tasks.init.redis_connection import redis_connection as redis
 from augur import instance_id
-from redis import exceptions
 
 
 class RedisList(MutableSequence):

--- a/augur/tasks/util/worker_util.py
+++ b/augur/tasks/util/worker_util.py
@@ -1,14 +1,13 @@
 #SPDX-License-Identifier: MIT
-import os, json, requests, logging
-from flask import Flask, Response, jsonify, request
+import json
 #import gunicorn.app.base
 import numpy as np
 from celery import group
 from celery.result import AsyncResult
 from celery.result import allow_join_result
 
-from typing import Optional, List, Any, Tuple
-from datetime import datetime, timedelta
+from typing import List
+from datetime import datetime
 import json
 import subprocess
 

--- a/augur/util/inspect_without_import.py
+++ b/augur/util/inspect_without_import.py
@@ -1,7 +1,3 @@
-import os
-import os.path as path
-
-
 #needed as a workaround since python executes imported files
 #This presents a problem since importing the phase functions themselves needs information from the config
 #while the config needs the phase names before population

--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -1,14 +1,11 @@
-import re
 import logging
 
-import sqlalchemy as s
-import pandas as pd
 import base64
 
-from typing import List, Any, Dict
+from typing import Any, Dict
 
 from augur.application.db.engine import DatabaseEngine
-from augur.application.db.models import Repo, UserRepo, RepoGroup, UserGroup, User, CollectionStatus
+from augur.application.db.models import Repo, UserRepo, RepoGroup, UserGroup, User
 from augur.application.db.models.augur_operations import retrieve_owner_repos
 from augur.application.db.util import execute_session_query
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,6 @@
 import pytest
-import os
-import json
 import sqlalchemy as s
+import logging
 from augur.application.db.session import DatabaseSession
 
 TEST_DB_STRING = "postgresql+psycopg2://augur:mcguire18@chaoss.tv:5432/augur-test"


### PR DESCRIPTION
**Description**
- Removes unused imports to clean up the code and give us lower chances for things like circular imports
- Implemented a get_engine method in the db/__init.py that the collection tasks now use to get an engine rather than importing it from the celery_app.py.
- Implemented a dispose_database_engine method so the celery_worker can dispose of the engine when is it stopping