### PR TITLE
Fix DB dockerfile env var warning

### DIFF
--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -4,9 +4,9 @@ FROM postgres:16
 LABEL maintainer="outdoors@acm.org"
 LABEL version="0.86.1"
 
-ENV POSTGRES_DB "test"
-ENV POSTGRES_USER "augur"
-ENV POSTGRES_PASSWORD "augur"
+ENV POSTGRES_DB="test"
+ENV POSTGRES_USER="augur"
+ENV POSTGRES_PASSWORD="augur"
 
 EXPOSE 5432
 


### PR DESCRIPTION
**Description**

Fixed warning about "Legacy key/value format with whitespace separator should not be used" in Dockerfiles

This PR fixes #

**Notes for Reviewers**

**Signed commits**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->