### PR TITLE
Fix(facade): Validate git timestamps to prevent PostgreSQL errors (#3458)

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -77,13 +77,17 @@ BACKEND_URL = f'{redis_conn_string}{redis_db_number+1}'
 class AugurCoreRepoCollectionTask(celery.Task):
 
     def augur_handle_task_failure(self,exc,task_id,repo_git,logger_name,collection_hook='core',after_fail=CollectionState.ERROR.value):
-            
+
         # Note: I think self.app.engine would work but leaving it to try later
         engine = get_engine()
 
         logger = AugurLogger(logger_name).get_logger()
 
         logger.error(f"Task {task_id} raised exception: {exc}\n Traceback: {''.join(traceback.format_exception(None, exc, exc.__traceback__))}")
+
+        if repo_git is None:
+            logger.error(f"Task {task_id} failed but could not extract repo_git from task args/kwargs. Cannot update collection status.")
+            return
 
         with get_session() as session:
             logger.info(f"Repo git: {repo_git}")


### PR DESCRIPTION
**Description**
- Adds `sanitize_timestamp()` to validate git timestamps before database insertion
- Uses `datetime.strptime` with `%z` format to validate timezone offsets
- Fixes `InvalidTimeZoneDisplacementValue` error from corrupted commit metadata
- Extracts `FALLBACK_TIMESTAMP` constant to avoid magic string duplication
- Adds null guard in `augur_handle_task_failure()` to prevent cascading errors when `repo_git` extraction fails

**Notes for Reviewers**
- The frr repository contains commits with corrupted metadata (e.g., `2106-02-07 06:28:23 -13068837`)
- Primary fix in `analyzecommit.py`: uses stdlib `datetime.strptime` to validate timestamps at extraction time
- Secondary fix in `celery_app.py`: prevents `NoResultFound` exception when error handler can't determine which repo failed
- Refactored existing `placeholder_date` local variable to use new `FALLBACK_TIMESTAMP` constant

**Testing**
- Tested `sanitize_timestamp()` locally against valid/invalid inputs
- @MoralCode  Could you please test against `frrouting/frr` repository which triggers this issue? I am running a data collection task that I would rather not stop right now. 

**Signed commits**
- [x] Yes, I signed my commits.

Fixes #3458

**AI Disclosure**: Used Claude Code for root cause analysis. Claude wrote the `sanitize_timestamp()` function which I ran locally to verify sanitization behavior. All code changes were reviewed and verified by me.