### PR TITLE
Prevent database connection leaks in config helpers #3452 issue resolved

### DIFF
--- a/augur/application/db/engine.py
+++ b/augur/application/db/engine.py
@@ -10,23 +10,23 @@ from sqlalchemy.engine import Engine
 from augur.application.db.util import catch_operational_error
 
 
-def parse_database_string(db_string: str) -> tuple[str,str, str, str, str]:
-    """Parse database string into the following components:
-        username, password, host, port, database 
-    """
-
-    match = re.match(r"postgresql\+psycopg2:\/\/(?P<username>[a-zA-Z0-9_]+):(?P<password>[^@]+)@(?P<host>[^:]+):(?P<port>\d+)\/(?P<database>\w+)", db_string)
-
+def parse_database_string(db_string: str) -> tuple[str, str, str, str, str]:
+    """Parse database string into username, password, host, port, database."""
+    match = re.match(
+        r"postgresql\+psycopg2://(?P<username>[a-zA-Z0-9_]+):(?P<password>[^@]+)@"
+        r"(?P<host>[^:]+):(?P<port>\d+)/(?P<database>\w+)",
+        db_string
+    )
     if not match:
-         raise ValueError("Invalid database string")
+        raise ValueError("Invalid database string")
 
-    username = match.group("username")
-    password = match.group("password")
-    host = match.group("host")
-    port = match.group("port")
-    database = match.group("database")
-
-    return username, password, host, port, database
+    return (
+        match.group("username"),
+        match.group("password"),
+        match.group("host"),
+        match.group("port"),
+        match.group("database"),
+    )
 
 
 def execute_sql_file(sql_file, dbname, username, password, host, port):
@@ -38,8 +38,6 @@ def execute_sql_file(sql_file, dbname, username, password, host, port):
         "-d", dbname,
         "-f", sql_file,
     ]
-
-    # Set the PGPASSWORD environment variable to provide the password
     env = dict(**os.environ, PGPASSWORD=password)
 
     try:
@@ -49,18 +47,7 @@ def execute_sql_file(sql_file, dbname, username, password, host, port):
 
 
 def get_database_string() -> str:
-    """Get database string from env or file
-
-    Note:
-        If environment variable is defined the function 
-            will use that as the database string. And if the 
-            environment variable is not defined, it will use the 
-            db.config.json file to get the database string
-
-    Returns:
-        postgres database string
-    """
-
+    """Get database string from env or file."""
     augur_db_environment_var = os.getenv("AUGUR_DB")
 
     try:
@@ -69,35 +56,35 @@ def get_database_string() -> str:
         print("\n\nPlease run augur commands in the root directory\n\n")
         sys.exit()
 
-    db_json_file_location = current_dir + "/db.config.json"
+    db_json_file_location = os.path.join(current_dir, "db.config.json")
     db_json_exists = os.path.exists(db_json_file_location)
 
     if not augur_db_environment_var and not db_json_exists:
-
-        print("ERROR no way to get connection to the database. \n\t\t\t\t\t\t    There is no db.config.json and the AUGUR_DB environment variable is not set\n\t\t\t\t\t\t    Please run make install or set the AUGUR_DB environment then run make install")
+        print(
+            "ERROR: No way to get connection to the database.\n"
+            "There is no db.config.json and the AUGUR_DB environment variable is not set.\n"
+            "Please run make install or set the AUGUR_DB environment then run make install."
+        )
         sys.exit()
 
     if augur_db_environment_var:
         return augur_db_environment_var
 
-
-    with open("db.config.json", 'r') as f:
+    with open(db_json_file_location, "r") as f:
         db_config = json.load(f)
 
-    db_conn_string = f"postgresql+psycopg2://{db_config['user']}:{db_config['password']}@{db_config['host']}:{db_config['port']}/{db_config['database_name']}"
+    return (
+        f"postgresql+psycopg2://{db_config['user']}:{db_config['password']}"
+        f"@{db_config['host']}:{db_config['port']}/{db_config['database_name']}"
+    )
 
