### PR TITLE
[backend] refactor docker container to builder pattern

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -6,6 +6,7 @@ FROM golang:1.23 AS golang
 
 # RUN ./scripts/docker/install-go.sh
 ENV PATH="${PATH}:/usr/local/go/bin"
+COPY ./scripts/ scripts/
 RUN ./scripts/docker/install-golang-deps.sh
 
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -9,6 +9,25 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 RUN ./scripts/docker/install-golang-deps.sh
 
 
+FROM rust:1.78 as rust
+
+# Ensure Rust directories are writable
+RUN mkdir -p /root/.rustup/downloads /root/.cargo/registry && \
+    chmod -R 777 /root/.rustup /root/.cargo
+
+# Add rust and cargo to PATH
+# ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install the specific version of Rust
+# RUN set -x \
+#     && rustup install 1.78.0
+# RUN set -x \
+#     && rustup default 1.78.0
+
+
+# Add rust and cargo to PATH
+ENV PATH="/usr/bin/:/root/.cargo/bin:/usr/local/bin:${PATH}"
+
 FROM python:3.11-slim-bullseye
 
 LABEL maintainer="outdoors@acm.org"
@@ -34,15 +53,12 @@ RUN set -x \
         postgresql-client \
         libpq-dev \
         build-essential \
-        rustc \
-        cargo \
         chromium \
         tar \
 	jq \
         chromium-driver \
         && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Firefox from Debian repositories for ARM64 architecture
 RUN set -x \
@@ -68,18 +84,9 @@ RUN GECKODRIVER_VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriv
 RUN firefox --version
 RUN geckodriver --version
 
-# Ensure Rust directories are writable
-RUN mkdir -p /root/.rustup/downloads /root/.cargo/registry && \
-    chmod -R 777 /root/.rustup /root/.cargo
 
-# Add rust and cargo to PATH
-ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install the specific version of Rust
-RUN set -x \
-    && rustup install 1.78.0
-RUN set -x \
-    && rustup default 1.78.0
+
 
 EXPOSE 5000
 
@@ -92,8 +99,7 @@ COPY ./setup.py .
 COPY ./scripts/ scripts/
 COPY ./keyman/ keyman/
 
-# Add rust and cargo to PATH
-ENV PATH="/usr/bin/:/root/.cargo/bin:/usr/local/bin:${PATH}"
+
 
 RUN python3 -m venv /opt/venv
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -9,24 +9,24 @@ ENV PATH="${PATH}:/usr/local/go/bin"
 RUN ./scripts/docker/install-golang-deps.sh
 
 
-FROM rust:1.78 as rust
+# FROM rust:1.78 as rust
 
-# Ensure Rust directories are writable
-RUN mkdir -p /root/.rustup/downloads /root/.cargo/registry && \
-    chmod -R 777 /root/.rustup /root/.cargo
+# # Ensure Rust directories are writable
+# RUN mkdir -p /root/.rustup/downloads /root/.cargo/registry && \
+#     chmod -R 777 /root/.rustup /root/.cargo
 
-# Add rust and cargo to PATH
-# ENV PATH="/root/.cargo/bin:${PATH}"
+# # Add rust and cargo to PATH
+# # ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install the specific version of Rust
-# RUN set -x \
-#     && rustup install 1.78.0
-# RUN set -x \
-#     && rustup default 1.78.0
+# # Install the specific version of Rust
+# # RUN set -x \
+# #     && rustup install 1.78.0
+# # RUN set -x \
+# #     && rustup default 1.78.0
 
 
-# Add rust and cargo to PATH
-ENV PATH="/usr/bin/:/root/.cargo/bin:/usr/local/bin:${PATH}"
+# # Add rust and cargo to PATH
+# ENV PATH="/usr/bin/:/root/.cargo/bin:/usr/local/bin:${PATH}"
 
 FROM python:3.11-slim-bullseye
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -119,8 +119,8 @@ RUN set -x \
 
 RUN ./scripts/docker/install-workers-deps.sh
 
-COPY --from=golang "$HOME/scc" "$HOME/scc"
-COPY --from=golang "$HOME/scorecard" "$HOME/scorecard"
+COPY --from=golang "/root/scc" "./scc"
+COPY --from=golang "/root/scorecard/scorecard" "./scorecard"
 
 # RUN ./scripts/install/workers.sh 
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,14 @@
 # SPDX-License-Identifier: MIT
+
+
+FROM golang:1.23 AS golang
+
+
+# RUN ./scripts/docker/install-go.sh
+ENV PATH="${PATH}:/usr/local/go/bin"
+RUN ./scripts/docker/install-golang-deps.sh
+
+
 FROM python:3.11-slim-bullseye
 
 LABEL maintainer="outdoors@acm.org"
