### PR TITLE
Consistent SA model setup

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -1359,7 +1359,8 @@ class Commit(Base):
 
 class CommitMessage(Base):
     __tablename__ = "commit_messages"
-    __table_args__ = ( UniqueConstraint("repo_id","cmt_hash", name="commit-message-insert-unique"),
+    __table_args__ = (
+        UniqueConstraint("repo_id","cmt_hash", name="commit-message-insert-unique"),
         { 
             "schema": "augur_data",
             "comment": "This table holds commit messages",
@@ -1930,9 +1931,12 @@ class RepoClusterMessage(Base):
 
 class RepoDependency(Base):
     __tablename__ = "repo_dependencies"
-    __table_args__ = ( UniqueConstraint("repo_id","dep_name","data_collection_date", name="deps-insert-unique"),
-        {"schema": "augur_data",
-        "comment": "Contains the dependencies for a repo.",},
+    __table_args__ = (
+        UniqueConstraint("repo_id","dep_name","data_collection_date", name="deps-insert-unique"),
+        {
+            "schema": "augur_data",
+            "comment": "Contains the dependencies for a repo."
+        },
     )
 
     repo_dependencies_id = Column(
@@ -1960,7 +1964,8 @@ class RepoDependency(Base):
 
 class RepoDepsLibyear(Base):
     __tablename__ = "repo_deps_libyear"
-    __table_args__ = ( UniqueConstraint("repo_id","name", "data_collection_date", name="deps-libyear-insert-unique"),
+    __table_args__ = (
+        UniqueConstraint("repo_id","name", "data_collection_date", name="deps-libyear-insert-unique"),
         {"schema": "augur_data"}
     )
 
@@ -1993,7 +1998,8 @@ class RepoDepsLibyear(Base):
 
 class RepoDepsScorecard(Base):
     __tablename__ = "repo_deps_scorecard"
-    __table_args__ = ( UniqueConstraint("repo_id","name", name="deps-scorecard-insert-unique"),
+    __table_args__ = (
+        UniqueConstraint("repo_id","name", name="deps-scorecard-insert-unique"),
         {"schema": "augur_data"}
     )
 

--- a/augur/application/db/models/augur_operations.py
+++ b/augur/application/db/models/augur_operations.py
@@ -218,9 +218,7 @@ t_working_commits = Table(
 
 class BadgingDEI(Base):
     __tablename__ = 'dei_badging'
-    __table_args__ = (
-        {"schema": "augur_data"}
-    )
+    __table_args__ = {"schema": "augur_data"}
     id = Column(Integer, primary_key=True, nullable=False)
     badging_id = Column(Integer, nullable=False)
     level = Column(String, nullable=False)
@@ -742,11 +740,7 @@ class UserGroup(Base):
 
 class UserRepo(Base):
     __tablename__ = "user_repos"
-    __table_args__ = (
-        {
-            "schema": "augur_operations"
-        }
-    )
+    __table_args__ = { "schema": "augur_operations" }
 
     group_id = Column(
         ForeignKey("augur_operations.user_groups.group_id", name="user_repo_group_id_fkey"), primary_key=True, nullable=False
@@ -1013,11 +1007,7 @@ class UserRepo(Base):
 
 class UserSessionToken(Base):
     __tablename__ = "user_session_tokens"
-    __table_args__ = (
-        {
-            "schema": "augur_operations"
-        }
-    )
+    __table_args__ = { "schema": "augur_operations" }
 
     token = Column(String, primary_key=True, nullable=False)
     user_id = Column(ForeignKey("augur_operations.users.user_id", name="user_session_token_user_id_fkey"))
@@ -1055,11 +1045,7 @@ class UserSessionToken(Base):
 
 class ClientApplication(Base):
     __tablename__ = "client_applications"
-    __table_args__ = (
-        {
-            "schema": "augur_operations"
-        }
-    )
+    __table_args__ = { "schema": "augur_operations" }
 
     id = Column(String, primary_key=True, nullable=False)
     user_id = Column(ForeignKey("augur_operations.users.user_id", name="client_application_user_id_fkey"), nullable=False)
@@ -1086,11 +1072,7 @@ class ClientApplication(Base):
 
 class Subscription(Base):
     __tablename__ = "subscriptions"
-    __table_args__ = (
-        {
-            "schema": "augur_operations"
-        }
-    )
+    __table_args__ = { "schema": "augur_operations" }
 
     application_id = Column(ForeignKey("augur_operations.client_applications.id", name="subscriptions_application_id_fkey"), primary_key=True)
     type_id = Column(ForeignKey("augur_operations.subscription_types.id", name="subscriptions_type_id_fkey"), primary_key=True)

--- a/augur/application/db/models/spdx.py
+++ b/augur/application/db/models/spdx.py
@@ -176,7 +176,10 @@ class SpdxPackage(Base):
 
 class SpdxPackagesFile(Base):
     __tablename__ = "packages_files"
-    __table_args__ = (UniqueConstraint("package_id", "file_name"), {"schema": "spdx"})
+    __table_args__ = (
+        UniqueConstraint("package_id", "file_name"),
+        {"schema": "spdx"}
+    )
 
     package_file_id = Column(
         Integer,
@@ -312,7 +315,10 @@ class SpdxFileContributor(Base):
 
 class SpdxFilesLicense(Base):
     __tablename__ = "files_licenses"
-    __table_args__ = (UniqueConstraint("file_id", "license_id"), {"schema": "spdx"})
+    __table_args__ = (
+        UniqueConstraint("file_id", "license_id"), 
+        {"schema": "spdx"}
+    )
 
     file_license_id = Column(
         Integer,
@@ -331,7 +337,10 @@ class SpdxFilesLicense(Base):
 
 class SpdxFilesScan(Base):
     __tablename__ = "files_scans"
-    __table_args__ = (UniqueConstraint("file_id", "scanner_id"), {"schema": "spdx"})
+    __table_args__ = (
+        UniqueConstraint("file_id", "scanner_id"), 
+        {"schema": "spdx"}
+    )
 
     file_scan_id = Column(
         Integer,
@@ -347,7 +356,10 @@ class SpdxFilesScan(Base):
 
 class SpdxPackagesScan(Base):
     __tablename__ = "packages_scans"
-    __table_args__ = (UniqueConstraint("package_id", "scanner_id"), {"schema": "spdx"})
+    __table_args__ = (
+        UniqueConstraint("package_id", "scanner_id"), 
+        {"schema": "spdx"}
+    )
 
     package_scan_id = Column(
         Integer,
@@ -383,7 +395,10 @@ class SpdxDocumentsCreator(Base):
 
 class SpdxExternalRef(Base):
     __tablename__ = "external_refs"
-    __table_args__ = (UniqueConstraint("document_id", "id_string"), {"schema": "spdx"})
+    __table_args__ = (
+        UniqueConstraint("document_id", "id_string"), 
+        {"schema": "spdx"}
+    )
 
     external_ref_id = Column(
         Integer,


### PR DESCRIPTION
**Description**
- This change is a simple stylistic refactoring change that adjusts how our SQLAlchemy models are defined so that it follows consistent rules

These rules are:
- additional metadata parameters in models specifying constraints, tablename, or schema) appear at the top of the class definition
- these metadata definitions should use the simplest syntax available given what they need to do (i.e. if a model only needs a schema set, it can be defined as a plain dict, but if its a schema setting and constraints, it needs to be a tuple with the dict at the end)

This PR is intended to pull this relatively simple improvement out from #3435 to make that PR more easy to review.

**Notes for Reviewers**

This should be a relatively easy merge

**Signed commits**
- [X] Yes, I signed my commits.