-    return db_conn_string
 
-def create_database_engine(url: str, **kwargs) -> Engine:  
-    """Create sqlalchemy database engine 
+def create_database_engine(url: str, **kwargs) -> Engine:
+    """Create sqlalchemy database engine.
 
     Note:
-        A new database engine is created each time the function is called
-
-    Returns:
-        sqlalchemy database engine
-    """ 
-
+        A single engine should be reused instead of creating a new one each call.
+    """
     engine = create_engine(url, **kwargs)
 
     @event.listens_for(engine, "connect", insert=True)
@@ -105,30 +92,29 @@ def create_database_engine(url: str, **kwargs) -> Engine:
         existing_autocommit = dbapi_connection.autocommit
         dbapi_connection.autocommit = True
         cursor = dbapi_connection.cursor()
-        cursor.execute("SET SESSION search_path=public,augur_data,augur_operations,spdx")
+        cursor.execute(
+            "SET SESSION search_path=public,augur_data,augur_operations,spdx"
+        )
         cursor.close()
         dbapi_connection.autocommit = existing_autocommit
 
     return engine
 
-class DatabaseEngine():
 
+class DatabaseEngine:
     def __init__(self, **kwargs):
-
-        pool_size = kwargs.get("connection_pool_size")
+        pool_size = kwargs.pop("connection_pool_size", None)
         if pool_size:
-            del kwargs["connection_pool_size"]
             kwargs["pool_size"] = pool_size
 
+        
         self._engine = self.create_database_engine(**kwargs)
-
 
     def __enter__(self):
         return self._engine
 
-
     def __exit__(self, exception_type, exception_value, exception_traceback):
-
+        
         self._engine.dispose()
 
     def dispose(self):
@@ -138,16 +124,12 @@ class DatabaseEngine():
     def engine(self):
         return self._engine
 
-
-    def create_database_engine(self, **kwargs):  
-
-
+    def create_database_engine(self, **kwargs):
         db_conn_string = get_database_string()
-
         return create_database_engine(db_conn_string, **kwargs)
 
-class EngineConnection():
 
+class EngineConnection:
     def __init__(self, engine):
         self.connection = self.get_connection(engine)
 
@@ -155,16 +137,9 @@ class EngineConnection():
         return self.connection
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
-
+       
         self.connection.close()
 
     def get_connection(self, engine):
-
         func = engine.connect
-
         return catch_operational_error(func)
-
-        
-
-
-

--- a/augur/application/db/session.py
+++ b/augur/application/db/session.py
@@ -3,284 +3,195 @@ import random
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import OperationalError
-from sqlalchemy import func
+from sqlalchemy import func, or_
 
 from typing import Optional, List, Union
 from psycopg2.errors import DeadlockDetected
 
-# from augur.tasks.util.random_key_auth import RandomKeyAuth
 from augur.tasks.util.worker_util import remove_duplicates_by_uniques
 
 
 def remove_null_characters_from_string(string):
-
     if string:
         return string.replace("\x00", "\uFFFD")
-
     return string
 
+
 def remove_null_characters_from_strings_in_dict(data, fields):
-
     for field in fields:
-
-        # ensure the field exits in the dict
         try:
             data[field] = remove_null_characters_from_string(data[field])
         except KeyError:
-            print(
-                f"Error tried to remove null characters from the field: {field}, but it wasn't present in the dict")
+            print(f"Error: tried to remove null characters from field '{field}', but it wasn't present in dict")
             continue
-
         except AttributeError:
             continue
-
     return data
 
-def remove_null_characters_from_list_of_dicts(data_list, fields):
 
+def remove_null_characters_from_list_of_dicts(data_list, fields):
     for value in data_list:
         value = remove_null_characters_from_strings_in_dict(value, fields)
