### PR TITLE
Fix database connection leak when deleting repos via web UI: Fixes #3392

### DIFF
--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -566,9 +566,7 @@ class User(Base):
         from augur.util.repo_load_controller import RepoLoadController
 
         with DatabaseSession(logger) as session:
-            controller = RepoLoadController(session)
-
-        result = controller.get_repo_count(source="group", group_name=group_name, user=self, search=search)
+            result = RepoLoadController(session).get_repo_count(source="group", group_name=group_name, user=self, search=search)
 
         return result
 


### PR DESCRIPTION
**Description**
  - Fixed database connection leak that occurred when deleting multiple repos through the web UI. Fixes #3392.
  - The delete operation was creating new database connections without properly closing them, eventually hitting PostgreSQL's connection limit and causing "FATAL: sorry, too many clients already" errors 
  - Ensured proper session/connection management in the repo deletion flow

**Notes for Reviewers**
- Should no longer encounter "too many clients already" errors even when deleting many repos

**Signed commits**
- [x] Yes, I signed my commits.