### PR TITLE
Rollback transaction when query throws exception

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -878,7 +878,13 @@ class Repo(Base):
     @staticmethod
     def get_by_id(session, repo_id):
 
-        return session.query(Repo).filter(Repo.repo_id == repo_id).first()
+        try:
+            return session.query(Repo).filter(Repo.repo_id == repo_id).first()
+        except Exception as e:
+            session.rollback()
+            raise e
+
+        
 
     @staticmethod
     def get_by_repo_git(session, repo_git):

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -329,6 +329,9 @@ class User(Base):
             return user
         except NoResultFound:
             return None
+        except Exception as e:
+            session.rollback()
+            raise e
 
     @staticmethod
     def get_by_id(session, user_id: int):
@@ -1073,7 +1076,13 @@ class ClientApplication(Base):
 
     @staticmethod
     def get_by_id(session, client_id):
-        return session.query(ClientApplication).filter(ClientApplication.id == client_id).first()
+
+        try:
+            return session.query(ClientApplication).filter(ClientApplication.id == client_id).first()
+        except Exception as e:
+            session.rollback()
+            raise e
+
 
 class Subscription(Base):
     __tablename__ = "subscriptions"


### PR DESCRIPTION
**Description**
- Rollback changes when a query using the session throws an exception so that the session can still be used

This PR fixes #
- Issue where frontend doesn't work because the session fails on every query

Note: I don't care if this is merged into main or dev, I just noticed that dev is the same as main and this is a small fix so I opened it into main

**Signed commits**
- [X] Yes, I signed my commits.
