### PR TITLE
Patch DB CLI to Include GitLab Logic

### DIFF
--- a/augur/application/cli/db.py
+++ b/augur/application/cli/db.py
@@ -126,9 +126,10 @@ def add_repo_groups(filename):
                 if int(row[0]) not in repo_group_IDs:
                     repo_group_IDs.append(int(row[0]))
                     connection.execute(
-                        insert_repo_group_sql,
-                        repo_group_id=int(row[0]),
-                        repo_group_name=row[1],
+                        insert_repo_group_sql.bindparams(
+                            repo_group_id=int(row[0]),
+                            repo_group_name=row[1],
+                        )
                     )
                 else:
                     logger.info(

--- a/augur/application/cli/db.py
+++ b/augur/application/cli/db.py
@@ -66,7 +66,6 @@ def add_repos(filename):
                 
                 print(
                     f"Inserting repo with Git URL `{repo_data['url']}` into repo group {repo_data['repo_group_id']}")
-                controller.add_cli_repo(repo_data)
 
 
 

--- a/augur/application/cli/db.py
+++ b/augur/application/cli/db.py
@@ -66,6 +66,7 @@ def add_repos(filename):
                 
                 print(
                     f"Inserting repo with Git URL `{repo_data['url']}` into repo group {repo_data['repo_group_id']}")
+                controller.add_cli_repo(repo_data)
 
 
 

--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -54,15 +54,24 @@ class RepoLoadController:
 
         # if it is from not from an org list then we need to check its validity, and get the repo type
         if not from_org_list:
-            result = Repo.is_valid_github_repo(self.session, url)
+            if "gitlab" in url:
+                result = Repo.is_valid_gitlab_repo(self.session, url)
+            else:
+                result = Repo.is_valid_github_repo(self.session, url)
             if not result[0]:
                 return False, {"status": result[1]["status"], "repo_url": url}
             
-            repo_type = result[1]["repo_type"]
+            try:
+                repo_type = result[1]["repo_type"]
+            except KeyError:
+                print("Skipping repo type...")
 
 
         # if the repo doesn't exist it adds it
-        repo_id = Repo.insert_github_repo(self.session, url, repo_group_id, "CLI", repo_type)
+        if "gitlab" in url:
+            repo_id = Repo.insert_gitlab_repo(self.session, url, repo_group_id, "CLI")
+        else:
+            repo_id = Repo.insert_github_repo(self.session, url, repo_group_id, "CLI", repo_type)
 
         if not repo_id:
             logger.warning(f"Invalid repo group id specified for {url}, skipping.")


### PR DESCRIPTION
**Description**
Allow GitLab repositories to be added to augur via the old cli interface that uses csv files.  Also patches a bug in the CLI that used deprecated syntax to add a repo group. 

**Signed commits**
- [x] Yes, I signed my commits.
