### PR TITLE
Push the keyman container image

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -145,6 +145,7 @@ jobs:
         image:
           - backend
           - database
+          - keyman
           - rabbitmq
     runs-on: ubuntu-latest
     steps:
@@ -157,7 +158,6 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
**Description**
- Now that keyman is a separate container, we should push that image to ghcr.io as well

This PR fixes #

**Notes for Reviewers**
- I also removed a conditional on the login step since the whole job now only runs when it's not a PR.

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->