### PR TITLE
handle rate limiting and more repo load messages

### DIFF
--- a/augur/application/cli/__init__.py
+++ b/augur/application/cli/__init__.py
@@ -3,9 +3,9 @@ import click
 from functools import update_wrapper
 import os
 import sys
-import socket
 import re
 import json
+import httpx
 
 from augur.application.db.engine import DatabaseEngine
 from augur.application.db import get_engine, dispose_database_engine
@@ -16,13 +16,22 @@ def test_connection(function_internet_connection):
     @click.pass_context
     def new_func(ctx, *args, **kwargs):
         usage = re.search(r"Usage:\s(.*)\s\[OPTIONS\]", str(ctx.get_usage())).groups()[0]
-        try:
-            #try to ping google's dns server
-            socket.create_connection(("8.8.8.8",53))
-            return ctx.invoke(function_internet_connection, *args, **kwargs)
-        except OSError as e:
-            print(e)
-            print(f"\n\n{usage} command setup failed\nYou are not connect to the internet. Please connect to the internet to run Augur\n")
+        with httpx.Client() as client:
+            try:
+                _ = client.request(
+                    method="GET", url="http://chaoss.community", timeout=10, follow_redirects=True)
+
+                return ctx.invoke(function_internet_connection, *args, **kwargs)
+            except (TimeoutError, httpx.TimeoutException):
+                print("Request timed out.")
+            except httpx.NetworkError:
+                print(f"Network Error: {httpx.NetworkError}")
+            except httpx.ProtocolError:
+                print(f"Protocol Error: {httpx.ProtocolError}")
+            print(f"\n\n{usage} command setup failed\n \
+                You are not connected to the internet.\n \
+                Please connect to the internet to run Augur\n \
+                Consider setting http_proxy variables for limited access installations.")
             sys.exit()        
         
     return update_wrapper(new_func, function_internet_connection)


### PR DESCRIPTION
**Description**
- more messages when loading repos
- patched edge cases where sometimes no message would occur
- rate limiting will now wait to continue loading repositories (before it would fail and continue to the next repo, making large load jobs very difficult)
- allowed for [use of a proxy](https://www.python-httpx.org/environment_variables/#http_proxy-https_proxy-all_proxy) when checking internet access (`http_proxy`/`HTTP_PROXY` is standard in many libraries, including the one in use here)

Future enhancements could include skipping validation on github until checking that a given repo is not in the database -- that's a problem for another day.

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->