### PR TITLE
Fix: Eliminate redundant full table scans in messages and events collection (phase 1, only events.py)

### DIFF
--- a/augur/tasks/github/events.py
+++ b/augur/tasks/github/events.py
@@ -118,6 +118,9 @@ class BulkGithubEventCollection(GithubEventCollection):
 
         event_batch_size = get_batch_size("event")
 
+        issue_url_to_id_map = self._get_map_from_issue_url_to_id(repo_id)
+        pr_url_to_id_map = self._get_map_from_pr_url_to_id(repo_id)
+        
         events = []
         for event in self._collect_events(repo_git, key_auth, since):
             events.append(event)


### PR DESCRIPTION
**Description**


#### `augur/tasks/github/events.py`
- Built `issue_url_to_id_map` and `pr_url_to_id_map` once in `BulkGithubEventCollection.collect()` before the batch loop
- Updated `_process_events()`, `_process_issue_events()`, and `_process_pr_events()` to accept mappings as parameters
- Removed redundant `_get_map_from_*()` calls from batch processing methods
**Notes for Reviewers**

- This PR fixes (partially) #3440 


**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->