### PR TITLE
Fix: python3.9 compatibility message in docs #3266

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -31,7 +31,7 @@ Required:
 
 
 
-Our REST API & data collection workers write in Python 3.6. We query the GitHub & GitLab API to collect data about issues, pull requests, contributors, and other information about a repository, so GitLab and GitHub access tokens are **required** for data collection.
+Our REST API & data collection workers query the GitHub & GitLab API to collect data about issues, pull requests, contributors, and other information about a repository. Values for GitLab and GitHub access tokens are **required** for data collection and must be provided (an invalid token can be provided if you don't plan to use one platform) .
 
 Optional:
 


### PR DESCRIPTION
**Description**
This removes the `python3.9` compatibility message in docs.  

This PR fixes #3266 

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.
