### PR TITLE
add date filter to contributer resolution logic queries

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -112,8 +112,6 @@ def trim_commits_post_analysis_facade_task(repo_git):
     repo = repo = get_repo_by_repo_git(repo_git)
     repo_id = repo.repo_id
 
-    start_date = facade_helper.get_setting('start_date')
-    
     logger.info(f"Generating sequence for repo {repo_id}")
 
     repo = get_repo_by_repo_git(repo_git)
@@ -123,7 +121,7 @@ def trim_commits_post_analysis_facade_task(repo_git):
     repo_loc = (f"{absolute_path}/.git")
     # Grab the parents of HEAD
 
-    parent_commits = get_parent_commits_set(repo_loc, start_date)
+    parent_commits = get_parent_commits_set(repo_loc)
 
     # Grab the existing commits from the database
     existing_commits = get_existing_commits_set(repo_id)
@@ -237,7 +235,7 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
     repo = get_repo_by_repo_git(repo_git)
     repo_id = repo.repo_id
 
-    start_date = facade_helper.get_setting('start_date')
+    start_date = facade_helper.get_last_collected_commit_date(repo_id)#.get_setting('start_date')
 
     logger.info(f"Generating sequence for repo {repo_id}")
     
@@ -438,11 +436,6 @@ def generate_analysis_sequence(logger,repo_git, facade_helper):
 
     analysis_sequence = []
 
-    #repo_list = s.sql.text("""SELECT repo_id,repo_group_id,repo_path,repo_name FROM repo WHERE repo_git=:value""").bindparams(value=repo_git)
-    #repos = fetchall_data_from_sql_text(repo_list)
-
-    start_date = facade_helper.get_setting('start_date')
-
     #repo_ids = [repo['repo_id'] for repo in repos]
 
     #repo_id = repo_ids.pop(0)
@@ -472,8 +465,6 @@ def facade_phase(repo_git, full_collection):
     #Get the repo_id
     #repo_list = s.sql.text("""SELECT repo_id,repo_group_id,repo_path,repo_name FROM repo WHERE repo_git=:value""").bindparams(value=repo_git)
     #repos = fetchall_data_from_sql_text(repo_list)
-
-    start_date = facade_helper.get_setting('start_date')
 
     #repo_ids = [repo['repo_id'] for repo in repos]
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -235,8 +235,6 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
     repo = get_repo_by_repo_git(repo_git)
     repo_id = repo.repo_id
 
-    start_date = facade_helper.get_last_collected_commit_date(repo_id)#.get_setting('start_date')
-
     logger.info(f"Generating sequence for repo {repo_id}")
     
     repo = get_repo_by_repo_id(repo_id)
@@ -246,7 +244,7 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
     repo_loc = (f"{absolute_path}/.git")
     # Grab the parents of HEAD
 
-    parent_commits = get_parent_commits_set(repo_loc, start_date)
+    parent_commits = get_parent_commits_set(repo_loc)
 
     # Grab the existing commits from the database
     existing_commits = get_existing_commits_set(repo_id)

--- a/augur/tasks/git/util/facade_worker/facade_worker/config.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/config.py
@@ -244,6 +244,17 @@ class FacadeHelper():
             return
     def inc_repos_processed(self):
         self.repos_processed += 1
+    
+    def get_last_collected_commit_date(self,repo_id):
+        commit_date_query = s.sql.text("""
+        SELECT cmt_committer_timestamp FROM commits 
+        WHERE repo_id=:repo_id 
+        ORDER BY data_collection_date DESC
+        LIMIT 1;
+        """).bindparams(repo_id=repo_id)
+
+        result = execute_sql(commit_date_query).fetchone()
+        return result[0]
 
 """
 class FacadeConfig:

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -105,10 +105,10 @@ def get_absolute_repo_path(repo_base_dir, repo_id, repo_path,repo_name):
 	
 	return f"{repo_base_dir}{repo_id}-{repo_path}/{repo_name}"
 
-def get_parent_commits_set(absolute_repo_path, start_date):
+def get_parent_commits_set(absolute_repo_path):
 	
 	parents = subprocess.Popen(["git --git-dir %s log --ignore-missing "
-								"--pretty=format:'%%H' --since=%s" % (absolute_repo_path,start_date)],
+								"--pretty=format:'%%H'" % (absolute_repo_path)],
 	stdout=subprocess.PIPE, shell=True)
 
 	parent_commits = set(parents.stdout.read().decode("utf-8",errors="ignore").split(os.linesep))


### PR DESCRIPTION
**Description**
- Add a date filter to the Facade contributer resolution logic
- Now, we will only use commits that have appeared since last time facade was ran in contributer resolution
- I have also removed the start_date setting because it wasn't doing anything 
- Added a helper function for if we need to get the date that the last commit was added

**Signed commits**
- [x] Yes, I signed my commits.
