### PR TITLE
specify `pr_review_body` as a User generated content string field

### DIFF
--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -403,7 +403,8 @@ def collect_pull_request_reviews(repo_git: str, full_collection: bool) -> None:
 
             logger.info(f"{owner}/{repo}: Inserting pr reviews of length: {len(pr_reviews)}")
             pr_review_natural_keys = ["pr_review_src_id",]
-            augur_db.insert_data(pr_reviews, PullRequestReview, pr_review_natural_keys)
+            pr_review_string_fields = ["pr_review_body",]
+            augur_db.insert_data(pr_reviews, PullRequestReview, pr_review_natural_keys, string_fields=pr_review_string_fields)
 
 
 


### PR DESCRIPTION
**Description**
Specifies that user generated content may be contained in the PR review body so it can be filtered for null values 

This PR fixes #3434 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->