### PR TITLE
Allow log directory to be specified

### DIFF
--- a/augur/application/cli/config.py
+++ b/augur/application/cli/config.py
@@ -29,11 +29,12 @@ def cli(ctx):
 @click.option('--gitlab-api-key', help="GitLab API key for data collection from the GitLab API", envvar=ENVVAR_PREFIX + 'GITLAB_API_KEY')
 @click.option('--redis-conn-string', help="String to connect to redis cache", envvar=ENVVAR_PREFIX + 'REDIS_CONN_STRING')
 @click.option('--rabbitmq-conn-string', help="String to connect to rabbitmq broker", envvar=ENVVAR_PREFIX + 'RABBITMQ_CONN_STRING')
+@click.option('--logs-directory', help="Directory to store logs", envvar=ENVVAR_PREFIX + 'LOGS_DIRECTORY')
 @test_connection
 @test_db_connection
 @with_database
 @click.pass_context
-def init_config(ctx, github_api_key, facade_repo_directory, gitlab_api_key, redis_conn_string, rabbitmq_conn_string):
+def init_config(ctx, github_api_key, facade_repo_directory, gitlab_api_key, redis_conn_string, rabbitmq_conn_string, logs_directory):
 
     if not github_api_key:
 
@@ -99,7 +100,7 @@ def init_config(ctx, github_api_key, facade_repo_directory, gitlab_api_key, redi
 
         default_config["Facade"]["repo_directory"] = facade_repo_directory
 
-        default_config["Logging"]["logs_directory"] = ROOT_AUGUR_DIRECTORY + "/logs/"
+        default_config["Logging"]["logs_directory"] = logs_directory or (ROOT_AUGUR_DIRECTORY + "/logs/")
 
         config.load_config_from_dict(default_config)
 
@@ -263,5 +264,3 @@ def clear_config(ctx):
         config.clear()
 
         print("Config cleared")
-
-

--- a/augur/application/logs.py
+++ b/augur/application/logs.py
@@ -198,7 +198,12 @@ class AugurLogger():
         if reset_logfiles is True:
             try:
                 print("(augur) Reseting log files")
-                shutil.rmtree(base_log_dir)
+                base_log_dir_path = Path(base_log_dir)
+                for item in base_log_dir_path.iterdir():
+                    if item.is_dir():
+                        shutil.rmtree(item, ignore_errors=True)
+                    else:
+                        item.unlink(missing_ok=True)
             except FileNotFoundError as e:
                 pass
 
@@ -236,4 +241,3 @@ class AugurLogger():
 
     def get_logger(self):
         return self.lg
-

--- a/docker/backend/init.sh
+++ b/docker/backend/init.sh
@@ -19,11 +19,6 @@ if [[ -f /repos.csv ]]; then
    augur db add-repos /repos.csv
 fi
 
-if [[ -d /augur/logs ]]; then
-    echo "The directory exists" > /augur/logs/log.holder
-
-fi
-
 echo $PATH
 
 exec augur backend start

--- a/scripts/install/config.sh
+++ b/scripts/install/config.sh
@@ -219,7 +219,7 @@ function create_config() {
 
     #special case for docker entrypoint
     if [ $target = "docker" ]; then
-      cmd=( augur config init --github-api-key $github_api_key --gitlab-api-key $gitlab_api_key --facade-repo-directory $facade_repo_directory --redis-conn-string $redis_conn_string --rabbitmq-conn-string $rabbitmq_conn_string )
+      cmd=( augur config init --github-api-key $github_api_key --gitlab-api-key $gitlab_api_key --facade-repo-directory $facade_repo_directory --redis-conn-string $redis_conn_string --rabbitmq-conn-string $rabbitmq_conn_string --logs-directory /logs)
       echo "init with redis $redis_conn_string"
     else
       cmd=( augur config init --github-api-key $github_api_key --gitlab-api-key $gitlab_api_key --facade-repo-directory $facade_repo_directory --rabbitmq-conn-string $rabbitmq_conn_string )


### PR DESCRIPTION
**Description**
- `augur config init` now takes a parameter for the log file location
- Log file location in the docker container has been moved to /logs
- Log file "reset" step now deletes the *contents* of the log directory, not the directory itself

Related to #3107 

**Notes for Reviewers**
This is a step toward the non-root container in that it gets the log files out of a privileged location. The behavior for non-docker instances should be unchanged.

**Signed commits**
- [x] Yes, I signed my commits.