### PR TITLE
Add dockerfile for performing an empty database build

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -300,6 +300,7 @@ jobs:
           - database
           - keyman
           - rabbitmq
+          - empty_database
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/docker/empty_database/Dockerfile
+++ b/docker/empty_database/Dockerfile
@@ -1,0 +1,66 @@
+from postgres:16 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install uv (https://docs.astral.sh/uv/guides/integration/docker/#installing-uv)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+ENV UV_COMPILE_BYTECODE=1
+# The uv package cache will be on a cache volume, so can't be linked
+ENV UV_LINK_MODE=copy
+# Assert that the lockfile (uv.lock) is up-to-date. Use `uv lock` to update it
+# manually if this fails the container build.
+ENV UV_LOCKED=1
+
+WORKDIR /augur
+
+COPY pyproject.toml .
+COPY uv.lock .
+COPY .python-version .
+
+# Install augur's dependencies early to take advantage of build cache
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --no-install-project --no-dev
+
+# Copy in the actual code
+# The RUN line below ensure that permissions are set correctly.
+# This is the equivalent of the following docker --chmod flags, but done in a way thats compatible with podman.
+# This can be removed once https://github.com/containers/buildah/issues/6066 or relevant equivalent is fixed
+# - u=rw,u+X: user can read and write all files/dirs and execute directories
+# - go=r,go+X: group and others can read all files/dirs and execute directories
+COPY README.md .
+COPY LICENSE .
+COPY alembic.ini .
+COPY augur/ augur/
+COPY metadata.py .
+COPY scripts/ scripts/
+
+RUN find augur -type d -exec chmod u=rwx,go=rx {} + && find augur -type f -exec chmod u=rw,go=r {} +
+
+RUN find scripts -exec chmod u=rwx,go=rx {} +
+
+# Install the main project
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --no-dev
+
+# We aren't going to activate the virtualenv (manually or via uv run), so we
+# need adjust the PATH
+ENV PATH="/augur/.venv/bin:${PATH}"
+
+ENV POSTGRES_DB="augur"
+ENV POSTGRES_USER="augur"
+ENV POSTGRES_PASSWORD="augur"
+ENV AUGUR_DB="postgresql+psycopg2://augur:augur@localhost:5432/augur"
+# ENV PGDATA="/var/lib/postgresql/data"
+
+RUN set -e && \
+    gosu postgres initdb && \
+    gosu postgres pg_ctl -D "$PGDATA" -o "-c listen_addresses='localhost'" -w start && \
+    gosu postgres psql -c "CREATE USER ${POSTGRES_USER} WITH SUPERUSER PASSWORD '${POSTGRES_PASSWORD}';" && \
+    gosu postgres psql -c "CREATE DATABASE ${POSTGRES_DB} OWNER ${POSTGRES_USER};" && \
+    augur db create-schema && \
+    gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop
+
+
+FROM postgres:16
+
+COPY --from=builder /var/lib/postgresql/data /var/lib/postgresql/data


### PR DESCRIPTION
**Description**
I recently created https://github.com/orgs/chaoss/packages/container/package/augur_empty_database, a GHCR container containing an empty augur Database for the purposes of enabling a downstream project like 8Knot to run [CI jobs](https://github.com/oss-aspen/8Knot/pull/849) without needing to publish credentials to a publicly accessible database.

This container is a very thin wrapper around postgres 16 that ships postgres data for an empty augur db. While this intentionally violates usual docker conventions of storing postgres data in volumes, it does so to enable downstream projects to provide their CI jobs with SOMETHING to connect to in place of a real augur database for the purpose of testing.

This path was easier than attempts to create scripts that could [anonymize an existing augur db](https://github.com/chaoss/augur-utilities/pull/17) for use in CI jobs.

This PR adds a dockerfile that can ensure this empty database image stays up to date as the augur schema evolves, as well as includes it in the existing docker build pipeline.

**Notes for Reviewers**
This dockerfile is largely a copy paste of the existing backend docker compose with some things removed (keyman, etc) that are not likely to be needed for the sole purpose of running `augur db create-schema`.

If theres a way to COPY this augur CLI binary and reduce the duplication in build steps with this container, that would also be super helpful.

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->