### PR TITLE
cache redis connection on first retrieval

### DIFF
--- a/augur/tasks/init/redis_connection.py
+++ b/augur/tasks/init/redis_connection.py
@@ -4,9 +4,11 @@ from augur.tasks.init import get_redis_conn_values
 
 
 def get_redis_connection():
+    global redis_connection
 
-    redis_db_number, redis_conn_string = get_redis_conn_values()
-
-    redis_connection= redis.from_url(f'{redis_conn_string}{redis_db_number+2}', decode_responses=True)
+    # Only load the redis connection values once
+    if "redis_connection" not in globals():
+        redis_db_number, redis_conn_string = get_redis_conn_values()
+        redis_connection = redis.from_url(f'{redis_conn_string}{redis_db_number+2}', decode_responses=True)
 
     return redis_connection


### PR DESCRIPTION
**Description**
- Avoid recreating Redis connection on every request
- Cache connection info for the life of the process

This PR is intended to determine if the process of creating a Redis connection creates a non-closeable database session.

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->