### PR TITLE
Explicitly identify iconized buttons using role attribute

### DIFF
--- a/augur/templates/groups-table.j2
+++ b/augur/templates/groups-table.j2
@@ -55,7 +55,7 @@
                     <th scope="row">{{loop.index}}</th>
                     <td><a href="{{ url_for('user_group_view', group=group.name) }}">{{ group.name }}</a></td>
                     <td>{{ group.count }}</td>
-                    <td><i onclick="toggleFavorite(this, '{{ group.name }}')" class="bi {% if group.favorited %} bi-star-fill {% else %} bi-star {% endif %} cursor-pointer"></i></td>
+                    <td><i role="button" onclick="toggleFavorite(this, '{{ group.name }}')" class="bi {% if group.favorited %} bi-star-fill {% else %} bi-star {% endif %} cursor-pointer"></i></td>
                 </tr>
         {% endfor %}
             </tbody>

--- a/augur/templates/login.j2
+++ b/augur/templates/login.j2
@@ -16,7 +16,7 @@
                     required>
                 <div class="input-group-append">
                     <button class="btn password-toggle" type="button" onclick="togglePass()">
-                        <i class="bi bi-eye-slash" id="togglePassword"></i>
+                        <i role="button" class="bi bi-eye-slash" id="togglePassword"></i>
                     </button>
                 </div>
             </div>
@@ -26,7 +26,7 @@
                         placeholder="Confirm Password">
                     <div class="input-group-append">
                         <button class="btn password-toggle" type="button" onclick="togglePass()">
-                            <i class="bi bi-eye-slash" id="togglePasswordConfirm"></i>
+                            <i role="button" class="bi bi-eye-slash" id="togglePasswordConfirm"></i>
                         </button>
                     </div>
                 </div>

--- a/augur/templates/login.j2
+++ b/augur/templates/login.j2
@@ -16,7 +16,7 @@
                     required>
                 <div class="input-group-append">
                     <button class="btn password-toggle" type="button" onclick="togglePass()">
-                        <i role="button" class="bi bi-eye-slash" id="togglePassword"></i>
+                        <i class="bi bi-eye-slash" id="togglePassword"></i>
                     </button>
                 </div>
             </div>
@@ -26,7 +26,7 @@
                         placeholder="Confirm Password">
                     <div class="input-group-append">
                         <button class="btn password-toggle" type="button" onclick="togglePass()">
-                            <i role="button" class="bi bi-eye-slash" id="togglePasswordConfirm"></i>
+                            <i class="bi bi-eye-slash" id="togglePasswordConfirm"></i>
                         </button>
                     </div>
                 </div>

--- a/augur/templates/settings.j2
+++ b/augur/templates/settings.j2
@@ -204,8 +204,8 @@
                                                                 href="{{ url_for('user_group_view', group=group.name) }}">{{
                                                                 group.name }}</a></th>
                                                         <td>{{ group.repos | length }}</td>
-                                                        <td><i onclick="toggleFavorite(this, '{{ group.name }}')"
-                                                                class="bi {% if group.favorited %} bi-star-fill {% else %} bi-star {% endif %} cursor-pointer"></i>
+                                                        <td><i role="button" onclick="toggleFavorite(this, '{{ group.name }}')"
+                                                                class="bi {% if group.favorited %} bi-star-fill {% else %} bi-star {% endif %}"></i>
                                                         </td>
                                                         <td><button class="btn btn-outline-primary btn-sm"
                                                                 onclick="delgroup(this, '{{ group.name }}')">Delete</button>


### PR DESCRIPTION
**Description**
- Makes the favorite/star buttons use a pointer cursor
- Allows screen-reader users to identify buttons that were previously not visible to screen-reader software

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->