### PR TITLE
Remove obsolete explorer_libyear_all matview refresh

### DIFF
--- a/scripts/control/refresh-matviews.sh
+++ b/scripts/control/refresh-matviews.sh
@@ -5,6 +5,5 @@ psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.api_get_all_repos_commits with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.augur_new_contributors with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_contributor_actions with data;'
-psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_libyear_all with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_new_contributors with data;'
 psql -U augur -h localhost -p 5432 -d padres -c 'REFRESH MATERIALIZED VIEW augur_data.explorer_entry_list with data;'


### PR DESCRIPTION
Removes refresh of explorer_libyear_all, which was dropped in migration 25 and never recreated. Prevents failures when running refresh-matviews.sh.