### PR TITLE
Handle 410 gone when querying github

### DIFF
--- a/augur/tasks/github/util/github_data_access.py
+++ b/augur/tasks/github/util/github_data_access.py
@@ -163,13 +163,16 @@ class GithubDataAccess:
             return self.__make_request_with_retries(url, method, timeout)
         except RetryError as e:
             raise e.last_attempt.exception()
+
+    def _decide_retry_policy(exception):
+        return not isinstance(num, (UrlNotFoundException, ResourceGoneException))
         
-    @retry(stop=stop_after_attempt(10), wait=wait_fixed(5), retry=retry_if_exception(lambda exc: not isinstance(exc, UrlNotFoundException)))
+    @retry(stop=stop_after_attempt(10), wait=wait_fixed(5), retry=retry_if_exception(_decide_retry_policy))
     def __make_request_with_retries(self, url, method="GET", timeout=100):
         """ What method does?
             1. Retires 10 times
             2. Waits 5 seconds between retires
-            3. Does not rety UrlNotFoundException
+            3. Does not retry any exceptions excluded by _decide_retry_policy
             4. Catches RatelimitException and waits or expires key before raising exception
         """
 

--- a/augur/tasks/github/util/github_data_access.py
+++ b/augur/tasks/github/util/github_data_access.py
@@ -164,7 +164,12 @@ class GithubDataAccess:
         except RetryError as e:
             raise e.last_attempt.exception()
 
-    def _decide_retry_policy(exception):
+    def _decide_retry_policy(exception: Exception) -> bool:
+        """Defines whether or not to retry a failed request based on the exception thrown
+
+        Returns:
+            bool: Boolean describing whether or not the request should be retried
+        """
         return not isinstance(num, (UrlNotFoundException, ResourceGoneException))
         
     @retry(stop=stop_after_attempt(10), wait=wait_fixed(5), retry=retry_if_exception(_decide_retry_policy))


### PR DESCRIPTION
This may happen if requesting issues or issue comments when issues have been disabled for a repo

**Description**
- added exception type for 410 Gone errors
- handle these exceptions in the request retry process so they dont throw an exception

This PR fixes #3191 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->