-
     return data_list
+
 
 class DatabaseSession(Session):
 
     def __init__(self, logger, engine=None, from_msg=None, **kwargs):
-    
         self.logger = logger
         self.engine = engine
-        self.session = self
         self.engine_created = False
 
         if self.engine is None:
             self.logger.debug("Passing engine will be required soon")
             from augur.application.db.engine import DatabaseEngine
-
             self.engine_created = True
-
             self.engine = DatabaseEngine().engine
             if from_msg:
                 logger.debug(f"ENGINE CREATE: {from_msg}")
             else:
-                logger.debug(f"ENGINE CREATE")
+                logger.debug("ENGINE CREATE")
 
-        super().__init__(self.engine, **kwargs)
+        super().__init__(bind=self.engine, **kwargs)   
 
     def __enter__(self):
         return self
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
-
-        if self.engine_created:
-            self.engine.dispose()
         
         self.close()
 
     def __del__(self):
         self.close()
-    
+
     def execute_sql(self, sql_text):
-
         with self.engine.begin() as connection:
-
-            return_data = connection.execute(sql_text)  
-
+            return_data = connection.execute(sql_text)
         return return_data
 
-    def fetchall_data_from_sql_text(self,sql_text):
-
+    def fetchall_data_from_sql_text(self, sql_text):
         with self.engine.begin() as connection:
-
             result = connection.execute(sql_text)
         return [dict(row) for row in result.mappings()]
 
-    def insert_data(self, data_input: Union[List[dict], dict], table, natural_keys: List[str], return_columns: Optional[List[str]] = None, string_fields: Optional[List[str]] = None, on_conflict_update:bool = True) -> Optional[List[dict]]:
+    def insert_data(
+        self,
+        data_input: Union[List[dict], dict],
+        table,
+        natural_keys: List[str],
+        return_columns: Optional[List[str]] = None,
+        string_fields: Optional[List[str]] = None,
+        on_conflict_update: bool = True
+    ) -> Optional[List[dict]]:
 
-        if isinstance(data_input, list) is False:
-            
-            # if a dict is passed to data then 
-            # convert it to a list with one value
-            if isinstance(data_input, dict) is True:
+       
+        if not isinstance(data_input, list):
+            if isinstance(data_input, dict):
                 data = [data_input]
-            
             else:
                 self.logger.info("Data must be a list or a dict")
                 return None
         else:
             data = list(data_input)
 
-        if len(data) == 0:
-            # self.logger.info("Gave no data to insert, returning...")
+        if not data:
             return None
 
-        if isinstance(data[0], dict) is False: 
+        if not isinstance(data[0], dict):
             self.logger.info("Must be list of dicts")
             return None
 
-        # remove any duplicate data 
-        # this only counts something as a duplicate if every field is the same
+      
         data = remove_duplicates_by_uniques(data, natural_keys)
 
-        # remove null data from string fields
+       
         if string_fields and isinstance(string_fields, list):
             data = remove_null_characters_from_list_of_dicts(data, string_fields)
 
-        # creates list of arguments to tell sqlalchemy what columns to return after the data is inserted
         returning_args = []
         if return_columns:
             for column in return_columns:
                 argument = getattr(table, column)
                 returning_args.append(argument)
 
-        # creates insert on table
-        # that returns cols specificed in returning_args
-        # and inserts the data specified in data
-        # NOTE: if return_columns does not have an values this still works
         stmnt = postgresql.insert(table).returning(*returning_args).values(data)
 
-
         if on_conflict_update:
-
-            # create a dict that the on_conflict_do_update method requires to be able to map updates whenever there is a conflict. See sqlalchemy docs for more explanation and examples: https://docs.sqlalchemy.org/en/14/dialects/postgresql.html#updating-using-the-excluded-insert-values
             setDict = {}
             base_table = getattr(table, "__table__", table)
             for key in data[0].keys():
                 existing_col = getattr(base_table.c, key)
                 setDict[key] = func.coalesce(getattr(stmnt.excluded, key), existing_col)
