### PR TITLE
Document onboarding process #3442 issue solved

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ but we are actively adding to it all the time.
 
 If you get stuck, please feel free to [ask for help](https://github.com/chaoss/augur/issues/new)!
 
+## Onboarding for New Contributors
+
+Newcomers can find a short onboarding guide with suggested steps and resources in `docs/onboarding.md`.
+It covers joining the community, running Augur locally, finding starter issues, and where to ask for help.
+
+
 ## Contributing
 
 To contribute to Augur, please follow the guidelines found in our [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md). Augur is a welcoming community that is open to all, regardless if you're working on your 1000th contribution to open source or your 1st.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,31 @@
+## Onboarding Guide for New Augur Contributors
+
+This guide collects suggested steps and resources to help a newcomer become a confident Augur contributor. It is a living document — please open issues or submit PRs to improve it.
+
+### Join the community, learn how things work
+- Join CHAOSS community Slack and introduce yourself: https://chaoss.community/kb-getting-started/
+- Read CHAOSS getting-started docs, the Code of Conduct, and other materials on the CHAOSS website.
+- Read the repository `CONTRIBUTING.md` — it contains important contribution guidelines (including our AI contribution policy once #3371 is merged).
+- Find the project calendar and attend meetings (recommended: newcomer hangout, community call, Software WG, Data Science WG).
+- Watch recorded meetings on the CHAOSS YouTube channel: https://www.youtube.com/@CHAOSStube
+
+### Run Augur locally
+- Read the docs at https://oss-augur.readthedocs.io/en/main/, especially the Docker setup and development guides.
+- Get Augur running on your machine. If docs are unclear or out of date, ask on Slack, open an issue, or submit a PR to fix them.
+- There are community videos that show setup steps — check the CHAOSS YouTube for walkthroughs.
+
+### Look for starter issues
+- Browse issues tagged `good first issue` or `first-timers-only` in this repo.
+- Try a small issue to get familiar with the codebase and the PR process.
+- If you want to work on something that doesn't have an issue yet, open an issue describing the problem and discuss it with us before starting.
+
+### Need help?
+- Ask on Slack, bring questions to meetings, or comment on an issue/PR where you need guidance. Maintainers and community members are happy to help.
+
+### Want more challenging work?
+- Look for issues tagged `challenging first issue`, or explore issues labeled `documentation` or `tech debt` for smaller scoped tasks inside larger efforts.
+- Ask on Slack about tasks that match your skills and interests — the community can help point you to a good fit.
+
+---
+
+If anything in this guide is unclear or outdated, please open an issue or submit a PR to improve it. Welcome to Augur!


### PR DESCRIPTION
Title: docs: Add onboarding guide and README link

Body:
Short summary:
Adds a concise onboarding guide for new Augur contributors and links it from the repository README to help newcomers find community, setup, and first-contribution resources more quickly.

What changed:

Added docs/onboarding.md — a short, actionable onboarding guide covering:
joining the CHAOSS community (Slack, meetings, YouTube)
running Augur locally (docs + Docker pointers)
finding starter issues (first-timers-only, good first issue)
where to ask for help and how to escalate
pointers for more challenging work
Updated [README.md](vscode-file://vscode-app/c:/Users/PARAS/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — inserted an "Onboarding for New Contributors" section linking to docs/onboarding.md.
Why:
This provides a clear, discoverable path for newcomers (derived from community suggestions) to get started contributing to Augur and reduces friction for first-time contributors. Relates to community discussion in issues #3442 and #3446.

Related issues / credit:

References: #3442, #3446
Contributor: @MoralCode (original suggestion)
Files: docs/onboarding.md, [README.md](vscode-file://vscode-app/c:/Users/PARAS/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

