### PR TITLE
Add .gitattributes to enforce LF line endings for source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Enforce LF line endings for source files
+*.py text eol=lf
+*.sh text eol=lf
+*.sql text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Docker-related files
+Dockerfile text eol=lf
+*.Dockerfile text eol=lf
+
+# Binary files (never modify)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.pdf binary


### PR DESCRIPTION
This PR adds a .gitattributes file to explicitly enforce LF line endings
for Python, shell, and other source files.

This prevents Windows-based Git configurations from automatically
rewriting line endings, which has caused CI and runtime issues.
