### PR TITLE
Fix: Make remaining periodic Celery tasks configurable

### DIFF
--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -74,7 +74,11 @@ default_config = {
                 "core_worker_count": 5,
                 "secondary_worker_count": 5,
                 "facade_worker_count": 5,
-                "refresh_materialized_views_interval_in_days": 1
+                "refresh_materialized_views_interval_in_days": 1,
+                "non_repo_domain_tasks_interval_in_days": 30,
+                "retry_errored_repos_interval_in_days": 1,
+                "process_contributors_interval_in_seconds": 3600,
+                "create_collection_status_records_interval_in_days": 1
             },
             "Redis": {
                 "cache_group": 0, 


### PR DESCRIPTION
**Description**
- This PR makes the remaining hardcoded periodic tasks in Celery configurable through the config system, consistent with the materialized views task. and solves #3406 

This PR fixes #3406 

**Notes for Reviewers**
**Changes:**
- Added four new configuration options in the `Celery` section:
  - `non_repo_domain_tasks_interval_in_days` (default: 30 days)
  - `retry_errored_repos_interval_in_days` (default: 1 day)  
  - `process_contributors_interval_in_seconds` (default: 3600 seconds / 1 hour)
  - `create_collection_status_records_interval_in_days` (default: 1 day)

- Updated `setup_periodic_tasks()` in `celery_app.py` to read intervals from config instead of using hardcoded values
- Converted `retry_errored_repos` from crontab-based scheduling to interval-based for consistency
- Added enable/disable functionality for all tasks (setting interval to 0 disables the task)
- Improved logging messages to show the configured intervals

All tasks now follow the same pattern as `refresh_materialized_views_interval_in_days`, allowing users to customize scheduling intervals or disable tasks as needed through the configuration system.



**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->