### PR TITLE
Update Python versionin README to 3.11 and use uv for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ For more information on [how to get involved on the CHAOSS website](https://chao
 
 ## Collecting Data
 
-Augur supports ```Python3.7``` through ```Python3.11``` on all platforms. ```Python3.12``` and above do not yet work because of machine learning worker dependencies. On OSX, you can create a ```Python3.11``` environment, by running:
+Augur officially supports ```Python3.11``` on all platforms. ```Python3.12``` and above do not yet work because of machine learning worker dependencies. We recommend using [uv](https://github.com/astral-sh/uv) to manage your Python environment:
 ```
-$ python3.11 -m venv path/to/venv
+$ uv venv --python 3.11
+$ source .venv/bin/activate  # On Unix/macOS
+$ .venv\Scripts\activate     # On Windows
 ```
 
 Augur's main focus is to measure the overall health and sustainability of open source projects.


### PR DESCRIPTION
## Summary
- Updated README to reflect Python 3.11 as the officially supported version
- Replaced venv usage example with uv (modern Python environment manager)
- Added cross-platform activation commands

## Changes Made
- **Line 46**: Changed "supports Python3.7 through Python3.11" to "officially supports Python3.11"
- **Lines 47-51**: Replaced venv example with uv commands:
  - Added link to uv GitHub repository
  - Updated environment creation command to use `uv venv --python 3.11`
  - Included both Unix/macOS and Windows activation commands for clarity

## Before
```
Augur supports ```Python3.7``` through ```Python3.11``` on all platforms. ```Python3.12``` and above do not yet work because of machine learning worker dependencies. On OSX, you can create a ```Python3.11``` environment, by running:
```
$ python3.11 -m venv path/to/venv
```
```

## After
```
Augur officially supports ```Python3.11``` on all platforms. ```Python3.12``` and above do not yet work because of machine learning worker dependencies. We recommend using [uv](https://github.com/astral-sh/uv) to manage your Python environment:
```
$ uv venv --python 3.11
$ source .venv/bin/activate  # On Unix/macOS
$ .venv\Scripts\activate     # On Windows
```
```

## Benefits
- Clearer documentation that Python 3.11 is the officially supported version
- Modern tooling recommendation (uv is faster and more reliable than venv)
- Better onboarding experience with explicit activation commands for both platforms

Fixes #3441