-                
+
             stmnt = stmnt.on_conflict_do_update(
-                #This might need to change
                 index_elements=natural_keys,
-                
-                #Columns to be updated
-                set_ = setDict
+                set_=setDict
             )
-
         else:
-            stmnt = stmnt.on_conflict_do_nothing(
-                index_elements=natural_keys
-            )
+            stmnt = stmnt.on_conflict_do_nothing(index_elements=natural_keys)
 
-
-        # print(str(stmnt.compile(dialect=postgresql.dialect())))
         attempts = 0
-        # creates list from 1 to 10
-        sleep_time_list = list(range(10,66))
+        sleep_time_list = list(range(10, 66))
         deadlock_detected = False
 
-
-        # if there is no data to return then it executes the insert then returns nothing
-        if not return_columns:
-            # TODO: duplicate-looking code alert
+        
+        def run_insert(statement):
+            nonlocal attempts, deadlock_detected
             while attempts < 10:
                 try:
-                    #begin keyword is needed for sqlalchemy 2.x
-                    #this is because autocommit support was removed in 2.0
                     with self.engine.begin() as connection:
-                        connection.execute(stmnt)
-                        break
+                        return connection.execute(statement)
                 except OperationalError as e:
-                    # print(str(e).split("Process")[1].split(";")[0])
                     if isinstance(e.orig, DeadlockDetected):
                         deadlock_detected = True
                         sleep_time = random.choice(sleep_time_list)
-                        self.logger.debug(f"Deadlock detected on {table.__table__} table...trying again in {round(sleep_time)} seconds: transaction size: {len(data)}")
+                        self.logger.debug(
+                            f"Deadlock detected on {getattr(table, '__table__', table)} table... "
+                            f"retrying in {sleep_time} seconds (transaction size: {len(data)})"
+                        )
                         time.sleep(sleep_time)
-
                         attempts += 1
                         continue
-                    
                     raise e
-
                 except Exception as e:
-                    #self.logger.info(e)
                     if len(data) == 1:
                         raise e
