### PR TITLE
apply coalesce to values being bulk-added to handle nulls

### DIFF
--- a/augur/application/db/lib.py
+++ b/augur/application/db/lib.py
@@ -354,8 +354,10 @@ def bulk_insert_dicts(logger, data_input: Union[List[dict], dict], table, natura
 
         # create a dict that the on_conflict_do_update method requires to be able to map updates whenever there is a conflict. See sqlalchemy docs for more explanation and examples: https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#updating-using-the-excluded-insert-values
         setDict = {}
+        base_table = getattr(table, "__table__", table)
         for key in data[0].keys():
-            setDict[key] = func.coalesce(getattr(stmnt.excluded, key), getattr(table.c, key))
+            existing_col = getattr(base_table.c, key)
+            setDict[key] = func.coalesce(getattr(stmnt.excluded, key), existing_col)
             
         stmnt = stmnt.on_conflict_do_update(
             #This might need to change

--- a/augur/application/db/session.py
+++ b/augur/application/db/session.py
@@ -143,8 +143,10 @@ class DatabaseSession(Session):
 
             # create a dict that the on_conflict_do_update method requires to be able to map updates whenever there is a conflict. See sqlalchemy docs for more explanation and examples: https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#updating-using-the-excluded-insert-values
             setDict = {}
+            base_table = getattr(table, "__table__", table)
             for key in data[0].keys():
-                setDict[key] = func.coalesce(getattr(stmnt.excluded, key), getattr(table.c, key))
+                existing_col = getattr(base_table.c, key)
+                setDict[key] = func.coalesce(getattr(stmnt.excluded, key), existing_col)
                 
             stmnt = stmnt.on_conflict_do_update(
                 #This might need to change


### PR DESCRIPTION
**Description**
A collaborative change built with the other augur maintainers (@sgoggins and @ABrain7710) to add the `coalesce` postgres function to our bulk insert methods to ensure that values in the database cannot be overwritten with NULL values. This was inspired by @razekmh's solution in #3342

This was implemented without a parameter to toggle this functionality off because we couldnt think of a scenario where one might want to intentionally overwrite data with null in augur 

This PR fixes #3317

This supersedes #3342 


**Notes for Reviewers**
should be all set to merge once the OP of the linked issue confirms this still fixes the issue.

**Signed commits**
- [X] Yes, I signed my commits.