### PR TITLE
Add metadata to json decode errors

### DIFF
--- a/augur/tasks/git/dependency_tasks/core.py
+++ b/augur/tasks/git/dependency_tasks/core.py
@@ -7,6 +7,7 @@ from augur.tasks.git.dependency_tasks.dependency_util import dependency_calculat
 from augur.tasks.util.worker_util import parse_json_from_subprocess_call
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path
 from augur.tasks.github.util.github_random_key_auth import GithubRandomKeyAuth
+from augur.tasks.util.metadata_exception import MetadataException
 
 
 def generate_deps_data(logger, repo_git):
@@ -94,50 +95,47 @@ def generate_scorecard(logger, repo_git):
     
     try: 
         required_output = parse_json_from_subprocess_call(logger,['./scorecard', command, '--format=json'],cwd=path_to_scorecard)
-    except Exception as e: 
-        logger.error(f"Could not parse required output! Error: {e}")
-        raise e        
-
-    # end
     
-    logger.info('adding to database...')
-    logger.debug(f"output: {required_output}")
+        logger.info('adding to database...')
+        logger.debug(f"output: {required_output}")
 
-    if not required_output['checks']:
-        logger.info('No scorecard checks found!')
-        return
-    
-    #Store the overall score first
-    to_insert = []
-    overall_deps_scorecard = {
-        'repo_id': repo_id,
-        'name': 'OSSF_SCORECARD_AGGREGATE_SCORE',
-        'scorecard_check_details': required_output['repo'],
-        'score': required_output['score'],
-        'tool_source': 'scorecard_model',
-        'tool_version': '0.43.9',
-        'data_source': 'Git',
-        'data_collection_date': datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
-    }
-    to_insert.append(overall_deps_scorecard)
-   # bulk_insert_dicts(overall_deps_scorecard, RepoDepsScorecard, ["repo_id","name"])
-
-    #Store misc data from scorecard in json field. 
-    for check in required_output['checks']:
-        repo_deps_scorecard = {
+        if not required_output['checks']:
+            logger.info('No scorecard checks found!')
+            return
+        
+        #Store the overall score first
+        to_insert = []
+        overall_deps_scorecard = {
             'repo_id': repo_id,
-            'name': check['name'],
-            'scorecard_check_details': check,
-            'score': check['score'],
+            'name': 'OSSF_SCORECARD_AGGREGATE_SCORE',
+            'scorecard_check_details': required_output['repo'],
+            'score': required_output['score'],
             'tool_source': 'scorecard_model',
             'tool_version': '0.43.9',
             'data_source': 'Git',
             'data_collection_date': datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
         }
-        to_insert.append(repo_deps_scorecard)
-    
-    bulk_insert_dicts(logger, to_insert, RepoDepsScorecard, ["repo_id","name"])
-    
-    logger.info(f"Done generating scorecard for repo {repo_id} from path {path}")
+        to_insert.append(overall_deps_scorecard)
+    # bulk_insert_dicts(overall_deps_scorecard, RepoDepsScorecard, ["repo_id","name"])
 
+        #Store misc data from scorecard in json field. 
+        for check in required_output['checks']:
+            repo_deps_scorecard = {
+                'repo_id': repo_id,
+                'name': check['name'],
+                'scorecard_check_details': check,
+                'score': check['score'],
+                'tool_source': 'scorecard_model',
+                'tool_version': '0.43.9',
+                'data_source': 'Git',
+                'data_collection_date': datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+            }
+            to_insert.append(repo_deps_scorecard)
+        
+        bulk_insert_dicts(logger, to_insert, RepoDepsScorecard, ["repo_id","name"])
+        
+        logger.info(f"Done generating scorecard for repo {repo_id} from path {path}")
 
+    except Exception as e: 
+        
+        raise MetadataException(e, f"required_output: {required_output}")

--- a/augur/tasks/util/metadata_exception.py
+++ b/augur/tasks/util/metadata_exception.py
@@ -2,7 +2,5 @@ class MetadataException(Exception):
     def __init__(self, original_exception, additional_metadata):
         self.original_exception = original_exception
         self.additional_metadata = additional_metadata
-        super().__init__(self._build_message())
-
-    def _build_message(self):
-        return f"{str(self.original_exception)} | Additional metadata: {self.additional_metadata}"
+        
+        super().__init__(f"{str(self.original_exception)} | Additional metadata: {self.additional_metadata}")

--- a/augur/tasks/util/metadata_exception.py
+++ b/augur/tasks/util/metadata_exception.py
@@ -1,0 +1,8 @@
+class MetadataException(Exception):
+    def __init__(self, original_exception, additional_metadata):
+        self.original_exception = original_exception
+        self.additional_metadata = additional_metadata
+        super().__init__(self._build_message())
+
+    def _build_message(self):
+        return f"{str(self.original_exception)} | Additional metadata: {self.additional_metadata}"

--- a/augur/tasks/util/worker_util.py
+++ b/augur/tasks/util/worker_util.py
@@ -11,6 +11,9 @@ from datetime import datetime
 import json
 import subprocess
 
+from augur.tasks.util.metadata_exception import MetadataException
+
+
 def create_grouped_task_load(*args,processes=8,dataList=[],task=None):
     
     if not dataList or not task:
@@ -141,7 +144,7 @@ def parse_json_from_subprocess_call(logger, subprocess_arr, cwd=None):
             required_output = {}
     except json.decoder.JSONDecodeError as e:
         logger.error(f"Could not parse required output! \n output: {output} \n Error: {e}")
-        raise e
+        raise MetadataException(e, f"output : {output}")
     
     return required_output
 


### PR DESCRIPTION
**Description**
- Currently we are logging the output when we get the json code errors in `parse_json_from_subprocess_call ` but it is impossible to find these logs in the huge log files so I added the exception so that the relevant data will show up in flower

**Signed commits**
- [X] Yes, I signed my commits.
