### PR TITLE
Update entrypoint.sh construction of AUGUR_DB from env vars

### DIFF
--- a/docker/backend/entrypoint.sh
+++ b/docker/backend/entrypoint.sh
@@ -3,14 +3,12 @@
 set -e
 
 if [[ -z "$AUGUR_DB" ]]; then
-    # Require AUGUR_DB_HOST, AUGUR_DB_USER, AUGUR_DB_PASSWORD, and AUGUR_DB_NAME to be set
-    if [[ -z "$AUGUR_DB_HOST" ]] || [[ -z "$AUGUR_DB_USER" ]] || [[ -z "$AUGUR_DB_PASSWORD" ]] || [[ -z "$AUGUR_DB_NAME" ]]; then
-        echo -e "When AUGUR_DB is not set, you must set AUGUR_DB_HOST, AUGUR_DB_USER,\nAUGUR_DB_PASSWORD, and AUGUR_DB_NAME"
-        exit 1
+    # If AUGUR_DB is not set, check for individual environment variables and construct AUGUR_DB connection string
+    if [[ -n "$AUGUR_DB_HOST" ]] && [[ -n "$AUGUR_DB_USER" ]] && [[ -n "$AUGUR_DB_PASSWORD" ]] && [[ -n "$AUGUR_DB_NAME" ]]; then
+        export AUGUR_DB="postgresql+psycopg2://${AUGUR_DB_USER}:${AUGUR_DB_PASSWORD}@${AUGUR_DB_HOST}/${AUGUR_DB_NAME}"
     fi
-    # Construct AUGUR_DB from the individual components
-    export AUGUR_DB="postgresql+psycopg2://${AUGUR_DB_USER}:${AUGUR_DB_PASSWORD}@${AUGUR_DB_HOST}/${AUGUR_DB_NAME}"
 fi
+
 
 if [[ "$AUGUR_DB" == *"localhost"* ]]; then
     echo "localhost db connection"


### PR DESCRIPTION
**Description**
- This changes the test for the DB connection components to not exit with failure if AUGUR_DB can't be constructed.

Fixes #3225 