### PR TITLE
adjust path that scc gets copied to

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -120,7 +120,7 @@ RUN set -x \
 
 RUN ./scripts/docker/install-workers-deps.sh
 
-COPY --from=golang "/root/scc" "./scc"
+COPY --from=golang "/root/scc" "/root/scc"
 COPY --from=golang "/root/scorecard/scorecard" "./scorecard"
 
 # RUN ./scripts/install/workers.sh 


### PR DESCRIPTION
**Description**
This is a *really* low effort shot in the (almost) dark solution to #3053 

Having some testing would be appreciated, especially if this does anything other than fixing the issue or at least moving the error to some thing similar to a `file not found` for `scorecard` (rather than `scc`) 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.
