### PR TITLE
[Docs] Corrected GitLab Public Access Token URL in Documentation

### DIFF
--- a/docs/dev-osx-install.md
+++ b/docs/dev-osx-install.md
@@ -31,7 +31,7 @@ export PKG_CONFIG_PATH="/opt/homebrew/opt/openblas/lib/pkgconfig"
 
 ## Git Platform Requirements (Things to have setup prior to initiating installation.)
 1. Obtain a GitHub Access Token: https://github.com/settings/tokens
-2. Obtain a GitLab Access Token: https://gitlab.com/-/profile/personal_access_tokens
+2. Obtain a GitLab Access Token: https://gitlab.com/-/user_settings/personal_access_tokens
 
 ### Fork and Clone Augur
 1. Fork https://github.com/chaoss/augur 

--- a/docs/new-install-ubuntu-python-3.10.md
+++ b/docs/new-install-ubuntu-python-3.10.md
@@ -5,7 +5,7 @@ We default to this version of Ubuntu for the moment because Augur does not yet s
 
 ## Git Platform Requirements (Things to have setup prior to initiating installation.)
 1. Obtain a GitHub Access Token: https://github.com/settings/tokens
-2. Obtain a GitLab Access Token: https://gitlab.com/-/profile/personal_access_tokens
+2. Obtain a GitLab Access Token: https://gitlab.com/-/user_settings/personal_access_tokens
 
 ### Fork and Clone Augur
 1. Fork https://github.com/chaoss/augur 

--- a/docs/new-install.md
+++ b/docs/new-install.md
@@ -5,7 +5,7 @@ We default to this version of Ubuntu for the moment because Augur does not yet s
 
 ## Git Platform Requirements (Things to have setup prior to initiating installation.)
 1. Obtain a GitHub Access Token: https://github.com/settings/tokens
-2. Obtain a GitLab Access Token: https://gitlab.com/-/profile/personal_access_tokens
+2. Obtain a GitLab Access Token: https://gitlab.com/-/user_settings/personal_access_tokens
 
 ### Fork and Clone Augur
 1. Fork https://github.com/chaoss/augur 

--- a/docs/source/getting-started/dev-osx-install.rst
+++ b/docs/source/getting-started/dev-osx-install.rst
@@ -47,8 +47,7 @@ Git Platform Requirements (Things to have setup prior to initiating installation
 ----------------------------------------------------------------------------------
 
 1. Obtain a GitHub Access Token: https://github.com/settings/tokens
-2. Obtain a GitLab Access Token:
-   https://gitlab.com/-/profile/personal_access_tokens
+2. Obtain a GitLab Access Token: https://gitlab.com/-/user_settings/personal_access_tokens
 
 Fork and Clone Augur
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/getting-started/new-install.rst
+++ b/docs/source/getting-started/new-install.rst
@@ -9,8 +9,7 @@ Git Platform Requirements (Things to have setup prior to initiating installation
 ----------------------------------------------------------------------------------
 
 1. Obtain a GitHub Access Token: https://github.com/settings/tokens
-2. Obtain a GitLab Access Token:
-   https://gitlab.com/-/profile/personal_access_tokens
+2. Obtain a GitLab Access Token: https://gitlab.com/-/user_settings/personal_access_tokens
 
 Fork and Clone Augur
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Description**
- Fixed incorrect GitLab Public Access Token URL in the documentation.
- Updated the link to point to the correct resource.

**Fixes Issue**
- No related issue, this is a minor fix. 

**Notes for Reviewers**
- Please verify that the updated URL works correctly.

**Signed Commits**
- [x] Yes, I signed my commits.