### PR TITLE
[tasks] Replace hardcoded tool_version with shared metadata version (Phase 1)

### DIFF
--- a/augur/tasks/github/repo_info/core.py
+++ b/augur/tasks/github/repo_info/core.py
@@ -11,6 +11,7 @@ from augur.application.db.lib import execute_sql
 from augur.tasks.github.util.github_task_session import *
 from augur.application.db.models.augur_data import RepoBadging
 from urllib.parse import quote
+from augur.metadata import __version__
 
 def query_committers_count(key_auth, logger, owner, repo):
 
@@ -223,7 +224,7 @@ def repo_info_model(key_auth, repo_orm_obj, logger):
         'pull_requests_closed': data['pr_closed']['totalCount'] if data['pr_closed'] else None,
         'pull_requests_merged': data['pr_merged']['totalCount'] if data['pr_merged'] else None,
         'tool_source': 'Repo_info Model',
-        'tool_version': '0.50.0',
+        'tool_version': __version__,
         'data_source': "Github"
     }
 
@@ -281,7 +282,6 @@ def badges_model(logger,repo_git,repo_id,db):
 
     #Hit cii api with no api key.
     response = hit_api(None, url, logger)
-
     try:
         response_data = response.json()
     except:


### PR DESCRIPTION
**Description**
- Replace hardcoded `tool_version` values in a small subset of Augur tasks
  by importing the shared version from `metadata.py`.
- This ensures consistency and avoids outdated version strings being written
  to the database.

This PR fixes #3486 (partial / Phase 1).

**Notes for Reviewers**
- This PR intentionally updates only two files as an initial step.
- No schema changes or behavior changes are introduced.
- Follow-up PRs can extend this approach to additional locations if desired.

**Signed commits**
- [ ] Yes, I signed my commits.
