### PR TITLE
Remove stale explorer_libyear_detail refresh from matview script

### DIFF
--- a/scripts/control/refresh-matviews.sh
+++ b/scripts/control/refresh-matviews.sh
@@ -6,6 +6,5 @@ psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.augur_new_contributors with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_contributor_actions with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_libyear_all with data;'
-psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_libyear_detail with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_new_contributors with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_entry_list with data;'


### PR DESCRIPTION
**Description**
The scripts/control/refresh-matviews.sh script references the materialized view
augur_data.explorer_libyear_detail.

This materialized view was dropped in migration 25 and is never recreated in any subsequent migration. As a result, running the refresh script against the current schema causes it to fail when attempting to refresh a non-existent view.

This pull request removes the stale refresh statement, bringing the script back into alignment with the current database schema.

This is a minimal, one-line fix and does not change any existing functionality beyond removing the invalid reference.

This PR fixes #3538

**Notes for Reviewers**
Note: Should be merged after #3482 (libyear column typo fix).
No runtime testing was performed, as this change removes a stale reference identified through schema and migration inspection.



**Signed commits**
- [x]  Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->