### PR TITLE
Configure key orchestrator to run in an independent container

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -126,7 +126,8 @@ def start(ctx, disable_collection, development, pidfile, port):
     keypub = KeyPublisher()
     
     if not disable_collection:
-        orchestrator = subprocess.Popen("python keyman/Orchestrator.py".split())
+        if os.environ.get('AUGUR_DOCKER_DEPLOY') != "1":
+            orchestrator = subprocess.Popen("python keyman/Orchestrator.py".split())
 
         # Wait for orchestrator startup
         if not keypub.wait(republish=True):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,18 @@ services:
     image: "redis:alpine"
     networks:
       - augur
-
+  augur-keyman:
+    image: augur-keyman
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: ./docker/keyman/Dockerfile
+    environment:
+      - REDIS_CONN_STRING=redis://redis:6379
+    depends_on:
+      - redis
+    networks:
+      - augur
   rabbitmq:
     image: augur-rabbitmq
     build:
@@ -58,6 +69,7 @@ services:
     depends_on:
       - augur-db
       - redis
+      - augur-keyman
       - rabbitmq
     networks:
       - augur

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -100,8 +100,6 @@ COPY ./setup.py .
 COPY ./scripts/ scripts/
 COPY ./keyman/ keyman/
 
-
-
 RUN python3 -m venv /opt/venv
 
 RUN set -x \

--- a/docker/keyman/Dockerfile
+++ b/docker/keyman/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11.12-alpine
+
+RUN pip install --upgrade pip 
+
+RUN pip install redis==4.3.3
+
+ENV KEYMAN_DOCKER=1
+ENV PYTHONPATH="${PYTHONPATH}:/augur"
+
+WORKDIR /augur
+COPY ./keyman keyman/
+
+ENTRYPOINT [ "python", "/augur/keyman/Orchestrator.py" ]


### PR DESCRIPTION
**Description**
- Add docker detection to key orchestrator entrypoint
- Add keyman Dockerfile
- Update backend start command to avoid starting keyman in docker

**TESTING**
Has not been tested on bare metal, will need testing to verify bare-metal functionality remains

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->