### PR TITLE
Ensure Docker logging facilities can see gunicorn errors

### DIFF
--- a/augur/api/gunicorn_conf.py
+++ b/augur/api/gunicorn_conf.py
@@ -39,8 +39,14 @@ del is_dev
 
 # set the log location for gunicorn    
 logs_directory = get_value('Logging', 'logs_directory')
+
+is_docker = os.getenv("AUGUR_DOCKER_DEPLOY").lower() in ('true', '1', 't', 'y', 'yes')
 accesslog = f"{logs_directory}/gunicorn.log"
 errorlog = f"{logs_directory}/gunicorn.log"
+
+# If deploying via docker, include gunicorn error logs in the docker log stream by sending it to stdout
+if is_docker:
+    errorlog = '-'
 
 ssl_bool = get_value('Server', 'ssl')
 


### PR DESCRIPTION
**Description**
Currently, if gunicorn crashes due to an error, the docker logs will only show the attempt to start the gunicorn (frontend) web server processes followed by their immediate shutdown. The cause is only findable by looking in the configured log directory and reading the log files.

This PR uses the environment variable for docker deployments to change the gunicorn config to redirect errors to stdout so they get picked up by docker

**Notes for Reviewers**
So uuh, I fixed the issue that was causing gunicorn to crash before realizing i should use it to test this, so while im not certain it works, it should be a pretty basic change and lines up with the [gunicorn docs for this errorlog setting](https://docs.gunicorn.org/en/stable/settings.html#errorlog)


**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->