@@ -101,9 +111,10 @@ RUN set -x \
     && /opt/venv/bin/pip install wheel \
     && /opt/venv/bin/pip install .
 
-RUN ./scripts/docker/install-go.sh
-ENV PATH="${PATH}:/usr/local/go/bin"
 RUN ./scripts/docker/install-workers-deps.sh
+
+COPY --from=golang "$HOME/scc" "$HOME/scc"
+COPY --from=golang "$HOME/scorecard" "$HOME/scorecard"
 
 # RUN ./scripts/install/workers.sh 
 

--- a/scripts/docker/install-golang-deps.sh
+++ b/scripts/docker/install-golang-deps.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -x
+
+# Note this
+CURRENT_DIR=$PWD;
+# 18GB
+# Install scc
+SCC_DIR="$HOME/scc"
+echo "Cloning Sloc Cloc and Code (SCC) to generate value data ..."
+git clone https://github.com/boyter/scc "$SCC_DIR"
+cd $SCC_DIR
+go build;
+echo "scc build done"
+cd $CURRENT_DIR
+# 18GB
+
+# Install scorecard
+SCORECARD_DIR="$HOME/scorecard"
+echo "Cloning OSSF Scorecard to generate scorecard data ..."
+git clone https://github.com/ossf/scorecard $SCORECARD_DIR
+cd $SCORECARD_DIR
+go build;
+echo "scorecard build done"
+cd $CURRENT_DIR
+
+# 16GB

--- a/scripts/docker/install-golang-deps.sh
+++ b/scripts/docker/install-golang-deps.sh
@@ -7,7 +7,9 @@ CURRENT_DIR=$PWD;
 # Install scc
 SCC_DIR="$HOME/scc"
 echo "Cloning Sloc Cloc and Code (SCC) to generate value data ..."
-git clone https://github.com/boyter/scc "$SCC_DIR"
+# this needs to be done from source. the latest version doesnt seem to exist on the package repo
+# however, the latest version (v3.5.0) requires bumping the golang version in the Dockerfile
+git clone --depth 1 --branch v3.4.0 https://github.com/boyter/scc "$SCC_DIR"
 cd $SCC_DIR
 go build;
 echo "scc build done"
@@ -17,7 +19,8 @@ cd $CURRENT_DIR
 # Install scorecard
 SCORECARD_DIR="$HOME/scorecard"
 echo "Cloning OSSF Scorecard to generate scorecard data ..."
-git clone https://github.com/ossf/scorecard $SCORECARD_DIR
+# lock version to prevent future issues if the golang version is bumped
+git clone --depth 1 --branch v5.1.1 https://github.com/ossf/scorecard $SCORECARD_DIR
 cd $SCORECARD_DIR
 go build;
 echo "scorecard build done"

--- a/scripts/docker/install-workers-deps.sh
+++ b/scripts/docker/install-workers-deps.sh
@@ -8,30 +8,3 @@ do
 	/opt/venv/bin/pip install .
 	cd $OLD
 done
-
-# install nltk
-# taken from ./scripts/install/nltk_dictionaries.sh
-for i in stopwords punkt popular universal_tagset ; do
-	/opt/venv/bin/python -m nltk.downloader $i
-done
-
-# Note this
-CURRENT_DIR=$PWD;
-
-# Install scc
-SCC_DIR="$HOME/scc"
-echo "Cloning Sloc Cloc and Code (SCC) to generate value data ..."
-git clone https://github.com/boyter/scc "$SCC_DIR"
-cd $SCC_DIR
-go build;
-echo "scc build done"
-cd $CURRENT_DIR
-
-# Install scorecard
-SCORECARD_DIR="$HOME/scorecard"
-echo "Cloning OSSF Scorecard to generate scorecard data ..."
-git clone https://github.com/ossf/scorecard $SCORECARD_DIR
-cd $SCORECARD_DIR
-go build;
-echo "scorecard build done"
-cd $CURRENT_DIR


### PR DESCRIPTION
**Description**
This change refactors the docker container for the backend to use a "builder container" pattern that attempts to help optimize the amount of disk space required to build the container

This PR contributed towards #3006 

As noted in the linked issue, this PR still refactors, but effectively removes the rust build step since there don't seem to be any dependencies written in rust.

**Testing**

Since im still trying to find ways to optimize the build, I haven't yet run a full instance of augur on my machine

**Notes for Reviewers**
TODO:
- [ ] Refactor the `graphical` dockerfile to be based on this main one since they're largely the same
- [ ] pull golang dependencies from the golang package repository where possible to (hopefully) avoid the need to build from source entirely
- [ ] move the building of all the python sub-packages into another builder container so that the build dependencies dont need to stick around either 

**Signed commits**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->