### PR TITLE
limit large glob operation in gunicorn config

### DIFF
--- a/augur/api/gunicorn_conf.py
+++ b/augur/api/gunicorn_conf.py
@@ -19,7 +19,17 @@ logger = logging.getLogger(__name__)
 workers = multiprocessing.cpu_count() * 2 + 1
 umask = 0o007
 reload = True
-reload_extra_files = glob(str(Path.cwd() / '**/*.j2'), recursive=True)
+
+augur_templates_dir = Path.cwd() / "augur/templates"
+
+if not augur_templates_dir.is_dir():
+    logger.critical("Could not locate templates in Gunicorn startup")
+    exit(-1)
+
+reload_extra_files = glob(str(augur_templates_dir.resolve() / '**/*.j2'), recursive=True)
+
+# Don't  want to leave extraneous variables in config scope
+del augur_templates_dir
 
 # set the log location for gunicorn    
 logs_directory = get_value('Logging', 'logs_directory')

--- a/augur/api/gunicorn_conf.py
+++ b/augur/api/gunicorn_conf.py
@@ -1,6 +1,7 @@
 # from augur import ROOT_AUGUR_DIRECTORY
 import multiprocessing
 import logging
+import os
 from pathlib import Path
 from glob import glob
 
@@ -20,16 +21,21 @@ workers = multiprocessing.cpu_count() * 2 + 1
 umask = 0o007
 reload = True
 
-augur_templates_dir = Path.cwd() / "augur/templates"
+is_dev = os.getenv("AUGUR_DEV", 'False').lower() in ('true', '1', 't', 'y', 'yes')
 
-if not augur_templates_dir.is_dir():
-    logger.critical("Could not locate templates in Gunicorn startup")
-    exit(-1)
+if is_dev:
 
-reload_extra_files = glob(str(augur_templates_dir.resolve() / '**/*.j2'), recursive=True)
+    augur_templates_dir = Path.cwd() / "augur/templates"
 
-# Don't  want to leave extraneous variables in config scope
-del augur_templates_dir
+    if not augur_templates_dir.is_dir():
+        logger.critical("Could not locate templates in Gunicorn startup")
+        exit(-1)
+
+    reload_extra_files = glob(str(augur_templates_dir.resolve() / '**/*.j2'), recursive=True)
+
+    # Don't  want to leave extraneous variables in config scope
+    del augur_templates_dir
+del is_dev
 
 # set the log location for gunicorn    
 logs_directory = get_value('Logging', 'logs_directory')


### PR DESCRIPTION
**Description**
This change removes a line of code from gunicorn config that performs a recursive glob operation for seemingly no purpose since the variable it assigns the results to is unused

This might help with performance somewhat, and in worst cases, helps prevent instances from accidentally self-DOS ing if they happen to store the fascade repository clones in the path of this glob (therefore looking at and processing all jinja2 files in all repositories being analyzed by augur)

**Notes for Reviewers**
This change has been deployed in prod in the Red Hat augur instance for a while without causing issues. It was put in place by previous sysadmins and has therefore been thoroughly reviewed by at least one other experienced person in addition to my searching for uses of this variable in the codebase

Fixes #2958 

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->