### PR TITLE
dont use repo_id as part of the natural key for a pull request

### DIFF
--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -119,7 +119,7 @@ def process_pull_requests(pull_requests, task_name, repo_id, logger, augur_db):
     # pr_urls are gloablly unique across github so we are using it to determine whether a pull_request we collected is already in the table
     # specified in pr_return_columns is the columns of data we want returned. This data will return in this form; {"pr_url": url, "pull_request_id": id}
     logger.info(f"{task_name}: Inserting prs of length: {len(pr_dicts)}")
-    pr_natural_keys = ["repo_id", "pr_src_id"]
+    pr_natural_keys = ["pr_src_id"]
     pr_return_columns = ["pull_request_id", "pr_url"]
     pr_string_fields = ["pr_src_title", "pr_body"]
     pr_return_data = augur_db.insert_data(pr_dicts, PullRequest, pr_natural_keys, 


### PR DESCRIPTION
**Description**
This removes the `repo_id` from the list of natural keys passed to `insert_data` when processing pull requests.

This prevents augur from trying to insert duplicate PRs from github on older instances where PRs may have been manually merged following the resolution of duplicate repos (i.e. two different repo_ids pointed to the same repo because that repo renamed itself). If repo_ids are not updated EVERYWHERE, this may cause augur to try and insert under the new, merged repo ID, and not detect that a duplicate value exists in the DB already. Therefore this would cause postgres to yell at augur because of an attempt to insert a PR with a duplicate URL.

Because we have strong reason to assume the `pr_src_id` from github is unique, we can rely solely on this as the check for duplicate information.

This PR fixes #3192

I notice the same issue exists in the gitlab code too.

This PR is arguably technically incomplete without also updating the unique constraints on the pull_requests table to also enforce uniqueness based ONLY on the `pr_src_id`. However, if a DB isn't perfectly deduplicated, the migration to this could cause some issues.

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->