### PR TITLE
Update Go version in Docker, and re-enable SCC/Scorecard

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -100,9 +100,10 @@ RUN set -x \
     && /opt/venv/bin/pip install wheel \
     && /opt/venv/bin/pip install .
 
+RUN ./scripts/docker/install-go.sh
+ENV PATH="${PATH}:/usr/local/go/bin"
 RUN ./scripts/docker/install-workers-deps.sh
 
-RUN ./scripts/docker/install-go.sh
 # RUN ./scripts/install/workers.sh 
 
 RUN mkdir -p repos/ logs/ /augur/facade/

--- a/scripts/docker/install-go.sh
+++ b/scripts/docker/install-go.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# install Go
-installGo() (
-    cd "$(mktemp -d)"
-    wget https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
-    rm -rf /usr/local/go && tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
-)
-installGo
+
+export VERSION="1.22.9"
+
+cd "$(mktemp -d)"
+wget https://golang.org/dl/go${VERSION}.linux-amd64.tar.gz
+rm -rf /usr/local/go && tar -C /usr/local -xzf go${VERSION}.linux-amd64.tar.gz
+
 export PATH=$PATH:/usr/local/go/bin

--- a/scripts/docker/install-workers-deps.sh
+++ b/scripts/docker/install-workers-deps.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -x
+
 OLD=$(pwd)
 for i in $(find . | grep -i setup.py);
 do
-	
 	cd $(dirname $i)
 	/opt/venv/bin/pip install .
 	cd $OLD
@@ -14,3 +14,24 @@ done
 for i in stopwords punkt popular universal_tagset ; do
 	/opt/venv/bin/python -m nltk.downloader $i
 done
+
+# Note this
+CURRENT_DIR=$PWD;
+
+# Install scc
+SCC_DIR="$HOME/scc"
+echo "Cloning Sloc Cloc and Code (SCC) to generate value data ..."
+git clone https://github.com/boyter/scc "$SCC_DIR"
+cd $SCC_DIR
+go build;
+echo "scc build done"
+cd $CURRENT_DIR
+
+# Install scorecard
+SCORECARD_DIR="$HOME/scorecard"
+echo "Cloning OSSF Scorecard to generate scorecard data ..."
+git clone https://github.com/ossf/scorecard $SCORECARD_DIR
+cd $SCORECARD_DIR
+go build;
+echo "scorecard build done"
+cd $CURRENT_DIR


### PR DESCRIPTION
**Description**
This commit fixes a couple of things.

Firstly, the `install-go` script uses an ancient version of Go that conflicts with the newer version needed for SCC, so that is updated. That script also wrapped the install in a function for no apparent reason, so I simplified it.

Second, I re-enabled the SCC & Scorecard installs. These have been commented out for some time, apparently because of the Go issues. Rather than uncomment it, I copied the relevant parts from `workers.sh` because the container doesn't need checks about whether directories exist - these are guaranteed not to exist in a fresh container.

**Notes for Reviewers**

I believe this will result in working SCC and Scorecard calculations in the container now

**Signed commits**
- [x ] Yes, I signed my commits.