### PR TITLE
Fix variable name in _decide_retry_policy

### DIFF
--- a/augur/tasks/github/util/github_data_access.py
+++ b/augur/tasks/github/util/github_data_access.py
@@ -170,7 +170,7 @@ class GithubDataAccess:
         Returns:
             bool: Boolean describing whether or not the request should be retried
         """
-        return not isinstance(num, (UrlNotFoundException, ResourceGoneException))
+        return not isinstance(exception, (UrlNotFoundException, ResourceGoneException))
         
     @retry(stop=stop_after_attempt(10), wait=wait_fixed(5), retry=retry_if_exception(_decide_retry_policy))
     def __make_request_with_retries(self, url, method="GET", timeout=100):


### PR DESCRIPTION
**Description**
- corrects a small mistake causing github API queries to not be particularly happy. 

fixes #3234 

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->