### PR TITLE
Add RabbitMQ healthcheck to prevent startup race conditions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,12 @@ services:
       - RABBIT_MQ_DEFAULT_VHOST=${AUGUR_RABBITMQ_VHOST:-augur_vhost}
     networks:
       - augur
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
 
   augur:
     image: augur-new:latest


### PR DESCRIPTION
**Description**
Added health check to rabbitmq to make sure it is fully initialized before other services connect. rabbitmq can take up to 60 secs to finish syncing its mnesia table on first startup, which was causing some ci timeouts. this fix allows rabbitmq enough time to start up correctly and stops premature connection attempts.

Logs - https://github.com/chaoss/augur/actions/runs/20908242825/job/60065967943?pr=3534
looking at the logs more carefully gives aspect that actual failure is augur-1 tried to connect to database and then postgreSQL was still initializing the error - "ERROR: connecting to database".  after that augur-1 exited with 254 , postgreSQL became ready at and rabbitmq was just still booting normally. 

This PR fixes #3548


**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->