### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,99 @@
+# Set default behavior to automatically normalize line endings.
+* text=auto
+
+# Force LF line endings for all text files
+*.py text eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+*.fish text eol=lf
+*.zsh text eol=lf
+
+# Configuration files
+*.ini text eol=lf
+*.cfg text eol=lf
+*.conf text eol=lf
+*.config text eol=lf
+*.toml text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+
+# Documentation
+*.md text eol=lf
+*.rst text eol=lf
+*.txt text eol=lf
+
+# SQL files
+*.sql text eol=lf
+
+# Web files
+*.html text eol=lf
+*.htm text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.vue text eol=lf
+
+# Template files
+*.j2 text eol=lf
+*.jinja text eol=lf
+*.jinja2 text eol=lf
+
+# Docker files
+Dockerfile* text eol=lf
+*.dockerfile text eol=lf
+docker-compose*.yml text eol=lf
+
+# Makefiles
+Makefile text eol=lf
+makefile text eol=lf
+*.mk text eol=lf
+
+# Git files
+.gitignore text eol=lf
+.gitattributes text eol=lf
+.gitmodules text eol=lf
+
+# CI/CD files
+.gitlab-ci.yml text eol=lf
+.travis.yml text eol=lf
+appveyor.yml text eol=lf
+
+# Other common text files
+*.xml text eol=lf
+*.svg text eol=lf
+*.csv text eol=lf
+*.tsv text eol=lf
+*.properties text eol=lf
+*.env text eol=lf
+*.sample text eol=lf
+LICENSE* text eol=lf
+CONTRIBUTING* text eol=lf
+CHANGELOG* text eol=lf
+README* text eol=lf
+
+# Binary files - ensure they're not modified
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.bz2 binary
+*.7z binary
+*.rar binary
+*.exe binary
+*.dll binary
+*.so binary
+*.dylib binary
+*.pyc binary
+*.pyo binary
+*.pyd binary
+*.whl binary
+*.egg binary


### PR DESCRIPTION
Fixes #3545

### Summary
This PR adds a .gitattributes file to the repository to prevent Windows CRLF line ending issues that can break Python scripts and shell script entrypoints.

### Changes

- Added .gitattributes file with rules to enforce LF line endings for:
- Python files (*.py)
- Shell scripts (*.sh)
- All text files (default * text=auto)
- Marked binary files appropriately to prevent line ending conversion

### Testing
The .gitattributes file follows GitHub's recommended format for handling line endings. This will prevent Git from automatically converting LF to CRLF on Windows systems, which has been causing issues in WSL and other Windows-based environments.

### Related Issues
Resolves #3545

Pls review @sgoggins @MoralCode @cdolfi 