### PR TITLE
Use key manager in github data access

### DIFF
--- a/augur/tasks/github/util/github_data_access.py
+++ b/augur/tasks/github/util/github_data_access.py
@@ -103,7 +103,7 @@ class GithubDataAccess:
             if response.status_code in [403, 429]:
                 raise RatelimitException(response)
 
-            elif response.status_code == 404:
+            if response.status_code == 404:
                 raise UrlNotFoundException(f"Could not find {url}")
             
             response.raise_for_status()

--- a/augur/tasks/github/util/github_data_access.py
+++ b/augur/tasks/github/util/github_data_access.py
@@ -98,7 +98,7 @@ class GithubDataAccess:
 
         with httpx.Client() as client:
 
-            response = client.request(method=method, url=url, timeout=timeout, follow_redirects=True)
+            response = client.request(method=method, url=url, auth=self.key_manager, timeout=timeout, follow_redirects=True)
 
             if response.status_code in [403, 429]:
                 raise RatelimitException(response)


### PR DESCRIPTION
**Description**
- The new github data access had a key manager passed to it but it was not using it to make the request, therefore the requests were being made without a github api key. This simply passes the key manager so it is provided an api key
- 
**Signed commits**
- [X] Yes, I signed my commits.
