### PR TITLE
scheduling: refactor send_messages to de-duplicate code path

### DIFF
--- a/augur/tasks/util/collection_util.py
+++ b/augur/tasks/util/collection_util.py
@@ -597,37 +597,33 @@ class AugurTaskRoutine:
             for repo_git, full_collection in col_hook.repo_list:
 
                 repo = get_repo_by_repo_git(repo_git)
+                platform_name = "github"
+                # this needs to be here and not up a level since it should be set/reset for each repo.
+                # otherwise a gitlab repo would reset it and cause subsequent github repos to use gitlab phases.
+                phases = None
                 if "github" in repo.repo_git:
-                    augur_collection_sequence = []
-                    for job in col_hook.phases:
-                        #Add the phase to the sequence in order as a celery task.
-                        #The preliminary task creates the larger task chain 
-                        augur_collection_sequence.append(job(repo_git, full_collection))
+                    phases = col_hook.phases
+                    # use default platform name
 
-                    #augur_collection_sequence.append(core_task_success_util.si(repo_git))
-                    #Link all phases in a chain and send to celery
-                    augur_collection_chain = chain(*augur_collection_sequence)
-                    task_id = augur_collection_chain.apply_async().task_id
+                elif "gitlab" in repo.repo_git:
+                    platform_name = "gitlab"
+                    if col_hook.gitlab_phases is None:
+                        return
+                    phases = col_hook.gitlab_phases
+           
+                augur_collection_sequence = []
+                for job in phases:
+                    #Add the phase to the sequence in order as a celery task.
+                    #The preliminary task creates the larger task chain 
+                    augur_collection_sequence.append(job(repo_git, full_collection))
 
-                    self.logger.info(f"Setting github repo {col_hook.name} status to collecting for repo: {repo_git}")
+                #augur_collection_sequence.append(core_task_success_util.si(repo_git))
+                #Link all phases in a chain and send to celery
+                augur_collection_chain = chain(*augur_collection_sequence)
+                task_id = augur_collection_chain.apply_async().task_id
 
-                    #yield the value of the task_id to the calling method so that the proper collectionStatus field can be updated
-                    yield repo_git, task_id, col_hook.name
-                else:
-                    if col_hook.gitlab_phases is not None:
-                        
-                        augur_collection_sequence = []
-                        for job in col_hook.gitlab_phases:
-                            #Add the phase to the sequence in order as a celery task.
-                            #The preliminary task creates the larger task chain 
-                            augur_collection_sequence.append(job(repo_git, full_collection))
+                self.logger.info(f"Setting {platform_name} repo {col_hook.name} status to collecting for repo: {repo_git}")
 
-                        #augur_collection_sequence.append(core_task_success_util.si(repo_git))
-                        #Link all phases in a chain and send to celery
-                        augur_collection_chain = chain(*augur_collection_sequence)
-                        task_id = augur_collection_chain.apply_async().task_id
-
-                        self.logger.info(f"Setting gitlab repo {col_hook.name} status to collecting for repo: {repo_git}")
-
-                        #yield the value of the task_id to the calling method so that the proper collectionStatus field can be updated
-                        yield repo_git, task_id, col_hook.name
+                #yield the value of the task_id to the calling method so that the proper collectionStatus field can be updated
+                yield repo_git, task_id, col_hook.name
+                


### PR DESCRIPTION
**Description**
in looking for the facade scheduling issues, I noticed a couple structural (not functional) issues that arent directly going to solve the core problem but just help to clean up the code so its more readable when trying to debug the facade issues

1. This code path was almost entirely duplicated in two branches of an if-else chain.
2. the catch-all else block was being used for gitlab, potentially blocking any future additional sources


This essentially moves the actual "meat" of this function to below the if-else chain and extracts a couple new variables to abstract the differences between the two implementations (i.e. changing which list of phases gets used, and also printing the correct platform name in log messages)

**Signed commits**
- [X] Yes, I signed my commits.
