### PR TITLE
Allow default config to be read from a file

### DIFF
--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -123,7 +123,8 @@ class AugurConfig():
         self.logger = logger
 
         self.accepted_types = ["str", "bool", "int", "float", "NoneType"]
-        config_path = Path("./augur.json")
+        config_dir = Path(os.getenv("CONFIG_DATADIR", "./"))
+        config_path = config_dir.joinpath("augur.json")
         if config_path.exists():
             self.default_config = json.loads(config_path.read_text(encoding="UTF-8"))
         else:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       - REDIS_CONN_STRING=redis://redis:6379
       - RABBITMQ_CONN_STRING=amqp://${AUGUR_RABBITMQ_USERNAME:-augur}:${AUGUR_RABBITMQ_PASSWORD:-password123}@rabbitmq:5672/${AUGUR_RABBITMQ_VHOST:-augur_vhost}
       - CONFIG_LOCATION=/config/config.yml
+      - CONFIG_DATADIR=/config
       - CACHE_DATADIR=/cache
       - CACHE_LOCKDIR=/cache
       - CELERYBEAT_SCHEDULE_DB=/tmp/celerybeat-schedule.db


### PR DESCRIPTION
**Description**
The default config is currently hardcoded. When sysadmins, (especially those using docker where the db config is overwritten on startup) want to change something, it requires augur's container images to be rebuilt since the code has changed.

This change checks for the presence of a json file reads from that if present, instead of the hardcoded config.  

Per #3302 this PR also introduces a new environment variable containing a path to a config directory, which, if specified, is used as the base directory when looking for this augur config file.

**Notes for Reviewers**
Draft PR because I have yet to test this locally - but will do soon

**Signed commits**
- [X] Yes, I signed my commits.