### PR TITLE
Disable Method Docstring Requirement for Pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -12,7 +12,7 @@
 #refactoring checker
 #enable=R
 
-disable=E0611,E1101,W1203,R0801,W0614,W0611,C0411,C0103,C0301,C0303,C0304,C0305,W0311,E0401
+disable=E0611,E1101,W1203,R0801,W0614,W0611,C0411,C0103,C0301,C0303,C0304,C0305,W0311,E0401,C0116
 
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and


### PR DESCRIPTION
**Description**
Add rule in `.pylintrc` to ignore method docstring warnings. 

**Signed commits**
- [x] Yes, I signed my commits.
