### PR TITLE
Fix variables issue in #3183

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@
 #
 import os
 import sys
-
+import sphinx_rtd_theme
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
**Description**
This PR resolves the warnings given in changes in #3183. Removes the unused import `sphinx_rtd_theme` and import variables `__copyright__, __release__, __version__` correctly from `metadata.py` into `conf.py` as suggested by reviewbot.

This PR fixes small import issues.

**Signed commits**
- [x] Yes, I signed my commits.
