### PR TITLE
Fix database migrations to support non-augur database usernames

### DIFF
--- a/augur/application/schema/alembic/versions/3_oauth_and_user_groups.py
+++ b/augur/application/schema/alembic/versions/3_oauth_and_user_groups.py
@@ -38,7 +38,7 @@ def upgrade():
 
 
             ALTER TABLE "augur_operations"."user_groups" 
-            OWNER TO "augur";
+            OWNER TO CURRENT_USER;
 
             INSERT INTO "augur_operations"."user_groups" ("group_id", "user_id", "name") VALUES (1, {}, 'default') ON CONFLICT ("user_id", "name") DO NOTHING;
             ALTER SEQUENCE user_groups_group_id_seq RESTART WITH 2;


### PR DESCRIPTION
**Description**
- Fixed two locations where `OWNER TO "augur"` was hardcoded:
- `0_legacy.py`: Added dynamic replacement of `OWNER TO "augur"` with `OWNER TO CURRENT_USER` before executing legacy SQL migration files
- `3_oauth_and_user_groups.py`: Changed hardcoded `OWNER TO "augur"` to `OWNER TO CURRENT_USER` in the `user_groups` table creation SQL

## Technical Details
- Uses PostgreSQL's `CURRENT_USER` keyword which always resolves to the current database session user
- Handles all variations: OWNER TO "augur", OWNER TO 'augur', OWNER TO augur
- No database queries needed - uses PostgreSQL's built-in functionality
- Works with any database username without code changes
- Solves #3417 


This PR fixes #3417 

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->