### PR TITLE
Fixing Facade Error on commit counting

### DIFF
--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -141,7 +141,7 @@ def get_repo_commit_count(logger, facade_helper, repo_git):
 	repo = get_repo_by_repo_git(repo_git)
     
 	absolute_path = get_absolute_repo_path(facade_helper.repo_base_directory, repo.repo_id, repo.repo_path,repo.repo_name)
-	repo_loc = (f"{absolute_path}/.git")
+	repo_loc = (f"{absolute_path}.git")
 
 	logger.debug(f"loc: {repo_loc}")
 	logger.debug(f"path: {repo.repo_path}")

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -226,6 +226,7 @@ def get_repo_commit_count(logger, facade_helper, repo_git):
 	commit_count = int(check_commit_count_cmd)
 
 	return commit_count
+"""
 
 def get_facade_weight_time_factor(repo_git):
 
@@ -271,4 +272,3 @@ def update_facade_scheduling_fields(repo_git, weight, commit_count):
 
 
 
-"""

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -141,7 +141,7 @@ def get_repo_commit_count(logger, facade_helper, repo_git):
 	repo = get_repo_by_repo_git(repo_git)
     
 	absolute_path = get_absolute_repo_path(facade_helper.repo_base_directory, repo.repo_id, repo.repo_path,repo.repo_name)
-	repo_loc = (f"{absolute_path}.git")
+	repo_loc = (f"{absolute_path}/.git")
 
 	logger.debug(f"loc: {repo_loc}")
 	logger.debug(f"path: {repo.repo_path}")

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -136,6 +136,60 @@ def count_branches(git_dir):
     branches_dir = os.path.join(git_dir, 'refs', 'heads')
     return sum(1 for _ in os.scandir(branches_dir))
 
+
+def get_repo_commit_count(logger, facade_helper, repo_git):
+    repo = get_repo_by_repo_git(repo_git)
+    
+    absolute_path = get_absolute_repo_path(
+        facade_helper.repo_base_directory,
+        repo.repo_id,
+        repo.repo_path,
+        repo.repo_name
+    )
+    repo_loc = f"{absolute_path}/.git"
+
+    logger.debug(f"loc: {repo_loc}")
+    logger.debug(f"path: {repo.repo_path}")
+
+    # Check if the .git directory exists, otherwise try without it.
+    if not os.path.exists(repo_loc):
+        logger.error(f"Directory not found: {repo_loc}. Trying without '.git' extension.")
+        repo_loc = absolute_path 
+        if not os.path.exists(repo_loc):
+            raise FileNotFoundError(f"Neither {absolute_path} nor {repo_loc} exist.")
+
+    # If there are no branches then the repo is empty.
+    if count_branches(repo_loc) == 0:
+        logger.info("Repository is empty; no branches found.")
+        return 0
+
+    try:
+        # Execute git command to count commits.
+        output = check_output(
+            ["git", "--git-dir", repo_loc, "rev-list", "--count", "HEAD"],
+            stderr=subprocess.PIPE
+        )
+        # Convert output to an integer. Decode and strip to be safe.
+        commit_count = int(output.decode('utf-8').strip())
+    except CalledProcessError as e:
+        stderr_msg = e.stderr.decode('utf-8') if e.stderr else ""
+        logger.error(
+            f"Error running git rev-list --count HEAD in {repo_loc}: "
+            f"Return code {e.returncode}. Stderr: {stderr_msg}"
+        )
+        # If error indicates there is no HEAD (commonly exit status 128), treat the repo as empty.
+        if e.returncode == 128 or "unknown revision" in stderr_msg.lower():
+            logger.info("Interpreting error as no valid HEAD (empty repository) and returning count 0.")
+            return 0
+        else:
+            # Re-raise the exception for any unexpected errors.
+            raise e
+    except Exception as e:
+        logger.error(f"Unexpected error while counting commits: {str(e)}")
+        raise e
+
+    return commit_count
+"""
 def get_repo_commit_count(logger, facade_helper, repo_git):
 
 	repo = get_repo_by_repo_git(repo_git)
@@ -217,3 +271,4 @@ def update_facade_scheduling_fields(repo_git, weight, commit_count):
 
 
 
+"""

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -148,7 +148,13 @@ def get_repo_commit_count(logger, facade_helper, repo_git):
 
 	# Check if the .git directory exists
 	if not os.path.exists(repo_loc):
