### PR TITLE
Allow exception visibility in CLI

### DIFF
--- a/augur/application/cli/_multicommand.py
+++ b/augur/application/cli/_multicommand.py
@@ -7,6 +7,8 @@ import os
 import click
 import importlib
 import traceback
+
+from pathlib import Path
 # import augur.application
 
 CONTEXT_SETTINGS = dict(auto_envvar_prefix='AUGUR')
@@ -24,11 +26,16 @@ class AugurMultiCommand(click.MultiCommand):
         return rv
 
     def get_command(self, ctx, name):
-        try:
-            module = importlib.import_module('.' + name, 'augur.application.cli')
-            return module.cli
-        except ModuleNotFoundError as e:
-            pass
+        cmdfile = "augur/application/cli" / Path(name + ".py")
+
+        # Check that the command exists before importing
+        if not cmdfile.is_file():
+
+            return
+
+        # Prefer to raise exception instead of silcencing it
+        module = importlib.import_module('.' + name, 'augur.application.cli')
+        return module.cli
 
 @click.command(cls=AugurMultiCommand, context_settings=CONTEXT_SETTINGS)
 @click.pass_context


### PR DESCRIPTION
**Description**
This change makes the CLI pass-through *all* exceptions when they occur while loading a module.

Previously, import exceptions were silenced during import of a CLI command module. Although most exceptions would have been displayed, by catching `ModuleNotFoundError`, any import errors in sub-modules would be silenced during Click imports.

The fix is to check first if the module exists using a file check, and if it does not, return None to indicate as such.

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->