### PR TITLE
Strip whitespace from keys while loading

### DIFF
--- a/augur/tasks/github/util/github_api_key_handler.py
+++ b/augur/tasks/github/util/github_api_key_handler.py
@@ -107,6 +107,8 @@ class GithubApiKeyHandler():
 
         if len(keys) == 0:
             return []
+        
+        keys = [key.strip() for key in keys]
 
         valid_keys = []
         with httpx.Client() as client:

--- a/augur/tasks/gitlab/gitlab_api_key_handler.py
+++ b/augur/tasks/gitlab/gitlab_api_key_handler.py
@@ -110,6 +110,8 @@ class GitlabApiKeyHandler():
         if len(keys) == 0:
             return []
 
+        keys = [key.strip() for key in keys]
+
         valid_keys = []
         with httpx.Client() as client:
 


### PR DESCRIPTION
**Description**
- Fixes a crash that occurs when using HTTPX with API keys that have trailing whitespace

This PR fixes #2998 

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->