### PR TITLE
[infrastructure] Add .gitattributes to normalize line endings and prevent Windows Docker build issues.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize line endings for all text files
+* text=auto
+
+# Force shell scripts to use LF (important for Docker builds)
+*.sh text eol=lf

--- a/docs/wsl2-setup-notes.md
+++ b/docs/wsl2-setup-notes.md
@@ -1,0 +1,15 @@
+# 🐧 WSL2 & Windows: Environment Setup Troubleshooting Notes
+
+These notes are based on installation errors encountered while setting up Augur on a Windows 11 + WSL2 system. They aim to assist new contributors in overcoming platform-specific issues and improving onboarding documentation.
+
+---
+
+## 🔧 Common Problems & Fixes
+
+### 1. Shell scripts not executing (`.sh not found`)
+**Symptoms**: Error like `install.sh: not found` or `permission denied`.
+
+**Fix**:
+```bash
+dos2unix scripts/install/*.sh
+chmod +x scripts/install/*.sh


### PR DESCRIPTION

Description
- This pull request introduces a `.gitattributes` file at the root of the repository to help normalize line endings across different operating systems. This is especially useful for Windows users, where improper line endings can cause Docker build scripts (like `workers.sh`) to fail with "file not found" errors, even when the file exists.

The file contains:
# Normalize line endings for all text files
* text=auto

# Force shell scripts to use LF (important for Docker builds)
*.sh text eol=lf


Notes for Reviewers
This change does not impact application logic or features.

It is strictly an environment improvement for cross-platform compatibility.

Helpful for preventing subtle Docker build issues caused by CRLF/LF mismatch on Windows systems.

Signed commits
 Yes, I signed my commits..

