### PR TITLE
facade: refactor facade_phase to return the group itself so that celery can properly convert things into a chord

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -491,7 +491,6 @@ def facade_phase(repo_git, full_collection):
     #force_analysis = session.force_analysis
     run_facade_contributors = facade_helper.run_facade_contributors
 
-    facade_sequence = []
     facade_core_collection = []
 
     if not limited_run or (limited_run and pull_repos):
@@ -509,14 +508,12 @@ def facade_phase(repo_git, full_collection):
 
 
     #These tasks need repos to be cloned by facade before they can work.
-    facade_sequence.append(
-        group(
-            chain(*facade_core_collection),
-            process_dependency_metrics.si(repo_git),
-            process_libyear_dependency_metrics.si(repo_git),
-            process_scc_value_metrics.si(repo_git)
-        )
+    facade_sequence = group(
+        chain(*facade_core_collection),
+        process_dependency_metrics.si(repo_git),
+        process_libyear_dependency_metrics.si(repo_git),
+        process_scc_value_metrics.si(repo_git)
     )
 
     logger.info(f"Facade sequence: {facade_sequence}")
-    return chain(*facade_sequence)
+    return facade_sequence


### PR DESCRIPTION
**Description**
While I haven't been certain that I can see the facade recollection issue locally, this change allowed me to successfully find `facade_task_success_util` via a flower task search in my local instance, meaning the tasks that were not running are now running again,

The thing that helped me get through this issue was this analysis from GPT5:
> I traced the facade orchestration. The issue is how the facade phase is chained: your facade_phase returns a chain that ends with a group, and then the outer routine chains the “success” util after that. In Celery, when you want to run something after a group completes, you must form a chord (e.g., group(...) | next_task). A nested chain that returns only a group won’t implicitly convert to a chord, so the subsequent facade_task_success_util never fires.


**Notes for Reviewers**
In doing this refactor, I didnt see any other uses of `facade_phase` besides in `build_facade_repo_collect_request`, so it doesnt seem like the specific return type here is being super heavily relied on (although maybe thats due to an unwritten convention as noted in #3272)

**Signed commits**
- [X] Yes, I signed my commits.