### PR TITLE
Deadlock patch 001: Addressing accumulating locks on contributors table on very large instances

### DIFF
--- a/augur/tasks/github/contributors.py
+++ b/augur/tasks/github/contributors.py
@@ -91,7 +91,7 @@ def process_contributors():
     logger = logging.getLogger(process_contributors.__name__)
 
     tool_source = "Contributors task"
-    tool_version = "2.0"
+    tool_version = "3.0"
     data_source = "Github API"
 
     key_auth = GithubRandomKeyAuth(logger)

--- a/augur/tasks/github/contributors.py
+++ b/augur/tasks/github/contributors.py
@@ -1,3 +1,4 @@
+"""
 import time
 import logging
 import traceback 
@@ -10,9 +11,26 @@ from augur.application.db.models import Contributor
 from augur.application.db.util import execute_session_query
 from augur.application.db.lib import bulk_insert_dicts, get_session
 from augur.tasks.github.util.github_random_key_auth import GithubRandomKeyAuth
+""" 
+import time
+import logging
+import traceback
+import random
+
+from sqlalchemy.exc import OperationalError
+from psycopg2.errors import DeadlockDetected
+
+from augur.tasks.init.celery_app import celery_app as celery
+from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
+from augur.tasks.github.util.github_paginator import hit_api
+from augur.tasks.github.facade_github.committers import grab_committer_list  # Ensure this is the correct function
+from augur.application.db.models import Contributor
+from augur.application.db.util import execute_session_query
+from augur.application.db.lib import bulk_insert_dicts, get_session
+from augur.tasks.github.util.github_random_key_auth import GithubRandomKeyAuth
 
 
-
+"""  
 @celery.task
 def process_contributors():
 
@@ -65,6 +83,86 @@ def process_contributors():
     logger.info(f"Enriching {len(enriched_contributors)} contributors")
     bulk_insert_dicts(enriched_contributors, Contributor, ["cntrb_id"])
 
+
+""" 
+
+@celery.task
+def process_contributors():
+    logger = logging.getLogger(process_contributors.__name__)
+
+    tool_source = "Contributors task"
+    tool_version = "2.0"
+    data_source = "Github API"
+
+    key_auth = GithubRandomKeyAuth(logger)
+
+    with get_session() as session:
+        query = session.query(Contributor).filter(
+            Contributor.data_source == data_source,
+            Contributor.cntrb_created_at.is_(None),
+            Contributor.cntrb_last_used.is_(None)
+        )
+        contributors = execute_session_query(query, 'all')
+
+    contributors_len = len(contributors)
+
+    if contributors_len == 0:
+        logger.info("No contributors to enrich...returning...")
+        return
+
+    logger.info(f"Length of contributors to enrich: {contributors_len}")
+
+    batch_size = 50  # Adjust batch size as needed
+    max_retries = 5
+    enriched_contributors = []
+
+    for index, contributor in enumerate(contributors):
+        logger.info(f"Processing Contributor {index + 1} of {contributors_len}")
+
+        contributor_dict = contributor.__dict__
+        del contributor_dict["_sa_instance_state"]
+
+        url = f"https://api.github.com/users/{contributor_dict['cntrb_login']}" 
+        data = retrieve_dict_data(url, key_auth, logger)
+
+        if data is None:
+            logger.warning(f"Unable to get contributor data for: {contributor_dict['cntrb_login']}")
+            continue
+
+        new_contributor_data = {
+            "cntrb_created_at": data["created_at"],
+            "cntrb_last_used": data["updated_at"]
+        }
+
+        contributor_dict.update(new_contributor_data)
+        enriched_contributors.append(contributor_dict)
+
+        # Process in batches to reduce deadlocks
+        if len(enriched_contributors) >= batch_size:
+            _insert_with_retries(enriched_contributors, max_retries, logger)
+            enriched_contributors = []
+
+    # Insert remaining contributors
+    if enriched_contributors:
+        _insert_with_retries(enriched_contributors, max_retries, logger)
+
+def _insert_with_retries(contributors_batch, max_retries, logger):
+    """Handles deadlocks by retrying transactions with exponential backoff."""
+    retries = 0
+    while retries < max_retries:
+        try:
+            bulk_insert_dicts(contributors_batch, Contributor, ["cntrb_id"])
+            return  # Exit function if successful
+        except (OperationalError, DeadlockDetected) as e:
+            wait_time = 2 ** retries + random.uniform(0, 1)  # Exponential backoff
+            logger.warning(f"Deadlock detected, retrying in {wait_time:.2f} seconds... (Attempt {retries + 1}/{max_retries})")
+            time.sleep(wait_time)
+            retries += 1
+        except Exception as e:
+            logger.error(f"Unexpected error during batch insert: {e}")
+            break  # Exit on non-deadlock errors
+
+    logger.error("Max retries reached. Some records may not have been inserted.")
 
 
 def retrieve_dict_data(url: str, key_auth, logger):

