### PR TITLE
Main bug fix: line missed in bug fix to allow non root user

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -113,5 +113,6 @@ RUN ln -s /cache /augur/augur/static/cache
 
 COPY --chmod=u=rwx,go=rx ./docker/backend/entrypoint.sh /
 COPY --chmod=u=rwx,go=rx ./docker/backend/init.sh /
+RUN chmod +x /entrypoint.sh /init.sh
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 CMD ["/init.sh"]


### PR DESCRIPTION
When I tried running the new release I hit the same issue of "/entrypoint.sh: line 27: /init.sh: Permission denied" This one line was necessary to be able to run the changes made in #3131 


Linked relevant issues/prs: #3131 #3150 