### PR TITLE
allow materialized view refresh to be disabled

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -241,8 +241,11 @@ def setup_periodic_tasks(sender, **kwargs):
         sender.add_periodic_task(thirty_days_in_seconds, non_repo_domain_tasks.s())
 
         mat_views_interval = int(config.get_value('Celery', 'refresh_materialized_views_interval_in_days'))
-        logger.info(f"Scheduling refresh materialized view every night at 1am CDT")
-        sender.add_periodic_task(datetime.timedelta(days=mat_views_interval), refresh_materialized_views.s())
+        if mat_views_interval > 0: 
+            logger.info(f"Scheduling refresh materialized view every night at 1am CDT")
+            sender.add_periodic_task(datetime.timedelta(days=mat_views_interval), refresh_materialized_views.s())
+        else:
+            logger.info(f"Refresh materialized view task is disabled.")
 
         # logger.info(f"Scheduling update of collection weights on midnight each day")
         # sender.add_periodic_task(crontab(hour=0, minute=0),augur_collection_update_weights.s())


### PR DESCRIPTION
**Description**
this change skips scheduling the materialized view refresh task if the config item for it (refresh_materialized_views_interval_in_days) is set to 0

This PR fixes #3331

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.