### PR TITLE
determine whether to reset logs via new  AUGUR_RESET_LOGS environment variable

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -32,7 +32,9 @@ import sqlalchemy as s
 
 from keyman.KeyClient import KeyClient, KeyPublisher
 
-logger = AugurLogger("augur", reset_logfiles=True).get_logger()
+reset_logs = os.getenv("AUGUR_RESET_LOGS", 'True').lower() in ('true', '1', 't', 'y', 'yes')
+
+logger = AugurLogger("augur", reset_logfiles=reset_logs).get_logger()
 
 
 @click.group('server', short_help='Commands for controlling the backend API server & data collection workers')


### PR DESCRIPTION
This defaults to True to avoid infinite log growth unless explicitly opted in

**Description**
To give sysadmins more control over their instances, specifically with logging policy, this PR adds a new  `AUGUR_RESET_LOGS` environment variable. If the variable is not set, it defaults to True (the current behavior).

Setting this variable to a value other than True (or one of a few common variations) signifies that the sysadmin is taking responsibility for managing logs, and augur should not reset or clear logs on startup.

If desired, I could also add a log message that says (in big scary letters) that log resetting is disabled and that the sysdmin is responsible for log management. Let me know if this would be preferable.


**Signed commits**
- [X] Yes, I signed my commits.
