### PR TITLE
bump rabbitmq to 4.1

### DIFF
--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.12-management-alpine
+FROM rabbitmq:4.1-management-alpine
 
 LABEL maintainer="574/augur@simplelogin.com"
 LABEL version="0.90.0"

--- a/docker/rabbitmq/definitions.json
+++ b/docker/rabbitmq/definitions.json
@@ -1,5 +1,5 @@
 {
-    "rabbit_version": "3.12",
+    "rabbit_version": "4.1",
     "users": [
         {
             "name": "",


### PR DESCRIPTION
**Description**
this bumps rabbitmq to a supported version

With this change, augur seems to run just fine. Theres a warning in console that we are using the "global QOS" feature that is going to be deprecated very soon, but i cant find any mention of that in our code and am not sure where else to go to change the setting

Docs related to that change:
- https://stackoverflow.com/questions/69263559/disable-global-qos-in-rabbitmq-from-celery
- https://www.rabbitmq.com/blog/2021/08/21/4.0-deprecation-announcements#removal-of-global-qos

This PR fixes #3255 

**Signed commits**
- [X] Yes, I signed my commits.