### PR TITLE
Gitlab Mr Metadata Improvements

### DIFF
--- a/augur/application/db/data_parse.py
+++ b/augur/application/db/data_parse.py
@@ -1088,17 +1088,21 @@ def extract_needed_mr_metadata(mr_dict, repo_id, pull_request_id, tool_source, t
     Returns:
         List of dicts of parsed mr metadata
     """
-    head = {'sha': mr_dict['diff_refs']['head_sha'],
+
+    diff_refs = mr_dict['diff_refs']
+    author = mr_dict['author']
+
+    head = {'sha': diff_refs['head_sha'],
             'ref': mr_dict['target_branch'],
             'label': str(mr_dict['target_project_id']) + ':' + mr_dict['target_branch'],
-            'author': mr_dict['author']['username'],
+            'author': author['username'],
             'repo': str(mr_dict['target_project_id'])
             }
 
-    base = {'sha': mr_dict['diff_refs']['base_sha'],
+    base = {'sha': diff_refs['base_sha'],
             'ref': mr_dict['source_branch'],
             'label': str(mr_dict['source_project_id']) + ':' + mr_dict['source_branch'],
-            'author': mr_dict['author']['username'],
+            'author': author['username'],
             'repo': str(mr_dict['source_project_id'])
             }
 

--- a/augur/application/db/data_parse.py
+++ b/augur/application/db/data_parse.py
@@ -1089,20 +1089,19 @@ def extract_needed_mr_metadata(mr_dict, repo_id, pull_request_id, tool_source, t
         List of dicts of parsed mr metadata
     """
 
-    diff_refs = mr_dict['diff_refs']
-    author = mr_dict['author']
+    diff_refs = mr_dict.get('diff_refs', {})
 
-    head = {'sha': diff_refs['head_sha'],
+    head = {'sha': diff_refs.get('head_sha', None),
             'ref': mr_dict['target_branch'],
             'label': str(mr_dict['target_project_id']) + ':' + mr_dict['target_branch'],
-            'author': author['username'],
+            'author': mr_dict['author']['username'],
             'repo': str(mr_dict['target_project_id'])
             }
 
-    base = {'sha': diff_refs['base_sha'],
+    base = {'sha': diff_refs.get('base_sha', None),
             'ref': mr_dict['source_branch'],
             'label': str(mr_dict['source_project_id']) + ':' + mr_dict['source_branch'],
-            'author': author['username'],
+            'author': mr_dict['author']['username'],
             'repo': str(mr_dict['source_project_id'])
             }
 

--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -102,41 +102,41 @@ class AugurCoreRepoCollectionTask(celery.Task):
                 session.commit()
 
     def on_failure(self,exc,task_id,args, kwargs, einfo):
-        repo_git = extract_repo_git(args, kwargs)
+        repo_git = self._extract_repo_git(args, kwargs)
         # log traceback to error file
         self.augur_handle_task_failure(exc, task_id, repo_git, "core_task_failure")
+
+    def _extract_repo_git(self, args, kwargs):
+        if 'repo_git' in kwargs:
+            return kwargs['repo_git']
+        
+        sig = inspect.signature(self.run)
+        param_names = list(sig.parameters.keys())
+
+        try:
+            index = param_names.index('repo_git')
+            return args[index]
+        except (ValueError, IndexError):
+            pass
+
+        return None 
 
 class AugurSecondaryRepoCollectionTask(AugurCoreRepoCollectionTask):
     def on_failure(self,exc,task_id,args, kwargs, einfo):
         
-        repo_git = extract_repo_git(args, kwargs)
+        repo_git = self._extract_repo_git(args, kwargs)
         self.augur_handle_task_failure(exc, task_id, repo_git, "secondary_task_failure",collection_hook='secondary')
 
 class AugurFacadeRepoCollectionTask(AugurCoreRepoCollectionTask):
     def on_failure(self,exc,task_id,args, kwargs, einfo):
-        repo_git = extract_repo_git(args, kwargs)
+        repo_git = self._extract_repo_git(args, kwargs)
         self.augur_handle_task_failure(exc, task_id, repo_git, "facade_task_failure",collection_hook='facade')
 
 class AugurMlRepoCollectionTask(AugurCoreRepoCollectionTask):
     def on_failure(self,exc,task_id,args,kwargs,einfo):
-        repo_git = extract_repo_git(args, kwargs)
+        repo_git = self._extract_repo_git(args, kwargs)
         self.augur_handle_task_failure(exc,task_id,repo_git, "ml_task_failure", collection_hook='ml')
 
-
-def extract_repo_git(self, args, kwargs):
-    if 'repo_git' in kwargs:
-        return kwargs['repo_git']
-    
-    sig = inspect.signature(self.run)
-    param_names = list(sig.parameters.keys())
-
-    try:
-        index = param_names.index('repo_git')
-        return args[index]
-    except (ValueError, IndexError):
-        pass
-
-    return None  # If not found
 
 
 #task_cls='augur.tasks.init.celery_app:AugurCoreRepoCollectionTask'


### PR DESCRIPTION
**Description**
- The issue #3185 shows a NoneType exception happenening when trying to retrieve the `head_sha`, so I fixed this by providing a default value of None if the diff_refs are missing or head_sha or base_sha.
- Additionally the issue pointed out that the failure handler was assuming that the first paramater to the task would be repo_git, but it this task it can't be the first paramater the celery chain is passing the mr_ids to the first param in the task. To fix this I implemented a method to search the methods parameters for the repo_git parameter. 

This PR fixes #
#3185


**Signed commits**
- [X] Yes, I signed my commits.
