### PR TITLE
Fix RabbitMQ config issue in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,15 +24,16 @@ services:
     build:
       context: .
       dockerfile: ./docker/rabbitmq/Dockerfile
+      args:
+      - RABBIT_MQ_DEFAULT_USER=${AUGUR_RABBITMQ_USERNAME:-augur}
+      - RABBIT_MQ_DEFAULT_PASSWORD=${AUGUR_RABBITMQ_PASSWORD:-password123}
+      - RABBIT_MQ_DEFAULT_VHOST=${AUGUR_RABBITMQ_VHOST:-augur_vhost}
     # ports for amqp connections / management api
     ports:
       - 5671:5671
       - 5672:5672
       - 15671:15671
       - 15672:15672
-    environment:
-      - "RABBIT_MQ_DEFAULT_USER=${AUGUR_RABBITMQ_USERNAME:-augur}"
-      - "RABBIT_MQ_DEFAULT_PASSWORD=${AUGUR_RABBITMQ_PASSWORD:-password123}"
 
   augur:
     image: augur-new:latest
@@ -54,7 +55,7 @@ services:
       - "AUGUR_GITHUB_USERNAME=${AUGUR_GITHUB_USERNAME}"
       - "AUGUR_GITLAB_USERNAME=${AUGUR_GITLAB_USERNAME}"
       - REDIS_CONN_STRING=redis://redis:6379
-      - RABBITMQ_CONN_STRING=amqp://${AUGUR_RABBITMQ_USERNAME:-augur}:${AUGUR_RABBITMQ_PASSWORD:-password123}@rabbitmq:5672/augur_vhost
+      - RABBITMQ_CONN_STRING=amqp://${AUGUR_RABBITMQ_USERNAME:-augur}:${AUGUR_RABBITMQ_PASSWORD:-password123}@rabbitmq:5672/${AUGUR_RABBITMQ_VHOST:-augur_vhost}
     depends_on:
       - augur-db
       - redis

--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -3,10 +3,21 @@ FROM rabbitmq:3.12-management-alpine
 LABEL maintainer="574/augur@simplelogin.com"
 LABEL version="0.62.6"
 
+ARG RABBIT_MQ_DEFAULT_USER
+ARG RABBIT_MQ_DEFAULT_PASSWORD
+ARG RABBIT_MQ_DEFAULT_VHOST
+
 COPY --chown=rabbitmq:rabbitmq ./docker/rabbitmq/augur.conf /etc/rabbitmq/conf.d/
+
+ADD docker/rabbitmq/definitions.json /etc/rabbitmq/
+RUN chown rabbitmq:rabbitmq /etc/rabbitmq/definitions.json
+
+ADD docker/rabbitmq/advanced.config /etc/rabbitmq/
+RUN chown rabbitmq:rabbitmq /etc/rabbitmq/advanced.config
 
 RUN chmod 777 /etc/rabbitmq/conf.d/augur.conf
 
-RUN touch /etc/rabbitmq/advanced.config \
-  && chmod 544 /etc/rabbitmq/advanced.config \
-  && echo '[ {rabbit, [ {consumer_timeout, undefined} ]} ].' >> /etc/rabbitmq/advanced.config
+RUN apk add --no-cache python3
+COPY docker/rabbitmq/update_config.py /
+
+RUN exec python3 update_config.py

--- a/docker/rabbitmq/advanced.config
+++ b/docker/rabbitmq/advanced.config
@@ -1,0 +1,9 @@
+[
+  {rabbit, [
+    {loopback_users, []},
+    {consumer_timeout, undefined}
+  ]},
+  {rabbitmq_management, [
+    {load_definitions, "/etc/rabbitmq/definitions.json"}
+  ]}
+].

--- a/docker/rabbitmq/definitions.json
+++ b/docker/rabbitmq/definitions.json
@@ -1,0 +1,30 @@
+{
+    "rabbit_version": "3.12",
+    "users": [
+        {
+            "name": "",
+            "password_hash": "",
+            "hashing_algorithm": "rabbit_password_hashing_sha256",
+            "tags": "administrator"
+        }
+    ],
+    "vhosts": [
+        {
+            "name": ""
+        }
+    ],
+    "permissions": [
+        {
+            "user": "",
+            "vhost": "",
+            "configure": ".*",
+            "write": ".*",
+            "read": ".*"
+        }
+    ],
+    "parameters": [],
+    "policies": [],
+    "queues": [],
+    "exchanges": [],
+    "bindings": []
+}

--- a/docker/rabbitmq/update_config.py
+++ b/docker/rabbitmq/update_config.py
@@ -1,0 +1,41 @@
+from os import environ as env
+import json, subprocess
+from pathlib import Path
+
+rabbit_user = env.get("RABBIT_MQ_DEFAULT_USER")
+rabbit_pass = env.get("RABBIT_MQ_DEFAULT_PASSWORD")
+rabbit_vhost = env.get("RABBIT_MQ_DEFAULT_VHOST")
+
+if not rabbit_user:
+    raise ValueError("No default user set")
+
+if not rabbit_pass:
+    raise ValueError("No default password set")
+    
+if not rabbit_vhost:
+    raise ValueError("No default vhost set")
+
+config_file = Path("/etc/rabbitmq/definitions.json")
+
+with config_file.open() as file:
+    config = json.load(file)
+
+hash_processor = subprocess.run(f"rabbitmqctl hash_password {rabbit_pass}".split(),
+                                text=True,
+                                stdout=subprocess.PIPE)
+
+if hash_processor.returncode != 0:
+    raise Exception("Could not calculate password hash")
+
+pass_hash = hash_processor.stdout.splitlines()[-1]
+
+config["users"][0]["name"] = rabbit_user
+config["users"][0]["password_hash"] = pass_hash
+
+config["vhosts"][0]["name"] = rabbit_vhost
+
+config["permissions"][0]["user"] = rabbit_user
+config["permissions"][0]["vhost"] = rabbit_vhost
+
+with config_file.open("w") as file:
+    json.dump(config, file)


### PR DESCRIPTION
**Description**
- Change RabbitMQ configuration scheme
  - Add `definitions.json` to contain default user, password, and vhost definitions
  - Add `update_config.py` to convert Docker args to RabbitMQ config items
    - NOTE: RabbitMQ ignores *all* envvars if *any* config file is present
  - I'm not sure if the original `augur.conf` is doing anything anymore, but there's no reason to get rid of it as of right now
- Add `update_config.py`
  - Pull Docker args and check that they exist
  - Compute password hash with `rabbitmqctl`
    - AFAICT RabbitMQ does not support plain-text passwords in a config file
  - load default `definitions.json`, update with new values and write changes
- Provide default `advanced.config`
  - Previously we were creating this file with `RUN echo ...`
  - Extra entries are required in this file to enable loading of `definitions.json`
- In `docker-compose.yml`
  - Move `environment` section to `args` section, update formatting
  - Make default vhost configurable (defaults to same, `augur_vhost`)
- In `rabbitmq/Dockerfile`
  - Import default args
  - Import new config files described above
  - Add Python to container, and run the config updater at build time

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->