### PR TITLE
Remove recursive flag from chmod in docker-compose issue 3306

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     user: 2345:2345  # Run as an arbitrary non-root user
     post_start:
       # Make sure the user has access to the volumes
-      - command: chmod -R 777 /facade /logs /config /cache
+      - command: chmod 777 /facade /logs /config /cache
         user: root
   
   # Flower is a UI that helps more easily monitor running tasks for celery workers.


### PR DESCRIPTION
Fixes #3306
Related to #3212

### Problem
When Augur restarts, the chmod -R 777 command recursively changes permissions on all files in /facade, /logs, /config, and /cache directories. This causes all files in cloned git repositories under /facade to have their permissions changed to 777, putting them in a dirty state where git sees all files as modified.

### Solution ( as sir @JohnStrunk proposed)
Removed the -R (recursive) flag from the chmod command. Now it only changes permissions on the directories themselves, not all files within them. This is sufficient for the container user to access these directories while preserving the original permissions of files inside them.

### Changes
Changed chmod -R 777 /facade /logs /config /cache to chmod 777 /facade /logs /config /cache
Testing
As noted by sir @JohnStrunk in the issue, this should work fine as long as the directories are empty on the first run of the container, which is the normal case.

Next Steps
I will work on #3212  next to address the broader podman compose compatibility issues.

Fixes #3306 

Pls review sir @sgoggins @MoralCode 