### PR TITLE
Add index pull_request_files.repo_id

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -3052,6 +3052,7 @@ class PullRequestEvent(Base):
 class PullRequestFile(Base):
     __tablename__ = "pull_request_files"
     __table_args__ = (
+        Index("repo_id"),
         UniqueConstraint("pull_request_id", "repo_id", "pr_file_path"),
         {
             "schema": "augur_data",


### PR DESCRIPTION
**Description**

Add an index on pull_request_files.repo_id, since that column supports a foriegn key, and it's a good idea to index any FK column on a large table unless it's extremely low cardinality.

This PR fixes #

No issue filed; change discussed in Slack.

**Notes for Reviewers**

Are there migrations somewhere I also need to update?  Or will folks just pick this up from base SQLAlchemy migrations?

**Signed commits**
- [x] Yes, I signed my commits.