### PR TITLE
Encode non-utf8 chars as bytes in analyze_commit

### DIFF
--- a/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
@@ -173,7 +173,7 @@ def analyze_commit(
     try:
         commit_message = check_output(
             f"git --git-dir {repo_loc} log --format=%B -n 1 {commit}".split()
-        ).decode('utf-8').strip()
+        ).decode('utf-8', errors="backslashreplace").strip()
     except CalledProcessError as e:
         logger.error(f"Git failed to retrieve commit message for {commit}: {e}")
         commit_message = "<invalid commit message>"


### PR DESCRIPTION
**Description**
- Use `errors = "backslashreplace"` in decode to avoid non-utf8 characters in commit messages

The git log does not store character encoding metadata afaik, and there is no way to programmatically determine what encoding was used with 100% accuracy. En lieu of that, we can just encode the raw bytes directly into the string as a UTF-8 escaped byte sequence.

As an example:

Commit [25120e32fd761df284df417b7ebfa1cb8560fba7](https://github.com/jboss-logging/slf4j/commit/25120e32fd761df284df417b7ebfa1cb8560fba7) was encoded with `windows-1252`, and should read:
> Added a link to Thorbjørn's article on SLF4J...

However, this exact byte sequence can be decoded with `windows-1250` or `windows-1251`, or any other number of compatible encodings, and each one would lead to a different UTF8-encoding, respectively:
> Added a link to Thorbjřrn's article on SLF4J...

> Added a link to Thorbjшrn's article on SLF4J...

This change decodes the above commit message to:
> Added a link to Thorbj\\xf8rn's article on SLF4J...

Which leaves the original information intact, without the need to guess at which encoding to use.

This PR fixes #3165 

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->