### PR TITLE
fixing make clean to preserve uv.lock

### DIFF
--- a/scripts/control/clean.sh
+++ b/scripts/control/clean.sh
@@ -14,7 +14,8 @@ echo "Cleaning output files..."
 find . -name \*.out -delete
 find . -name \*.log -delete
 find . -name \*.err -delete
-find . -type f -name "*.lock" -delete
+find . -type f -name "*.lock" ! -name "uv.lock" -delete
+
 rm -rf logs/
 
 echo "Removing build files..."


### PR DESCRIPTION
**Description**
- fixing `make rebuild` so it does not delete `uv.lock`
- fixes #3209 