### PR TITLE
Fix: missing commit_messages config variable and add automatic config value syncing

### DIFF
--- a/augur/application/cli/backend.py
+++ b/augur/application/cli/backend.py
@@ -28,6 +28,7 @@ from augur.application.db.session import DatabaseSession
 from augur.application.logs import AugurLogger
 from augur.application.db.lib import get_value
 from augur.application.cli import test_connection, test_db_connection, with_database, DatabaseContext
+from augur.application.config import AugurConfig
 import sqlalchemy as s
 
 from keyman.KeyClient import KeyClient, KeyPublisher
@@ -157,6 +158,10 @@ def start(ctx, disable_collection, development, pidfile, port):
             keypub.publish(key, "gitlab_rest")
         
         with DatabaseSession(logger, engine=ctx.obj.engine) as session:
+            # Sync missing config values from defaults to database
+            # This ensures new config values are automatically added for existing installations
+            config = AugurConfig(logger, session)
+            config.sync_missing_config_values()
 
             clean_collection_status(session)
             assign_orphan_repos_to_default_user(session)

--- a/augur/tasks/git/util/facade_worker/facade_worker/config.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/config.py
@@ -114,6 +114,18 @@ class FacadeHelper():
         with DatabaseSession(logger, engine) as session:
             config = AugurConfig(logger, session)
         
+            """ worker_options is a dictionary containing all settings from the "Facade" section
+            of the config. It comes from config.get_section("Facade"), which merges config
+            from multiple sources in order of precedence:
+            1. default_config (from augur/application/config.py)
+            2. augur.json file (if it exists)
+            3. Database config (augur_operations.config table)
+            
+            The merge uses dict.update(), so database values override defaults.
+            If a new config value is added to default_config but doesn't exist in the database,
+            it will be missing from worker_options unless sync_missing_config_values() has
+            been called to populate it.
+            """
             worker_options = config.get_section("Facade")
 
         self.limited_run = worker_options["limited_run"]
@@ -132,7 +144,7 @@ class FacadeHelper():
         self.multithreaded = worker_options["multithreaded"]
         self.create_xlsx_summary_files = worker_options["create_xlsx_summary_files"]
         self.facade_contributor_full_recollect = worker_options["facade_contributor_full_recollect"]
-        self.commit_messages = worker_options["commit_messages"]
+        self.commit_messages = worker_options.get("commit_messages", 1)
 
         self.tool_source = "Facade"
         self.data_source = "Git Log"


### PR DESCRIPTION
**Description**
1. Immediate fix: Changed `worker_options["commit_messages"]` to `worker_options.get("commit_messages", 1)` in `FacadeHelper.__init__` to prevent `KeyError` and use a safe default.
2. Long-term fix: Added `sync_missing_config_values()` method to `AugurConfig` that automatically syncs missing config values from `default_config` to the `database.` This method: Only adds values that don't exist in the database (preserves user customizations) Logs when adding missing values Is called during backend startup to ensure manual install users get new config values automatically 
3. Integration: Integrated the sync function into backend startup (augur backend start) so it runs automatically for all installations.

## Changes made: 
- `augur/tasks/git/util/facade_worker/facade_worker/config.py`: Added `.get()` fallback for `commit_messages` and documentation
- `augur/application/config.py`: Added `sync_missing_config_values()` method
- `augur/application/cli/backend.py`: Integrated config sync into startup process
- Solves #3476 

This PR fixes #3476 

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
5. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->