### PR TITLE
Add Step to Fetch Missing Git Messages from Commits Analyzed Before Commits Message Table was Added

### DIFF
--- a/augur/application/db/lib.py
+++ b/augur/application/db/lib.py
@@ -182,6 +182,22 @@ def get_working_commits_by_repo_id(repo_id):
 
     return working_commits
 
+def get_missing_commit_message_hashes(repo_id):
+
+    fetch_missing_hashes_sql = s.sql.text("""
+    SELECT DISTINCT cmt_commit_hash FROM commits
+    WHERE repo_id=:repo_id 
+    AND cmt_commit_hash NOT IN 
+    (SELECT DISTINCT cmt_hash FROM commit_messages WHERE repo_id=:repo_id);
+    """).bindparams(repo_id=repo_id)
+
+    try:
+        missing_commit_hashes = fetchall_data_from_sql_text(fetch_missing_hashes_sql)
+    except:
+        missing_commit_hashes = []
+    
+    return missing_commit_hashes
+
 def get_worker_oauth_keys(platform: str):
 
     with get_session() as session:

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -193,6 +193,7 @@ def facade_fetch_missing_commit_messages(repo_git):
         
         if len(to_insert) >= 1000:
             bulk_insert_dicts(logger,to_insert, CommitMessage, ["repo_id","cmt_hash"])
+            to_insert = []
         
         to_insert.append(msg_record)
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -170,6 +170,8 @@ def facade_fetch_missing_commit_messages(repo_git):
 
     missing_message_hashes = get_missing_commit_message_hashes(repo.repo_id)
 
+    to_insert = []
+
     for hash in missing_message_hashes:
 
         absolute_path = get_absolute_repo_path(facade_helper.repo_base_directory, repo.repo_id, repo.repo_path,repo.repo_name)
@@ -188,6 +190,14 @@ def facade_fetch_missing_commit_messages(repo_git):
             'data_source' : 'git',
             'data_collection_date' : datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         }
+        
+        if len(to_insert) >= 1000:
+            bulk_insert_dicts(logger,to_insert, CommitMessage, ["repo_id","cmt_hash"])
+        
+        to_insert.append(msg_record)
+
+    if to_insert:
+        bulk_insert_dicts(logger, to_insert, CommitMessage, ["repo_id","cmt_hash"])
 
 
 #enable celery multithreading


### PR DESCRIPTION
**Description**
- Right now the commits that were analyzed before the commit message table was added to the database don't have any commit message and they won't get collected because Augur considers those commits already collected and won't collect them again unless a recollection is triggered in facade for some reason. 

- The solution to this is to go back and fetch them after we analyze commits. 

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->