### PR TITLE
Fix examples of repos CSV files

### DIFF
--- a/augur/application/schema/repo_load_sample.csv
+++ b/augur/application/schema/repo_load_sample.csv
@@ -1,8 +1,8 @@
-10,https://github.com/chaoss/augur.git
-10,https://github.com/chaoss/grimoirelab.git
-20,https://github.com/chaoss/wg-evolution.git
-20,https://github.com/chaoss/wg-risk.git
-20,https://github.com/chaoss/wg-common.git
-20,https://github.com/chaoss/wg-value.git
-20,https://github.com/chaoss/wg-diversity-inclusion.git
-20,https://github.com/chaoss/wg-app-ecosystem.git
+https://github.com/chaoss/augur.git,10
+https://github.com/chaoss/grimoirelab.git,10
+https://github.com/chaoss/wg-evolution.git,20
+https://github.com/chaoss/wg-risk.git,20
+https://github.com/chaoss/wg-common.git,20
+https://github.com/chaoss/wg-value.git,20
+https://github.com/chaoss/wg-diversity-inclusion.git,20
+https://github.com/chaoss/wg-app-ecosystem.git,20

--- a/docs/source/getting-started/command-line-interface/db.rst
+++ b/docs/source/getting-started/command-line-interface/db.rst
@@ -78,14 +78,14 @@ Example usage\:
 .. code-block:: bash
 
   # contents of repos.csv
-  10,https://github.com/chaoss/augur.git
-  10,https://github.com/chaoss/grimoirelab.git
-  20,https://github.com/chaoss/wg-evolution.git
-  20,https://github.com/chaoss/wg-risk.git
-  20,https://github.com/chaoss/wg-common.git
-  20,https://github.com/chaoss/wg-value.git
-  20,https://github.com/chaoss/wg-diversity-inclusion.git
-  20,https://github.com/chaoss/wg-app-ecosystem.git
+  https://github.com/chaoss/augur.git,10
+  https://github.com/chaoss/grimoirelab.git,10
+  https://github.com/chaoss/wg-evolution.git,20
+  https://github.com/chaoss/wg-risk.git,20
+  https://github.com/chaoss/wg-common.git,20
+  https://github.com/chaoss/wg-value.git,20
+  https://github.com/chaoss/wg-diversity-inclusion.git,20
+  https://github.com/chaoss/wg-app-ecosystem.git,20
 
   # to add repos to the database
   $ augur db add-repos repos.csv

--- a/tests/test_workers/test_facade/test_facade_contributor_interface/test_repos.csv
+++ b/tests/test_workers/test_facade/test_facade_contributor_interface/test_repos.csv
@@ -1,8 +1,8 @@
-10,https://github.com/chaoss/augur.git
-10,https://github.com/chaoss/grimoirelab.git
-20,https://github.com/chaoss/wg-evolution.git
-20,https://github.com/chaoss/wg-risk.git
-20,https://github.com/chaoss/wg-common.git
-20,https://github.com/chaoss/wg-value.git
-20,https://github.com/chaoss/wg-diversity-inclusion.git
-20,https://github.com/chaoss/wg-app-ecosystem.git
+https://github.com/chaoss/augur.git,10
+https://github.com/chaoss/grimoirelab.git,10
+https://github.com/chaoss/wg-evolution.git,20
+https://github.com/chaoss/wg-risk.git,20
+https://github.com/chaoss/wg-common.git,20
+https://github.com/chaoss/wg-value.git,20
+https://github.com/chaoss/wg-diversity-inclusion.git,20
+https://github.com/chaoss/wg-app-ecosystem.git,20


### PR DESCRIPTION
The [code which parses the repos files](https://github.com/chaoss/augur/blob/b0bb3b80402ee5fcd84bec7334e58a41f9f5ec8a/augur/application/cli/db.py#L61-L69) interprets the first column as URL and the second one as repo group ID, but all the examples were doing the opposite.

**Signed commits**
- [x] Yes, I signed my commits.