### PR TITLE
Fixed issue with static log time | First time contributor

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -242,8 +242,13 @@ def setup_periodic_tasks(sender, **kwargs):
 
         mat_views_interval = int(config.get_value('Celery', 'refresh_materialized_views_interval_in_days'))
         if mat_views_interval > 0: 
+            # check correct pluralization
+            if mat_views_interval == 1:
+                day_text = "day"
+            else:
+                day_text = "days"
             # Relative log message from startup time (insted of 1am CDT)
-            logger.info(f"Scheduling refresh materialized view {mat_views_interval} day(s) after startup")
+            logger.info(f"Scheduling refresh materialized view every {mat_views_interval} {day_text} from startup")
             sender.add_periodic_task(datetime.timedelta(days=mat_views_interval), refresh_materialized_views.s())
         else:
             logger.info(f"Refresh materialized view task is disabled.")


### PR DESCRIPTION
**Description**
- Fixed misleading log message for materialized views refresh task.
- The log claimed it runs "every night at 1am CDT" but actually runs every N days relative to Augur startup time using.
- Updated the message to display the actual configurable interval and removed the incorrect timezone reference.

This PR fixes #3360 

**Notes for Reviewers**
- I am first time contributor trying to get hands on with Open-Source
- feel free to point out error(s) or possible improvement(s) would love to hear and learn!

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->