### PR TITLE
Fix docs build: corrected filename 

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ Augur Documentation
    schema/toc
    login
    procedures/toc
+   running-in-production
 .. 
 
 ..

--- a/docs/source/running-in-production.md
+++ b/docs/source/running-in-production.md
@@ -1,0 +1,26 @@
+# Running Augur in Production
+
+This guide explains how to run Augur in a production environment.
+
+## Prerequisites
+- Docker and Docker Compose installed
+- PostgreSQL database configured
+- Redis installed and running
+
+## Environment Variables
+Make sure to configure the following environment variables:
+
+- `AUGUR_RESET_LOGS`: Determines whether logs should be reset on startup.
+- `REFRESH_MATERIALIZED_VIEWS_INTERVAL_IN_DAYS`: Controls how often materialized views are refreshed. (Default: 1 day)
+- `AUGUR_DB`: Database connection string
+- `AUGUR_REDIS_URL`: Redis connection string
+
+## Related Resources
+- [oss-aspen/infra-ansible](https://github.com/oss-aspen/infra-ansible/)
+- [chaoss/augur-utilities](https://github.com/chaoss/augur-utilities/)
+
+## Steps to Run
+1. Clone the repository
+   ```bash
+   git clone https://github.com/chaoss/augur.git
+   cd augur


### PR DESCRIPTION
**Description**
- Added `running-in-production.md` under `docs/source/`.
- Updated the `index.rst` toctree to include the new page.
- Fixed documentation build warnings caused by missing/misnamed files

This PR fixes #3249 

**Notes for Reviewers**
- Verified that both **Quick Start** and **Running in Production** appear correctly in the docs sidebar.
- Confirmed that the documentation builds without any warnings or errors.

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->