### PR TITLE
feat: Comment out working_commits for verification (#3323)

### DIFF
--- a/augur/application/db/lib.py
+++ b/augur/application/db/lib.py
@@ -106,18 +106,16 @@ def get_gitlab_repo_by_src_id(src_id):
         return repo
         
     
-def remove_working_commits_by_repo_id_and_hashes(repo_id, commit_hashes):
+# Commented out for issue #3323 - working_commits appears to be legacy/unused
+# def remove_working_commits_by_repo_id_and_hashes(repo_id, commit_hashes):
+#     remove_working_commits = s.sql.text("""DELETE FROM working_commits 
+#         WHERE repos_id = :repo_id AND working_commit IN :hashes
+#         """).bindparams(repo_id=repo_id,hashes=tuple(commit_hashes))
+#     execute_sql(remove_working_commits)  
 
-    remove_working_commits = s.sql.text("""DELETE FROM working_commits 
-        WHERE repos_id = :repo_id AND working_commit IN :hashes
-        """).bindparams(repo_id=repo_id,hashes=tuple(commit_hashes))
-    
-    execute_sql(remove_working_commits)  
-
-def remove_working_commits_by_repo_id(repo_id):
-
-    remove_working_commits = s.sql.text("""DELETE FROM working_commits WHERE repos_id=:repo_id""").bindparams(repo_id=repo_id)
-    execute_sql(remove_working_commits)
+# def remove_working_commits_by_repo_id(repo_id):
+#     remove_working_commits = s.sql.text("""DELETE FROM working_commits WHERE repos_id=:repo_id""").bindparams(repo_id=repo_id)
+#     execute_sql(remove_working_commits)
 
 def remove_commits_by_repo_id_and_hashes(repo_id, commit_hashes):
 
@@ -132,17 +130,15 @@ def remove_commits_by_repo_id(repo_id):
     remove_commits = s.sql.text("""DELETE FROM commits WHERE repo_id=:repo_id""").bindparams(repo_id=repo_id)
     execute_sql(remove_commits) 
 
-def get_working_commits_by_repo_id(repo_id):
-
-    query = s.sql.text("""SELECT working_commit FROM working_commits WHERE repos_id=:repo_id
-    """).bindparams(repo_id=repo_id)
-
-    try:
-        working_commits = fetchall_data_from_sql_text(query)
-    except:
-        working_commits = []
-
-    return working_commits
+# Commented out for issue #3323 - working_commits appears to be legacy/unused
+# def get_working_commits_by_repo_id(repo_id):
+#     query = s.sql.text("""SELECT working_commit FROM working_commits WHERE repos_id=:repo_id
+#     """).bindparams(repo_id=repo_id)
+#     try:
+#         working_commits = fetchall_data_from_sql_text(query)
+#     except:
+#         working_commits = []
+#     return working_commits
 
 def get_missing_commit_message_hashes(repo_id):
 

--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -5,7 +5,9 @@ import datetime
 from celery import group, chain
 
 from subprocess import check_output
-from augur.application.db.lib import get_session, get_repo_by_repo_git, get_repo_by_repo_id, remove_working_commits_by_repo_id_and_hashes, get_working_commits_by_repo_id, facade_bulk_insert_commits, bulk_insert_dicts, get_missing_commit_message_hashes
+from augur.application.db.lib import get_session, get_repo_by_repo_git, get_repo_by_repo_id, facade_bulk_insert_commits, bulk_insert_dicts, get_missing_commit_message_hashes
+# Commented out for issue #3323 - working_commits appears to be legacy/unused
+# from augur.application.db.lib import remove_working_commits_by_repo_id_and_hashes, get_working_commits_by_repo_id
 
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import trim_commits
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_absolute_repo_path, get_parent_commits_set, get_existing_commits_set
@@ -88,15 +90,13 @@ def trim_commits_facade_task(repo_git):
 
     facade_helper.inc_repos_processed()
     facade_helper.update_analysis_log(repo_id,"Beginning analysis.")
+    # Commented out for issue #3323 - working_commits appears to be legacy/unused
     # First we check to see if the previous analysis didn't complete
-
-    working_commits = get_working_commits_by_repo_id(repo_id)
-
+    # working_commits = get_working_commits_by_repo_id(repo_id)
     # If there's a commit still there, the previous run was interrupted and
     # the commit data may be incomplete. It should be trimmed, just in case.
-    commits_to_trim = [commit['working_commit'] for commit in working_commits]
-    
-    trim_commits(facade_helper,repo_id,commits_to_trim)
+    # commits_to_trim = [commit['working_commit'] for commit in working_commits]
+    # trim_commits(facade_helper,repo_id,commits_to_trim)
     # Start the main analysis
 
     facade_helper.update_analysis_log(repo_id,'Collecting data')
@@ -331,9 +331,10 @@ def analyze_commits_in_parallel(repo_git, multithreaded: bool)-> None:
     )
     if pendingCommitRecordsToInsert:
         facade_bulk_insert_commits(logger, pendingCommitRecordsToInsert)