--- a/augur/tasks/github/contributors.py
+++ b/augur/tasks/github/contributors.py
@@ -23,7 +23,7 @@ from psycopg2.errors import DeadlockDetected
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.tasks.github.util.github_paginator import hit_api
-from augur.tasks.github.facade_github.committers import grab_committer_list  # Ensure this is the correct function
+from augur.tasks.github.facade_github.tasks import * 
 from augur.application.db.models import Contributor
 from augur.application.db.util import execute_session_query
 from augur.application.db.lib import bulk_insert_dicts, get_session

--- a/augur/tasks/github/contributors.py
+++ b/augur/tasks/github/contributors.py
@@ -154,7 +154,7 @@ def _insert_with_retries(contributors_batch, max_retries, logger):
             bulk_insert_dicts(contributors_batch, Contributor, ["cntrb_id"])
             return  # Exit function if successful
         except (OperationalError, DeadlockDetected) as e:
-            wait_time = 2 ** retries + random.uniform(0, 1)  # Exponential backoff
+            wait_time = 3 ** retries + random.uniform(0, 1)  # Exponential backoff
             logger.warning(f"Deadlock detected, retrying in {wait_time:.2f} seconds... (Attempt {retries + 1}/{max_retries})")
             time.sleep(wait_time)
             retries += 1

--- a/augur/tasks/github/contributors.py
+++ b/augur/tasks/github/contributors.py
@@ -112,7 +112,7 @@ def process_contributors():
 
     logger.info(f"Length of contributors to enrich: {contributors_len}")
 
-    batch_size = 50  # Adjust batch size as needed
+    batch_size = 20  # Started with 50. Backed off to 20
     max_retries = 5
     enriched_contributors = []
 


### PR DESCRIPTION
**Description**
- Deadlock management in Augur is generally addressed using a progressive transaction shrinking and waiting policy in order to: 
  - Maximize data gathering throughput
  - Minimize contention and deadlocking
- Experiments show that this strategy is working well with the occasional exception of deadlocks around the contributors table. In this case, and because contributors are so logically coupled with every other data gathering process, deadlocks can quickly cascade and accumulate. 
  - This PR implements the general strategy found in more general terms throughout Augur, but centered on the unique properties of the contributors problem (The snowball of deadlocks has been observed to accelerate quickly on instances of Augur with more than 10k repositories and more than 10 simultaneous data collection processes. 
  - The "storm" does not last forever and so far there is not any indication that in place retries are not ultimately working. 
  - Rather, this is about lowering the load on the database engine so that we avoid generating deadlocks as much as is sometimes happening when the "large instance" thresholds are met). 
  - Of course this problem like all programming and data problems is idiosyncratic to the particular repositories and contributors being selected at a point in time. Early indications are that when a repository is both new to Augur and contains more than 1,000 pull requests deadlocks occur more frequently