### PR TITLE
Add default arg values for rabbitmq dockerfile

### DIFF
--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -3,9 +3,9 @@ FROM rabbitmq:3.12-management-alpine
 LABEL maintainer="574/augur@simplelogin.com"
 LABEL version="0.63.0"
 
-ARG RABBIT_MQ_DEFAULT_USER
-ARG RABBIT_MQ_DEFAULT_PASSWORD
-ARG RABBIT_MQ_DEFAULT_VHOST
+ARG RABBIT_MQ_DEFAULT_USER=augur
+ARG RABBIT_MQ_DEFAULT_PASSWORD=password123
+ARG RABBIT_MQ_DEFAULT_VHOST=augur_vhost
 
 COPY --chown=rabbitmq:rabbitmq ./docker/rabbitmq/augur.conf /etc/rabbitmq/conf.d/
 


### PR DESCRIPTION
**Description**
- Provide default values for the RabbitMQ dockerfile args so it will build by default

It is still recommended to pass values for production builds via `--build-arg key=value`

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->