### PR TITLE
Add Check to SQL Update Statements to Avoid constraints on `date_last_collected`

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -326,13 +326,22 @@ def retry_errored_repos(self):
     #collection_status table once augur dev is less unstable.
     with DatabaseSession(logger,engine) as session:
         query = s.sql.text(f"""UPDATE collection_status SET secondary_status = '{CollectionState.PENDING.value}'"""
-        f""" WHERE secondary_status = '{CollectionState.ERROR.value}' ;"""
+        f""" WHERE secondary_status = '{CollectionState.ERROR.value}' and secondary_data_last_collected is NULL;"""
         f"""UPDATE collection_status SET core_status = '{CollectionState.PENDING.value}'"""
-        f""" WHERE core_status = '{CollectionState.ERROR.value}' ;"""
+        f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is NULL;"""
         f"""UPDATE collection_status SET facade_status = '{CollectionState.PENDING.value}'"""
-        f""" WHERE facade_status = '{CollectionState.ERROR.value}' ;"""
+        f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is NULL;"""
         f"""UPDATE collection_status SET ml_status = '{CollectionState.PENDING.value}'"""
-        f""" WHERE ml_status = '{CollectionState.ERROR.value}' ;"""
+        f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is NULL;"""
+        
+        f"""UPDATE collection_status SET secondary_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE secondary_status = '{CollectionState.ERROR.value}' and secondary_data_last_collected is not NULL;"""
+        f"""UPDATE collection_status SET core_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE core_status = '{CollectionState.ERROR.value}' and core_data_last_collected is not NULL;;"""
+        f"""UPDATE collection_status SET facade_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE facade_status = '{CollectionState.ERROR.value}' and facade_data_last_collected is not NULL;;"""
+        f"""UPDATE collection_status SET ml_status = '{CollectionState.SUCCESS.value}'"""
+        f""" WHERE ml_status = '{CollectionState.ERROR.value}' and ml_data_last_collected is not NULL;;"""
         )
 
         session.execute_sql(query)


### PR DESCRIPTION
**Description**
- There was a bug where tasks that had succeeded in the past but then subsequently fail later would not be reset correctly; running into a constraint on 'date_last_collected'
- In response I have added checks to the `date_last_collected` field in order to prevent this issue
- Specifically we now check for null values in the date field and update to either `SUCCESS` or `PENDING` depending on if the field is null or not. 
- The function now should reset the task to a state where it can be run again. 

**Signed commits**
- [x] Yes, I signed my commits.
