### PR TITLE
docker compose: Make it crystal clear that all the GitHub/GitLab user/keys must be set

### DIFF
--- a/docs/source/docker/docker-compose.rst
+++ b/docs/source/docker/docker-compose.rst
@@ -26,7 +26,7 @@ This section of the documentation details how to use Augur's Docker Compose conf
 
 .. warning::
 
-    Don't forget to provide your external database credentials in a file called ``.env`` file. Make sure the following environment variables are specified.
+    Don't forget to provide your external database credentials in a file called ``.env`` file. Make sure all the following environment variables are specified, keep placeholder values if you don't need some of them.
     Don't specify AUGUR_DB if you want the docker database to be used.
 
     Example .env:

--- a/docs/source/docker/getting-started.rst
+++ b/docs/source/docker/getting-started.rst
@@ -31,7 +31,7 @@ the following resources (or more):
 - 10 GB RAM
 
 Clone the Augur repository and create a .env file in the top level directory
-with the following fields:
+with the following fields (don't remove any variable, keep placeholder values if you don't need some of them):
 
 .. code:: python
 

--- a/docs/source/docker/quick-start.rst
+++ b/docs/source/docker/quick-start.rst
@@ -9,7 +9,7 @@ Before you get off to such a quick start, go ahead and
 
      git checkout main
 
-  4. Create a .env file in the top level directory with the following fields:
+  4. Create a .env file in the top level directory with the following fields (don't remove any variable, keep placeholder values if you don't need some of them):
 
 .. code:: python
 

--- a/docs/source/getting-started/using-docker.rst
+++ b/docs/source/getting-started/using-docker.rst
@@ -10,7 +10,7 @@ the following resources (or more).
 1. Clone the Augur repository https://github.com/chaoss/augur
 
 
-2. Create a .env file in the top level directory with the following fields:
+2. Create a ``.env`` file in the top level directory with the following fields (don't remove any variable, keep placeholder values if you don't need some of them):
 
 .. code:: python
 
@@ -35,7 +35,7 @@ or
 
     podman compose up --build
 
-And augur should be up and running! Over time, you may decide that you want to download and run newer releases of Augur. It is critical that your `.env` file remains configured to use the same database name and password; though you can change the password if you understand how to connect to a database running inside a Docker container on your computer.
+And augur should be up and running! Over time, you may decide that you want to download and run newer releases of Augur. It is critical that your ``.env`` file remains configured to use the same database name and password; though you can change the password if you understand how to connect to a database running inside a Docker container on your computer.
 
 Rebuilding Augur in Docker
 ----------------------------


### PR DESCRIPTION
The non-interactive Docker compose workflow requires all the variables `AUGUR_GIT{LA,HU}B_{USERNAME,API_KEY}` to be set even if they are going to be unused, otherwise you get stuck waiting for [the prompt](https://github.com/chaoss/augur/blob/b0bb3b80402ee5fcd84bec7334e58a41f9f5ec8a/scripts/install/config.sh#L18-L29)
```
You entered a blank line, are you sure?
```

**Signed commits**
- [x] Yes, I signed my commits.