### PR TITLE
Format formatting of wait until time

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -939,7 +939,7 @@ class Repo(Base):
                 )
                 wait_until_time = localtime(wait_until)
                 logger.error(f"rate limited fetching {url}")
-                logger.error(f"sleeping until {wait_until_time.tm_hour}:{wait_until_time.tm_min} ({wait_in_seconds} seconds)")
+                logger.error(f"sleeping until {wait_until_time.tm_hour:02d}:{wait_until_time.tm_min:02d} ({wait_in_seconds} seconds)")
                 sleep(wait_in_seconds)
                 attempts+=1
                 continue


### PR DESCRIPTION
**Description**

Current formatting of time in "sleeping until" message doesn't include leading zeros for single-digit minutes (and hours), which is odd:

```python
>>> import time
>>> wait_until_time = time.localtime(1760684520)
>>> f"sleeping until {wait_until_time.tm_hour}:{wait_until_time.tm_min}"
'sleeping until 8:2'
>>> f"sleeping until {wait_until_time.tm_hour:02d}:{wait_until_time.tm_min:02d}"
'sleeping until 08:02'
```

**Signed commits**
- [x] Yes, I signed my commits.