### PR TITLE
Fix broken 8knot link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you get stuck, please feel free to [ask for help](https://github.com/chaoss/a
 
 ## Contributing
 
-To contribute to Augur, please follow the guidelines found in our [CONTRIBUTING.md](CONTRIBUTING.md) and our [Code of Conduct](CODE_OF_CONDUCT.md). Augur is a welcoming community that is open to all, regardless if you're working on your 1000th contribution to open source or your 1st.
+To contribute to Augur, please follow the guidelines found in our [CONTRIBUTING.md](CONTRIBUTING.md) and the CHAOSS [Code of Conduct]([CODE_OF_CONDUCT.md](https://github.com/chaoss/.github/blob/main/CODE_OF_CONDUCT.md)). Augur is a welcoming community that is open to all, regardless if you're working on your 1000th contribution to open source or your 1st.
 We strongly believe that much of what makes open source so great is the incredible communities it brings together, so we invite you to join us!
 
 ## License, Copyright, and Funding


### PR DESCRIPTION
This PR fixes #3152 

This PR supersedes (and cherry picks a small piece of) #3269

**Notes for Reviewers**
the commiter field and timestamps were preserved from the original PR, just rebased onto main and amended by me to remove the CI job stuff.

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->