### PR TITLE
fix: Update log message to show configurable mat_views_interval

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -242,7 +242,7 @@ def setup_periodic_tasks(sender, **kwargs):
 
         mat_views_interval = int(config.get_value('Celery', 'refresh_materialized_views_interval_in_days'))
         if mat_views_interval > 0: 
-            logger.info(f"Scheduling refresh materialized view every night at 1am CDT")
+            logger.info(f"Scheduling refresh materialized view every {mat_views_interval} day(s)")
             sender.add_periodic_task(datetime.timedelta(days=mat_views_interval), refresh_materialized_views.s())
         else:
             logger.info(f"Refresh materialized view task is disabled.")


### PR DESCRIPTION
The log message incorrectly stated that the materialized view refresh was scheduled "every night at 1am CDT" when the interval is actually configurable via the refresh_materialized_views_interval_in_days config option.

This change updates the log message to dynamically display the configured interval value (mat_views_interval) instead of the hardcoded time.

Fixes #3360

**Description**
- Please include a summary of the change.

This PR fixes #

**Notes for Reviewers**

**Signed commits**
- [ ] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->