### PR TITLE
Fix `git reset` command to include remote default branch

### DIFF
--- a/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/repofetch.py
@@ -435,7 +435,7 @@ def git_repo_updates(facade_helper, repo_git):
 
                 cmdpull2 = (f"git -C {absolute_path} pull")
 
-                cmd_reset = (f"git -C {absolute_path} reset --hard origin")
+                cmd_reset = (f"git -C {absolute_path} reset --hard origin/{remotedefault}")
 
                 cmd_reset_wait = subprocess.Popen(
                     [cmd_reset], shell=True).wait()


### PR DESCRIPTION
**Description**

`git reset --hard <remote>` isn't a correct command, the argument of `git reset` must be a tree-ish, which a remote name alone isn't.

In some cases this command fails with
```
fatal: ambiguous argument 'origin': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.