### PR TITLE
use check_output for git log fetching so that it can fail more easily

### DIFF
--- a/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
@@ -149,14 +149,19 @@ def analyze_commit(
     recordsToInsert: List[Dict[str, Any]] = []
 
     try:
-        git_log = subprocess.Popen(
-            ["git --git-dir %s log -p -M %s -n1 "
-             "--pretty=format:'"
-             "author_name: %%an%%nauthor_email: %%ae%%nauthor_date:%%ai%%n"
-             "committer_name: %%cn%%ncommitter_email: %%ce%%ncommitter_date: %%ci%%n"
-             "parents: %%p%%nEndPatch' " % (repo_loc, commit)],
-            stdout=subprocess.PIPE,
-            shell=True
+        pretty_format = (
+            "author_name: %an%n"
+            "author_email: %ae%n"
+            "author_date:%ai%n"
+            "committer_name: %cn%n"
+            "committer_email: %ce%n"
+            "committer_date: %ci%n"
+            "parents: %p%n"
+            "EndPatch"
+        )
+        git_log = check_output(
+            [f"git", "--git-dir", repo_loc, "log", "-p", "-M", commit, "-n1",
+             f"--pretty=format:'{pretty_format}'"]
         )
     except Exception as e:
         logger.error(f"Failed to run git log for commit {commit}: {e}")
@@ -189,7 +194,7 @@ def analyze_commit(
     }
 
     try:
-        log_output = git_log.stdout.read().decode("utf-8", errors="ignore")
+        log_output = git_log.decode("utf-8", errors="ignore")
     except Exception as e:
         logger.error(f"Failed to read stdout from git process for commit {commit}: {e}")
         return [], msg_record


### PR DESCRIPTION
**Description**
This PR attempts to address the problem of analyze_commits_in_parallel hanging as mentioned in https://github.com/chaoss/augur/issues/3228

It does so by using the same `check_output` method of running git shell commands as can be seen in the rest of the `analyze_commit` function. This method of running commands has a lot more error handling capabilities than `Popen` (which was used before) and can thus fail on conditions such as a nonzero exit code, allowing the facade task to fail and therefore allowing other tasks to run in that time (while allowing us to go in and diagnose the failure) 

**Signed commits**
- [X] Yes, I signed my commits.
