### PR TITLE
[lint] Disable pylint rule suggesting removal of explicit else blocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,3 +193,8 @@ ignore_missing_imports = true
 follow_imports = "skip"
 disallow_untyped_defs = false
 exclude_gitignore = true
+
+[tool.pylint.messages_control]
+disable = [
+    "R1705",  
+]


### PR DESCRIPTION
**Description**
This PR disables the Pylint rule that suggests removing explicit `else` blocks after `return`  statements. Keeping explicit `else` branches improves readability and makes developer intent clearer, especially for new contributors.

This PR fixes #3521

**Notes for Reviewers**
- Config-only change
- Disables Pylint rule R1705 (no-else-return)
- No runtime or behavior impact

**Signed commits**
- [ ] Yes, I signed my commits.
