### PR TITLE
Add guidance for joining CHAOSS Slack to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ We love to pull requests from everyone! We follow the standard Git workflow of `
 
 If you are new to open source, we recommend GitHub's excellent guide on "[How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)". In addition, please feel free to reach out to any of the maintainers or other community members if you are struggling as we are here to help you learn!
 
+Before getting started, please make sure you've read the [README](README.md) to get a primer on our project. Augur's documentation can be found [here](https://oss-augur.readthedocs.io/en/main/).
+
 ## Join the Community
 
 We encourage all contributors to join the [CHAOSS Slack workspace](https://chaoss.community/kb-getting-started/) and participate in the `#wg-augur-8knot` channel. This is a great place to ask questions, get help with issues, participate in discussions, and stay updated on community meetings and planning. Don't hesitate to introduce yourself and ask for help if you get stuck!
-
-Before getting started, please make sure you've read the [README](README.md) to get a primer on our project. Augur's documentation can be found [here](https://oss-augur.readthedocs.io/en/main/).
 
 ## Opening an issue
 If you're experiencing an issue with Augur or have a question you'd like help answering, please feel free to open an [issue](https://github.com/chaoss/augur/issues). To help us prevent duplicates, we kindly ask that you briefly search for your problem or question in our [issues](https://github.com/chaoss/augur/issues) before opening a new one.


### PR DESCRIPTION
Fixes #3365

**Description**
- Added a link to the CHAOSS getting started page (https://chaoss.community/kb-getting-started/) in the Community Resources section
- Included guidance about joining the `#wg-augur-8knot` channel for discussions, meetings, and planning
- This helps newcomers discover and participate in the CHAOSS Slack community more easily

This PR fixes #3365

**Notes for Reviewers**
- Minimal change: Added a single line to the CHAOSS section of CONTRIBUTING.md
- Maintains consistency with existing formatting and link structure
- Positioned logically between "Get Involved" and "Metrics" links

**Signed commits**
- [x] Yes, I signed my commits.