### PR TITLE
[Documentation]: Cleanup docker installation docs

### DIFF
--- a/docs/dev-osx-install.md
+++ b/docs/dev-osx-install.md
@@ -427,12 +427,21 @@ Note: Augur will run on port 5000 by default (you probably need to change that i
 ## Stopping your Augur Instance
 You can stop augur with `augur backend stop`, followed by `augur backend kill`. We recommend waiting 5 minutes between commands so Augur can shutdown more gently. There is no issue with data integrity if you issue them seconds apart, its just that stopping is nicer than killing. 
 
-### Docker
+## Docker
 1. Make sure docker, and docker compose are both installed
 2. Modify the `environment.txt` file in the root of the repository to include your GitHub and GitLab API keys.
 3. If you are already running postgresql on your server you have two choices: 
    - Change the port mappings in the `docker-compose.yml` file to match ports for Postgresql not currently in use.
-   - Change to variables in `environment.txt` to include the correct values for your local, non-docker-container database.
+   - Change the variables in `environment.txt` to include the correct values for your local, non-docker-container database.
 4. `sudo docker build -t augur-new -f docker/backend/Dockerfile .`
 5. `sudo docker compose --env-file ./environment.txt --file docker-compose.yml up` to run the database in a Docker Container or 
-   `sudo docker compose --env-file ./environment.txt --file docker-compose.yml up` to connect to an already running database. 
+   `sudo docker compose --env-file ./environment.txt --file docker-compose-externalDB.yml up` to connect to an already running database. 
+
+### Possible Apple Silicon Prerequisites: 
+```bash
+brew install libpq
+echo 'export LDFLAGS="-L/opt/homebrew/opt/libpq/lib"' >> ~/.zshrc
+echo 'export CPPFLAGS="-I/opt/homebrew/opt/libpq/include"' >> ~/.zshrc 
+```
+
+_Note: `AUGUR\_DB` and `RABBIT\_*` variables are optional when using the default docker-comopse.yml. `docker-compose-externalDB` does require `AUGUR\_DB` set to a postgresql installation._

--- a/docs/new-install.md
+++ b/docs/new-install.md
@@ -377,7 +377,7 @@ You can stop augur with `augur backend stop`, followed by `augur backend kill`. 
 2. Modify the `environment.txt` file in the root of the repository to include your GitHub and GitLab API keys.
 3. If you are already running postgresql on your server you have two choices: 
    - Change the port mappings in the `docker-compose.yml` file to match ports for Postgresql not currently in use.
-   - Change the variables in `environment.txt` to include the correct values for your local, non-docker-container database.
+   - Change the variables in `environment.txt` to include the correct environment variables for your local, non-docker-container database. This file is used in step 5 to configure the environment variables using docker compose.
 4. `sudo docker build -t augur-new -f docker/backend/Dockerfile .`
 5. `sudo docker compose --env-file ./environment.txt --file docker-compose.yml up` to run the database in a Docker Container or 
    `sudo docker compose --env-file ./environment.txt --file docker-compose-externalDB.yml up` to connect to an already running database. *Note*: Environment file would be modified to point to an already running database. 

--- a/docs/new-install.md
+++ b/docs/new-install.md
@@ -370,24 +370,16 @@ Note: Augur will run on port 5000 by default (you probably need to change that i
 ## Stopping your Augur Instance
 You can stop augur with `augur backend stop`, followed by `augur backend kill`. We recommend waiting 5 minutes between commands so Augur can shutdown more gently. There is no issue with data integrity if you issue them seconds apart, its just that stopping is nicer than killing. 
 
-### Docker
+## Docker
 *Note: `sudo` is not necessary on OSX or Windows
 
 1. Make sure docker, and docker compose are both installed
 2. Modify the `environment.txt` file in the root of the repository to include your GitHub and GitLab API keys.
 3. If you are already running postgresql on your server you have two choices: 
    - Change the port mappings in the `docker-compose.yml` file to match ports for Postgresql not currently in use.
-   - Change to variables in `environment.txt` to include the correct values for your local, non-docker-container database.
-4. `sudo docker build -t augur-new -f docker/backend/Dockerfile .` OSX: 
+   - Change the variables in `environment.txt` to include the correct values for your local, non-docker-container database.
+4. `sudo docker build -t augur-new -f docker/backend/Dockerfile .`
 5. `sudo docker compose --env-file ./environment.txt --file docker-compose.yml up` to run the database in a Docker Container or 
-   `sudo docker compose --env-file ./environment.txt --file docker-compose.yml up` to connect to an already running database. *Note*: Environment file would be modified to point to an already running database. 
-
-
-#### Possible Apple Silicon Prerequisites: 
-```bash
-brew install libpq
-echo 'export LDFLAGS="-L/opt/homebrew/opt/libpq/lib"' >> ~/.zshrc
-echo 'export CPPFLAGS="-I/opt/homebrew/opt/libpq/include"' >> ~/.zshrc 
-```
+   `sudo docker compose --env-file ./environment.txt --file docker-compose-externalDB.yml up` to connect to an already running database. *Note*: Environment file would be modified to point to an already running database. 
 
 _Note: `AUGUR\_DB` and `RABBIT\_*` variables are optional when using the default docker-comopse.yml. `docker-compose-externalDB` does require `AUGUR\_DB` set to a postgresql installation._


### PR DESCRIPTION
**Description**
Docs: 
- Moved apple silicon prerequisites from the Ubuntu to the OSX section
- Fixed docker-compose file reference for external db usage


**Notes for Reviewers**
Probably the docker documentation needs to be consolidated entirely.



**Signed commits**
- [x] Yes, I signed my commits.
