### PR TITLE
Don't log GitHub and Gitlab credentials

### DIFF
--- a/scripts/install/config.sh
+++ b/scripts/install/config.sh
@@ -147,7 +147,7 @@ function create_config() {
         get_github_api_key
     else
         echo
-        echo "Found AUGUR_GITHUB_API_KEY environment variable with value $AUGUR_GITHUB_API_KEY"
+        echo "Found AUGUR_GITHUB_API_KEY environment variable"
         echo "Using it in the config"
         echo "Please unset AUGUR_GITHUB_API_KEY if you would like to be prompted for a github api key"
         github_api_key=$AUGUR_GITHUB_API_KEY
@@ -158,7 +158,7 @@ function create_config() {
         get_github_username
     else
         echo
-        echo "Found AUGUR_GITHUB_USERNAME environment variable with value $AUGUR_GITHUB_USERNAME"
+        echo "Found AUGUR_GITHUB_USERNAME environment variable"
         echo "Using it in the config"
         echo "Please unset AUGUR_GITHUB_USERNAME if you would like to be prompted for a github username"
         github_username=$AUGUR_GITHUB_USERNAME
@@ -169,7 +169,7 @@ function create_config() {
         get_gitlab_api_key
     else
         echo
-        echo "Found AUGUR_GITLAB_API_KEY environment variable with value $AUGUR_GITLAB_API_KEY"
+        echo "Found AUGUR_GITLAB_API_KEY environment variable"
         echo "Using it in the config"
         echo "Please unset AUGUR_GITLAB_API_KEY if you would like to be prompted for a gitlab api key"
         gitlab_api_key=$AUGUR_GITLAB_API_KEY
@@ -180,7 +180,7 @@ function create_config() {
         get_gitlab_username
     else
         echo
-        echo "Found AUGUR_GITLAB_USERNAME environment variable with value $AUGUR_GITLAB_USERNAME"
+        echo "Found AUGUR_GITLAB_USERNAME environment variable"
         echo "Using it in the config"
         echo "Please unset AUGUR_GITLAB_USERNAME if you would like to be prompted for a gitlab username"
         gitlab_username=$AUGUR_GITLAB_USERNAME


### PR DESCRIPTION
**Description**
Remove environment variable values from log messages to prevent sensitive information from being exposed. This change improves security by not displaying API keys and usernames in the console output.

This is particularly an issue in containerized environments (e.g., docker/kube/openshift) where the logs are preserved indefinitely and potentially shipped off-cluster.

This PR fixes #

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->