-        
+    
+    # Commented out for issue #3323 - working_commits appears to be legacy/unused
     # Remove the working commit.
-    remove_working_commits_by_repo_id_and_hashes(repo_id, queue)
+    # remove_working_commits_by_repo_id_and_hashes(repo_id, queue)
 
     logger.info("Analysis complete")
     return

--- a/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/analyzecommit.py
@@ -167,13 +167,14 @@ def analyze_commit(
         logger.error(f"Failed to run git log for commit {commit}: {e}")
         return [], {}
 
-    try:
-        execute_sql(s.sql.text("""
-            INSERT INTO working_commits (repos_id, working_commit)
-            VALUES (:repo_id, :commit)
-        """).bindparams(repo_id=repo_id, commit=commit))
-    except Exception as e:
-        logger.error(f"Failed to insert working commit {commit} into DB: {e}")
+    # Commented out for issue #3323 - working_commits appears to be legacy/unused
+    # try:
+    #     execute_sql(s.sql.text("""
+    #         INSERT INTO working_commits (repos_id, working_commit)
+    #         VALUES (:repo_id, :commit)
+    #     """).bindparams(repo_id=repo_id, commit=commit))
+    # except Exception as e:
+    #     logger.error(f"Failed to insert working commit {commit} into DB: {e}")
 
     try:
         commit_message = check_output(

--- a/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/utilitymethods.py
@@ -32,7 +32,9 @@ import sqlalchemy as s
 from augur.application.db.models import *
 from .config import FacadeHelper as FacadeHelper
 from augur.tasks.util.worker_util import calculate_date_weight_from_timestamps
-from augur.application.db.lib import execute_sql, fetchall_data_from_sql_text, remove_working_commits_by_repo_id_and_hashes, remove_commits_by_repo_id_and_hashes, get_repo_by_repo_git, get_session
+from augur.application.db.lib import execute_sql, fetchall_data_from_sql_text, remove_commits_by_repo_id_and_hashes, get_repo_by_repo_git, get_session
+# Commented out for issue #3323 - working_commits appears to be legacy/unused
+# from augur.application.db.lib import remove_working_commits_by_repo_id_and_hashes
 from augur.application.db.util import execute_session_query
 #from augur.tasks.git.util.facade_worker.facade
 
@@ -59,12 +61,14 @@ def trim_commits(facade_helper, repo_id,commits):
 	if len(commits):
 		remove_commits_by_repo_id_and_hashes(repo_id, commits)
 	
+		# Commented out for issue #3323 - working_commits appears to be legacy/unused
 		# Remove the working commit.
-		remove_working_commits_by_repo_id_and_hashes(repo_id, commits)
+		# remove_working_commits_by_repo_id_and_hashes(repo_id, commits)
 
 	for commit in commits:
 		facade_helper.log_activity('Debug',f"Trimmed commit: {commit}")
-		facade_helper.log_activity('Debug',f"Removed working commit: {commit}")
+		# Commented out for issue #3323
+		# facade_helper.log_activity('Debug',f"Removed working commit: {commit}")
 
 def store_working_author(facade_helper, email):
 


### PR DESCRIPTION
### Summary
This PR addresses issue #3323 by commenting out all working_commits table usage to verify it's no longer needed before permanent removal. This is PR using approach to safely remove legacy code.


### Changes Made
All working_commits related code has been commented out with # TESTING: Commented out for issue #3323 markers:
1. Database Library Functions (lib.py)

- Commented out get_working_commits_by_repo_id()
- Commented out remove_working_commits_by_repo_id()
- Commented out remove_working_commits_by_repo_id_and_hashes()

2. Facade Tasks (facade_tasks.py)

-  Removed working_commits imports (line 8)
-  Commented out working_commits check in trim_commits_facade_task() (lines 93-97)
-  Commented out cleanup call in analyze_commits_in_parallel() (line 336)

3. Analyze Commit Worker (analyzecommit.py)

-  Commented out INSERT INTO working_commits statement (line 172)

4. Utility Methods (utilitymethods.py)

- Removed working_commits imports and cleanup calls from trim_commits()

### Testing Performed
Created and ran validation script that confirmed:
```
PASS: Database tables exist (both at 0 rows)
PASS: Module imports work without errors
PASS: working_commits functions are properly disabled
PASS: commits table remains accessible
```

### Related
- Issue #3323 

Fixes #3323 

Pls review @sgoggins @MoralCode @cdolfi 