### PR TITLE
Skip non-public GitHub events in contributor_breadth_worker avoid keyerror #3468

### DIFF
--- a/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
+++ b/augur/tasks/data_analysis/contributor_breadth_worker/contributor_breadth_worker.py
@@ -129,6 +129,8 @@ def process_contributor_events(cntrb, cntrb_events, logger, tool_source, tool_ve
 
     cntrb_repos_insert = []
     for event_id_api in cntrb_events:
+        if not event_id_api.get('public', True):
+            continue    
 
         cntrb_repos_insert.append({
             "cntrb_id": cntrb['cntrb_id'],


### PR DESCRIPTION
Description
This PR fixes https://github.com/chaoss/augur/issues/3468 by defensively skipping non-public GitHub events in the
contributor_breadth_worker.

Some GitHub Events API responses (notably private fork events) do not include
repository metadata (e.g. repo.url), which causes the worker to raise a
KeyError and crash. Skipping non-public events avoids this failure and
aligns behavior with data generally available via the public GitHub API.

Notes for Reviewers

The change is intentionally minimal and defensive.
Only non-public events are skipped; no existing public event behavior
is modified.
This avoids relying on private repository data, which most Augur
deployments cannot reliably access.
Signed commits

 Yes, I signed my commits.