### PR TITLE
copy podman test cleanup step to docker build as well

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -55,6 +55,11 @@ jobs:
     name: End-to-end test (Docker)
     runs-on: ubuntu-latest
     steps:
+      - name: Remove unnecessary files from the base image
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          
       - name: Checkout repository
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Add step to remove unnecessary files from Docker image

**Description**
We have had a couple docker build failures lately due to the docker build running out of disk space in the github actions runner. This PR copies the same build step that the podman test uses to free up space into the docker build test.

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.