### PR TITLE
force consistency for debian version 

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 
-FROM golang:1.23 AS golang
+FROM golang:1.23-bullseye AS golang
 
 
 # RUN ./scripts/docker/install-go.sh


### PR DESCRIPTION
The Augur container uses debian 11 but without specifying bullseye golang 1.23 uses 12. This impacts scc and scorecard as incompatible versions are brought in. The stable release of debian 12 (bookworm) was released on March 15th so this issue has popped up relatively recent. I will open an issue as well on if this is the right long term fix 