### PR TITLE
Proper Gunicorn bringup detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ augur_export_env.sh
 !docker.config.json
 config.yml
 reports.yml
+*.pid
 
 node_modules/
 .idea/

--- a/augur/api/routes/util.py
+++ b/augur/api/routes/util.py
@@ -5,12 +5,19 @@ import base64
 import sqlalchemy as s
 import pandas as pd
 import json
-from flask import Response, current_app
+from flask import Response, current_app, jsonify
 
 from augur.application.db.lib import get_value
 from augur.application.logs import AugurLogger
 
 logger = AugurLogger("augur").get_logger()
+
+@app.route("/api")
+def get_api_version():
+    return jsonify({
+        "status": "up",
+        "route": AUGUR_API_VERSION
+    })
 
 @app.route('/{}/repo-groups'.format(AUGUR_API_VERSION))
 def get_all_repo_groups(): #TODO: make this name automatic - wrapper?

--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -39,14 +39,17 @@ def cli(ctx):
 @cli.command("start")
 @click.option("--disable-collection", is_flag=True, default=False, help="Turns off data collection workers")
 @click.option("--development", is_flag=True, default=False, help="Enable development mode, implies --disable-collection")
+@click.option("--pidfile", default="main.pid", help="File to store the controlling process ID in")
 @click.option('--port')
 @test_connection
 @test_db_connection
 @with_database
 @click.pass_context
-def start(ctx, disable_collection, development, port):
+def start(ctx, disable_collection, development, pidfile, port):
     """Start Augur's backend server."""
-
+    with open(pidfile, "w") as pidfile:
+        pidfile.write(str(os.getpid()))
+        
     try:
         if os.environ.get('AUGUR_DOCKER_DEPLOY') != "1":
             raise_open_file_limit(100000)


### PR DESCRIPTION
**Description**
- Add `/api` route to get the location of the backend API
- Check that Gunicorn has actually started during `backend start` invocation
  - Poll the process state every 0.5 seconds
  - Make GET request to `/api` to check that service has started
  - Repeat until the state of the service can be determined

**Future Work**
- Implement timeout in case Gunicorn takes too long to respond or gets stuck during startup
  - Currently this waits until either the process dies or the server responds

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->