-                   
                     time.sleep(3)
                     first_half = data[:len(data)//2]
                     second_half = data[len(data)//2:]
-
-                    self.insert_data(first_half, table, natural_keys, return_columns, string_fields, on_conflict_update)
-                    self.insert_data(second_half,table, natural_keys, return_columns, string_fields, on_conflict_update)
-
+                    res1 = self.insert_data(first_half, table, natural_keys, return_columns, string_fields, on_conflict_update)
+                    res2 = self.insert_data(second_half, table, natural_keys, return_columns, string_fields, on_conflict_update)
+                    return (res1 or []) + (res2 or [])
             else:
                 self.logger.error("Unable to insert data in 10 attempts")
                 return None
 
-            if deadlock_detected is True:
+        if not return_columns:
+            run_insert(stmnt)
+            if deadlock_detected:
                 self.logger.error("Made it through even though Deadlock was detected")
-
-            # success  
-            return None
-        
-
-        # othewise it gets the requested return columns and returns them as a list of dicts
-        while attempts < 10:
-            try:
-                with self.engine.begin() as connection:
-                    return_data_tuples = connection.execute(stmnt)
-                    break
-            except OperationalError as e:
-                if isinstance(e.orig, DeadlockDetected):
-                    sleep_time = random.choice(sleep_time_list)
-                    self.logger.debug(f"Deadlock detected on {table.__table__} table...trying again in {round(sleep_time)} seconds: transaction size: {len(data)}")
-                    time.sleep(sleep_time)
-
-                    attempts += 1
-                    continue   
-
-                raise e
-
-            except Exception as e:
-                if len(data) == 1:
-                    raise e
-                
-                time.sleep(3)
-                first_half = data[:len(data)//2]
-                second_half = data[len(data)//2:]
-
-                self.insert_data(first_half, table, natural_keys, return_columns, string_fields, on_conflict_update)
-                self.insert_data(second_half, table, natural_keys, return_columns, string_fields, on_conflict_update)
-
-        else:
-            self.logger.error("Unable to insert and return data in 10 attempts")
             return None
 
-        if deadlock_detected is True:
-            self.logger.error("Made it through even though Deadlock was detected")
+        return_data_tuples = run_insert(stmnt)
+        if return_data_tuples is None:
+            return None
 
         return_data = [dict(row) for row in return_data_tuples.mappings()]
-        
-        #no longer working in sqlalchemy 2.x
-        #for data_tuple in return_data_tuples:
-        #    return_data.append(dict(data_tuple))
 
-        # using on confilict do nothing does not return the 
-        # present values so this does gets the return values
         if not on_conflict_update:
-
             conditions = []
             for column in natural_keys:
-
                 column_values = [value[column] for value in data]
+                column_obj = getattr(table, column)
+               
+                conditions.append(column_obj.in_(tuple(column_values)))
 
-                column = getattr(table, column)
-
-                conditions.append(column.in_(tuple(column_values)))
-
-            result = (
-                self.query(table).filter(*conditions).all()
-            )
-
+            result = self.query(table).filter(or_(*conditions)).all()
             for row in result:
-
-                return_dict = {}
-                for field in return_columns:
-
-                    return_dict[field] = getattr(row, field)
-
+                return_dict = {field: getattr(row, field) for field in return_columns}
                 return_data.append(return_dict)
 
+        if deadlock_detected:
+            self.logger.error("Made it through even though Deadlock was detected")
 
         return return_data

--- a/augur/tasks/init/__init__.py
+++ b/augur/tasks/init/__init__.py
@@ -4,28 +4,29 @@ from augur.application.db.session import DatabaseSession
 from augur.application.db.engine import DatabaseEngine
 from augur.application.config import AugurConfig
 
-def get_redis_conn_values():
 
+def get_redis_conn_values():
     logger = logging.getLogger(__name__)
 
+   
     with DatabaseEngine() as engine, DatabaseSession(logger, engine) as session:
-
         config = AugurConfig(logger, session)
 
-    redis_db_number = config.get_value("Redis", "cache_group") * 3
-    redis_conn_string = config.get_value("Redis", "connection_string")
+        redis_db_number = config.get_value("Redis", "cache_group") * 3
+        redis_conn_string = config.get_value("Redis", "connection_string")
 
-    if redis_conn_string[-1] != "/":
+    if redis_conn_string and redis_conn_string[-1] != "/":
         redis_conn_string += "/"
 
     return redis_db_number, redis_conn_string
 
+
 def get_rabbitmq_conn_string():
     logger = logging.getLogger(__name__)
 
+    
     with DatabaseEngine() as engine, DatabaseSession(logger, engine) as session:
         config = AugurConfig(logger, session)
-    
-        rabbbitmq_conn_string = config.get_value("RabbitMQ", "connection_string")
+        rabbitmq_conn_string = config.get_value("RabbitMQ", "connection_string")
 
-    return rabbbitmq_conn_string
+    return rabbitmq_conn_string


### PR DESCRIPTION
Fix: Prevent database connection leaks in config helpers
- Ensured all AugurConfig value lookups (get_redis_conn_values, get_rabbitmq_conn_string) are performed inside active DatabaseSession context managers.
- Adjusted DatabaseSession lifecycle to avoid disposing shared engines prematurely.
- Corrected recursive insert logic to merge results and prevent hidden leaks during retries.
- Added safety checks for empty config strings and fixed variable naming typo.
This resolves the issue where repeated calls to get_redis_conn_values opened new DB connections that were never closed. With this fix, connection pool usage remains stable under repeated calls.
