### PR TITLE
Filter worker_oauth keys by platform in cli

### DIFF
--- a/augur/application/cli/github.py
+++ b/augur/application/cli/github.py
@@ -32,7 +32,7 @@ def update_api_key():
             """
             SELECT value as github_key from config Where section_name='Keys' AND setting_name='github_api_key'
             UNION All
-            SELECT access_token as github_key from worker_oauth ORDER BY github_key DESC;
+            SELECT access_token as github_key from worker_oauth where platform='github' ORDER BY github_key DESC;
             """
         )
 


### PR DESCRIPTION
**Description**
- Update `augur github api-keys` command to filter worker_oauth keys by platform

This PR fixes #3004 

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->