### PR TITLE
Fix Libyear Parsing Function to Support More than One Dependency Manifest per Project

### DIFF
--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_parser.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/pypi_parser.py
@@ -140,12 +140,12 @@ def parse_poetry_lock(file_handle):
     group = 'runtime'
     for package in manifest['package']:
         req = None
-        if package['category'] == 'main':
+        if package.get('category') == 'main':
             group = 'runtime'
-        if package['category'] == 'dev':
+        if package.get('category') == 'dev':
             group = 'develop'
         if 'version' in package:
-            req = package['version']
+            req = package.get('version')
         elif 'git' in package:
             req = package['git']+'#'+package['ref']
         Dict = {'name': package['name'], 'requirement': req, 'type': group, 'package': 'PYPI'}

--- a/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
+++ b/augur/tasks/git/dependency_libyear_tasks/libyear_util/util.py
@@ -32,54 +32,56 @@ def get_parsed_deps(path,logger):
 
     deps_file = None
     dependency_list = list()
-
     for f in file_list:
         deps_file = find(f, path)
-        if not deps_file:
+
+        if not deps_file or not f:
             continue
         file_handle= open(deps_file)
 
-        if f == 'Requirement.txt':
-            dependency_list = parse_requirement_txt(file_handle)
+        short_file_name = os.path.split(deps_file)[-1]
+
+        if short_file_name == 'Requirement.txt':
+            dependency_list.extend(parse_requirement_txt(file_handle))
         
-        elif f == 'requirements.txt':
-            dependency_list = parse_requirement_txt(file_handle)
+        if short_file_name == 'requirements.txt':
+            dependency_list.extend(parse_requirement_txt(file_handle))
 
-        elif f == 'setup.py':
-            dependency_list = parse_setup_py(file_handle)
+        if short_file_name == 'setup.py':
+            dependency_list.extend(parse_setup_py(file_handle))
 
-        elif f == 'Pipfile':
-            dependency_list = parse_pipfile(file_handle)
+        if short_file_name == 'Pipfile':
+            dependency_list.extend(parse_pipfile(file_handle))
 
-        elif f == 'Pipfile.lock':
-            dependency_list = parse_pipfile_lock(file_handle)
+        if short_file_name == 'Pipfile.lock':
+            dependency_list.extend(parse_pipfile_lock(file_handle))
 
-        elif f == 'pyproject.toml':
-            dependency_list = parse_poetry(file_handle)
+        if short_file_name == 'pyproject.toml':
+            dependency_list.extend(parse_poetry(file_handle))
 
-        elif f == 'poetry.lock':
-            dependency_list = parse_poetry_lock(file_handle)
+        if short_file_name == 'poetry.lock':
+            dependency_list.extend(parse_poetry_lock(file_handle))
 
-        elif f == 'environment.yml':
-            dependency_list = parse_conda(file_handle)
+        if short_file_name == 'environment.yml':
+            dependency_list.extend(parse_conda(file_handle))
 
-        elif f == 'environment.yaml':
-            dependency_list = parse_conda(file_handle)
+        if short_file_name == 'environment.yaml':
+            dependency_list.extend(parse_conda(file_handle))
 
-        elif f == 'environment.yml.lock':
-            dependency_list = parse_conda(file_handle)
+        if f == 'environment.yml.lock':
+            dependency_list.extend(parse_conda(file_handle))
 
-        elif f == 'environment.yaml.lock':
-            dependency_list = parse_conda(file_handle) 
+        if short_file_name == 'environment.yaml.lock':
+            dependency_list.extend(parse_conda(file_handle)) 
             
-        elif f == 'package.json':
+        if short_file_name == 'package.json':
             try:
-                dependency_list = parse_package_json(file_handle)
+                dependency_list.extend(parse_package_json(file_handle))
             except KeyError as e:
                 logger.error(f"package.json for repo at path {path} is missing required key: {e}\n Skipping file...")
 
         
-        return dependency_list
+    return dependency_list
 
 
 def get_libyear(current_version, current_release_date, latest_version, latest_release_date):


### PR DESCRIPTION
**Description**
- Use `.get` instead of dictionary indices to avoid missing info in poetry.lock
- Make each dependency function extend the dep list instead of returning once we find the first manifest file
- Parse the path into a short string that can be more easily compared
- Parse through all found dependency manifest files and put them all in one big dictionary



**Notes for Reviewers**
I have tested locally on my repos but @sgoggins you might want to test it a bit on other repos.

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->