### PR TITLE
Draft of how to check if we already have messages

### DIFF
--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -10,7 +10,6 @@ from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.tasks.github.util.util import get_owner_repo
 from augur.application.db.models import PullRequest, Message, Issue, PullRequestMessageRef, IssueMessageRef, Contributor, Repo, CollectionStatus
 from augur.application.db import get_engine, get_session
-
 from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection
 from augur.application.db.models import *
 from augur.application.db.util import execute_session_query

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -10,11 +10,14 @@ from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.tasks.github.util.util import get_owner_repo
 from augur.application.db.models import PullRequest, Message, Issue, PullRequestMessageRef, IssueMessageRef, Contributor, Repo, CollectionStatus
 from augur.application.db import get_engine, get_session
-from sqlalchemy.sql import text
 
 from augur.tasks.github.util.gh_graphql_entities import GraphQlPageCollection
 from augur.application.db.models import *
 from augur.application.db.util import execute_session_query
+
+from sqlalchemy.sql import text
+
+
 
 platform_id = 1
 

--- a/augur/tasks/github/messages/tasks.py
+++ b/augur/tasks/github/messages/tasks.py
@@ -95,7 +95,9 @@ def fast_retrieve_all_pr_and_issue_messages(repo_git: str, logger, key_auth, tas
 
 
 def process_large_issue_and_pr_message_collection(repo_id, repo_git: str, logger, key_auth, task_name, augur_db) -> None:
-
+    """
+    This only runs if there is a large collection. 
+    """
     owner, repo = get_owner_repo(repo_git)
 
     # define logger for task


### PR DESCRIPTION
This uses the GraphQL API on GitHub to check if we already have messages for a PR or Issue. Using GraphQL to check this before going and getting all the messages if we already have them will avoid unnecessary REST API call, data marshalling, and database hits. 

Notes are below: 

https://stackoverflow.com/questions/58678266/is-there-any-quick-way-t…o-get-comment-count-of-all-open-pull-request

Query explorer:

https://docs.github.com/en/graphql/overview/explorer

GraphQL Query to get total PR Comment Count:

```bash
{
  repository(name: "material-ui", owner: "mui-org") {
    pullRequest(number: 21214) {
      comments(first: 100) {
        totalCount
      }
    }
  }
}
```

Graphql for the Issue Comment Count:

```bash
{
  repository(name: "deepgnn", owner: "microsoft") {
    issue(number: 193) {
      comments(first: 100) {
        totalCount
      }
    }
  }
}
```

Graphql for Issue or PR:

```bash

query {
  repository(owner: "microsoft", name: "deepgnn") {
    issueOrPullRequest(number: 193) {
      ... on PullRequest {
              comments(first: 100) {
                totalCount
              }
            }
      ... on Issue {
              comments(first: 100) {
                totalCount
              }
      }
    }
  }
}

```

And corresponding SQL to get the count of comments we have (Example):
```sql

SELECT
	  x.repo_id,
    comment_url,
    split_part(split_part(comment_url, '/repos/', 2), '/', 1) AS organization,
    split_part(split_part(comment_url, '/repos/', 2), '/', 2) AS repository,
    split_part(split_part(comment_url, '/issues/', 2), '/', 1) AS issue_number,
    theid,
    thenumber,
    COALESCE(COUNT(y.pull_request_id) + COUNT(z.issue_id), 0) AS comments
FROM
(
    SELECT repo_id, pr_comments_url AS comment_url ,pull_request_id AS theid, pr_src_number AS thenumber
    FROM augur_data.pull_requests
    WHERE repo_id=52445 and pr_comments_url = 'https://api.github.com/repos/microsoft/DeepGNN/issues/105/comments'

    UNION

    SELECT repo_id, comments_url as comment_url, issue_id AS theid, gh_issue_number AS thenumber
    FROM augur_data.issues
    WHERE repo_id = 52445 and comments_url = 'https://api.github.com/repos/microsoft/DeepGNN/issues/105/comments'
) x
LEFT JOIN augur_data.pull_request_message_ref y ON x.theid = y.pull_request_id
LEFT JOIN augur_data.issue_message_ref z ON x.theid = z.issue_id
GROUP BY x.repo_id, comment_url, organization, repository, issue_number, theid, thenumber;

```

**Description**
- Please include a summary of the change.

This PR fixes #

**Notes for Reviewers**

**Signed commits**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->