### PR TITLE
Fix #3474: Add default value for AUGUR_DOCKER_DEPLOY to prevent AttributeError on bare metal installs

### DIFF
--- a/augur/api/gunicorn_conf.py
+++ b/augur/api/gunicorn_conf.py
@@ -40,7 +40,7 @@ del is_dev
 # set the log location for gunicorn    
 logs_directory = get_value('Logging', 'logs_directory')
 
-is_docker = os.getenv("AUGUR_DOCKER_DEPLOY").lower() in ('true', '1', 't', 'y', 'yes')
+is_docker = os.getenv("AUGUR_DOCKER_DEPLOY", 'False').lower() in ('true', '1', 't', 'y', 'yes')
 accesslog = f"{logs_directory}/gunicorn.log"
 errorlog = f"{logs_directory}/gunicorn.log"
 


### PR DESCRIPTION
**Description**
   - Added default value 'False' to `os.getenv("AUGUR_DOCKER_DEPLOY")` in gunicorn_conf.py
   - Prevents AttributeError when environment variable is not set on bare metal installs
   - Follows the same pattern as AUGUR_DEV variable

This PR fixes #3474 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->