-		raise FileNotFoundError(f"The directory {absolute_path} does not exist.")
+		try:
+			logger.error(f"Ran into an error with {repo_loc}. Checking another strategy without .git extension.")
+			repo_loc = absolute_path 
+			if not os.path.exists(repo_loc):
+				raise FileNotFoundError(f"The directory {repo_loc} does not exist.")
+		except Exception as e: 
+			raise FileNotFoundError(f"The directory {absolute_path} does not exist, also {repo_loc} does not exist.")
 	
 	# if there are no branches then the repo is empty
 	if count_branches(repo_loc) == 0:


### PR DESCRIPTION
**Description**
- Various flavors of this error occur if there is any issue with the commit history: 
```bash
Traceback (most recent call last):
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/ai.chaoss/augur/tasks/git/facade_tasks.py", line 366, in git_update_commit_count_weight
    commit_count = get_repo_commit_count(logger, facade_helper, repo_git)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/ai.chaoss/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py", line 169, in get_repo_commit_count
    raise e
  File "/home/sean/github/ai.chaoss/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py", line 164, in get_repo_commit_count
    check_commit_count_cmd = check_output(
                             ^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', '--git-dir', '/mnt/external/ai-repos/mnt/repos/repos/hostedaugur/hosted/139113-github.com-spring-projects-spring-data-commons/spring-data-commons/.git', 'rev-list', '--count', 'HEAD']' returned non-zero exit status 128.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/redis.py", line 520, in on_chord_part_return
    resl = [unpack(tup, decode) for tup in resl]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/redis.py", line 520, in <listcomp>
    resl = [unpack(tup, decode) for tup in resl]
            ^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/redis.py", line 426, in _unpack_chord_result
    raise ChordError(f'Dependency {tid} raised {retval!r}')
celery.exceptions.ChordError: Dependency 123fb7d4-2b7d-4ad7-975c-17379f9d1e89 raised CalledProcessError(128, ['git', '--git-dir', '/mnt/external/ai-repos/mnt/repos/repos/hostedaugur/hosted/139113-github.com-spring-projects-spring-data-commons/spring-data-commons/.git', 'rev-list', '--count', 'HEAD'])

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/app/trace.py", line 468, in trace_task
    I, R, state, retval = on_error(task_request, exc, uuid)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/app/trace.py", line 379, in on_error
    R = I.handle_error_state(
        ^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/app/trace.py", line 178, in handle_error_state
    return {
           ^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/app/trace.py", line 225, in handle_failure
    task.backend.mark_as_failure(
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 217, in mark_as_failure
    self.on_chord_part_return(chain_elem_ctx, state, exc)
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/redis.py", line 539, in on_chord_part_return
    return self.chord_error_from_stack(callback, exc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 309, in chord_error_from_stack
    return backend.fail_from_current_stack(callback.id, exc=exc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 316, in fail_from_current_stack
    self.mark_as_failure(task_id, exc, exception_info.traceback)
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 172, in mark_as_failure
    self.store_result(task_id, exc, state,
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 528, in store_result
    self._store_result(task_id, result, state, traceback,
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 956, in _store_result
    current_meta = self._get_task_meta_for(task_id)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 978, in _get_task_meta_for
    meta = self.get(self.get_key_for_task(task_id))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/sean/github/virtualenv/ai/lib/python3.11/site-packages/celery/backends/base.py", line 856, in get_key_for_task
    return key_t('').join([
           ^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected a bytes-like object, NoneType found
```


This PR fixes that issue. 
