### PR TITLE
Fix: Add null check for release target in tag collection

### DIFF
--- a/augur/tasks/github/releases/core.py
+++ b/augur/tasks/github/releases/core.py
@@ -38,7 +38,7 @@ def get_release_inf(repo_id, release, tag_only):
             'tag_only': tag_only
         }
     else:
-        if 'tagger' in release['target']:
+        if release['target'] and 'tagger' in release['target']:
 
             tagger = release["target"]["tagger"]
 


### PR DESCRIPTION
**Description**
- Adds null check for `release['target']` before using `in` operator in `get_release_inf()`
- Fixes `TypeError: argument of type 'NoneType' is not iterable` when collecting tags from repos with orphaned/lightweight tags

**Root Cause**
- When a repo has no GitHub Releases, the code falls back to collecting tags via GraphQL
- The `Ref.target` field "[returns null when object does not exist](https://docs.github.com/en/graphql/reference/objects#ref)" per GitHub's schema
- Line 41 used `if 'tagger' in release['target']` without checking if `target` is `None` first
- The same file already handles this correctly for `release['author']` on line 13

**Notes for Reviewers**
- Minimal one-line fix following the existing null-check pattern in the same function
- Affected repos (gitGNU/collectd, ceph/collectd, rhboot/grubby) are forks/mirrors with orphaned tag references pointing to deleted commits

**Testing**
- @cdolfi Could you please verify against the repos mentioned in #3455?  I am running a data collection task that I would rather not stop right now. 

**Signed commits**
- [x] Yes, I signed my commits.

**AI Disclosure**: I used Claude Code to draft this PR (not code, just the PR draft).

Closes #3455
