### PR TITLE
Use jq to make parsing GECKODRIVER API call reproducible

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x \
         cargo \
         chromium \
         tar \
+	jq \
         chromium-driver \
         && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
@@ -39,7 +40,7 @@ RUN set -x \
     && apt-get install -y firefox-esr
 
 # Install Geckodriver
-RUN GECKODRIVER_VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep 'tag_name' | cut -d\" -f4 | sed 's/v//') \
+RUN GECKODRIVER_VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.tag_name' | sed 's/v//') \
     && ARCH=$(uname -m) \
     && if [ "$ARCH" = "aarch64" ]; then \
          GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux-aarch64.tar.gz"; \


### PR DESCRIPTION
**Description**
The `curl` call to the GitHub API to get the latest release of GECKODRIVER fails intermittently. The call looks like this:

```
curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest
```

On investigation, this appears to be because GitHub itself isn't consistent it how it returns the API data - sometimes it's a nicely formatted output, eg:

```
# cat good_response.json
{
  "url": "https://api.github.com/repos/mozilla/geckodriver/releases/168891133",
  "assets_url": "https://api.github.com/repos/mozilla/geckodriver/releases/168891133/assets",
  "upload_url": "https://uploads.github.com/repos/mozilla/geckodriver/releases/168891133/assets{?name,label}",
  "html_url": "https://github.com/mozilla/geckodriver/releases/tag/v0.35.0",
...
```

but sometimes it removes the newlines:

```
cat bad_response.json
{"url":"https://api.github.com/repos/mozilla/geckodriver/releases/168891133","assets_url":"https://api.github.com/repos/mozilla/geckodriver/releases/168891133/assets","upload_url":"https://uploads.github.com/repos/mozilla/geckodriver/releases/168891133/assets{?name,label}","html_url":"https://github.com/mozilla/geckodriver/releases/tag/v0.35.0"...
```

This second form causes the grep/sed combo to fail, since the grep now matches the entire output instead of one line.

This PR fixes the issue by using [JQ](https://jqlang.github.io/jq/) to parse the output, which works regardless of form:

```
# cat /tmp/good_response.json | jq -r '.tag_name' | sed 's/v//'
0.35.0

# cat /tmp/bad_response.json | jq -r '.tag_name' | sed 's/v//'                                                                                                                         
0.35.0
```

**Signed commits**
- [x] Yes, I signed my commits.