### PR TITLE
docs: redirect people to CONTRIBUTORS/MAINTAINERS.md in the maintainers section of index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,70 +59,11 @@ Who develops Augur
 - Many of Augur’s metrics come directly from the CHAOSS community.
 - If you want to get involved, visit the `CHAOSS website <https://chaoss.community>`_.
 
+For the current list of Augur maintainers and contributors, please refer to the
+`CONTRIBUTORS.md <https://github.com/chaoss/augur/blob/main/CONTRIBUTORS.md>`_
+file.
+
 See it in action
 -------------------
 
 - You can check out Augur live on the `CHAOSS instance <https://ai.chaoss.io>`_.
-
-
-Current maintainers
--------------------
-
-For the current list of Augur maintainers, please refer to the
-`CONTRIBUTORS.md <https://github.com/chaoss/augur/blob/main/CONTRIBUTORS.md>`_
-file.
-
-
-
-Former maintainers
---------------------
-- `Carter Landis <https://github.com/ccarterlandis>`_
-- `Gabe Heim <https://github.com/gabe-heim>`_
-- `Matt Snell <https://github.com/Nebrethar>`_
-- `Christian Cmehil-Warn <https://github.com/christiancme>`_
-- `Jonah Zukosky <https://github.com/jonahz5222>`_
-- `Carolyn Perniciaro <https://github.com/CMPerniciaro>`_
-- `Elita Nelson <https://github.com/ElitaNelson>`_
-- `Michael Woodruff <https://github.com/michaelwoodruffdev/>`_
-- `Max Balk <https://github.com/maxbalk/>`_
-
-Contributors
---------------------
-- `Dawn Foster <https://github.com/geekygirldawn/>`_
-- `Ivana Atanasova <https://github.com/ivanayov/>`_
-- `Georg J.P. Link <https://github.com/GeorgLink/>`_
-
-GSoC 2022 participants
------------------------
-- `Kaxada <https://github.com/kaxada>`_
-- `Mabel F <https://github.com/mabelbot>`_
-- `Priya Srivastava <https://github.com/Priya730>`_
-- `Ramya Kappagantu <https://github.com/RamyaKappagantu>`_
-- `Yash Prakash <https://gist.github.com/yash-yp>`__
-
-GSoC 2021 participants
------------------------
-- `Dhruv Sachdev <https://github.com/Dhruv-Sachdev1313>`_
-- `Rashmi K A <https://github.com/Rashmi-K-A>`_
-- `Yash Prakash <https://github.com/yash2002109/>`__
-- `Anuj Lamoria <https://github.com/anujlamoria/>`_
-- `Yeming Gu <https://github.com/gymgym1212/>`_
-- `Ritik Malik <https://gist.github.com/ritik-malik>`_
-
-GSoC 2020 participants
------------------------
-- `Akshara P <https://github.com/aksh555/>`_
-- `Tianyi Zhou <https://github.com/tianyichow/>`_
-- `Pratik Mishra <https://github.com/pratikmishra356/>`_
-- `Sarit Adhikari <https://github.com/sarit-adh/>`_
-- `Saicharan Reddy <https://github.com/mrsaicharan1/>`_
-- `Abhinav Bajpai <https://github.com/abhinavbajpai2012/>`_
-
-GSoC 2019 participants
------------------------
-- `Bingwen Ma <https://github.com/bing0n3/>`_
-- `Parth Sharma <https://github.com/parthsharma2/>`_
-
-GSoC 2018 participants
------------------------
-- `Keanu Nichols <https://github.com/kmn5409/>`_


### PR DESCRIPTION
**Description**
This PR updates the “Current Maintainers” section in docs/source/index.rst
to match the maintainer list in CONTRIBUTORS.md.


This PR fixes #3445


The change is limited to documentation only.
No code or schema changes were made.


**Signed commits**
- [ ] Yes, I signed my commits.
