### PR TITLE
fix(ci): resolve Podman E2E cleanup timeout failure

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -285,8 +285,8 @@ jobs:
         run: |
           podman compose -f docker-compose.yml up --no-build 2>&1 \
             | (./scripts/ci/await_all.py /tmp/regex_matches.txt \
-                && podman compose -f docker-compose.yml down -t 60)
-        timeout-minutes: 5
+                && podman compose -f docker-compose.yml down -t 120)
+        timeout-minutes: 7
         env:
           AUGUR_GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}
           AUGUR_GITHUB_USERNAME: ${{ github.repository_owner }}


### PR DESCRIPTION
Podman Compose uses a default 10-second shutdown timeout, which is insufficient for Augur's multi process architecture to terminate gracefully. Unlike Docker, podman exits with an error instead of force-killing containers when the timeout is exceeded. see [docs](https://docs.podman.io/en/latest/markdown/podman-stop.1.html)

resolves #3530 

Solution
- Added -t 60 flag to podman compose down to allow 60 seconds for graceful shutdown
- Increased timeout minutes from 3 to 5 to accommodate the extended shutdown window