### PR TITLE
Config data patch: Adding facade_contributor_full_recollect

### DIFF
--- a/augur/application/schema/alembic/versions/34_add_contrib_to_config.py
+++ b/augur/application/schema/alembic/versions/34_add_contrib_to_config.py
@@ -1,4 +1,4 @@
-"""Add extra celery options to the config if they do not exist
+"""Add Facade contributor full recollect to config, default to off (0) 
 
 Revision ID: 34
 Revises: 33


### PR DESCRIPTION
**Description**
- Adds `facade_contributor_full_recollect` parameter, defaulted to `0` to the `augur_operations.config` table. 
- Uses Alembic. We think there are other strategies more robust for config data items, but for now we also know this works and the config refactoring is down the road. 