### PR TITLE
Revert database url retrieval so manual install works

### DIFF
--- a/augur/application/schema/alembic/env.py
+++ b/augur/application/schema/alembic/env.py
@@ -6,7 +6,6 @@ from augur.application.db.models.base import Base
 from augur.application.db.engine import get_database_string
 from sqlalchemy import create_engine
 from dotenv import load_dotenv
-import os
 import re
 from pathlib import Path
 
@@ -32,10 +31,7 @@ target_metadata = Base.metadata
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
-# possibly swap sqlalchemy.url with AUGUR_DB env var too
-
 sqlalchemy_url = get_database_string()
-
 
 VERSIONS_DIR = Path(__file__).parent / "versions"
 


### PR DESCRIPTION
**Description**
This PR fixes the database url handling in Alembic's config so that it accounts for the `db.config.json` file used by manual installs.

This issue was introduced in #3416 

The solution is essentially a revert back to calling get_database_string(). It also removes the code that fetches the string from alembic.ini, since thats a file committed to the repo and thus would never be a good place to store the database connection string/credentials.

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->