### PR TITLE
Fix failing CI when not tagging a docker image

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -71,7 +71,8 @@ jobs:
           file: ./docker/${{ matrix.image }}/Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
+          # Only push if we've tagged the image in the metadata step
+          push: ${{ github.event_name != 'pull_request' && steps.meta.outputs.tags != '' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=container-${{ matrix.image }}
           cache-to: type=gha,scope=container-${{ matrix.image }},mode=max


### PR DESCRIPTION
**Description**
This is a follow-up to #3093 that attempts to fix the current failing CI due to trying to push a non-tagged docker image.

The following is taken from #3010
```
ERROR: tag is needed when pushing to registry
```

The issue is that we are trying to push the image for any non-PR triggered build, but that doesn't match the logic for when we actually tag an image. Hopefully the logic here will key off of whether we have actually applied a tag with the actual intent to push.

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.