### PR TITLE
Replace subprocess.call() with check_call() in db.py to prevent silent failures

### DIFF
--- a/augur/application/cli/db.py
+++ b/augur/application/cli/db.py
@@ -298,7 +298,7 @@ def upgrade_db_version():
 @test_db_connection
 def check_for_upgrade():
     """
-    Upgrade the configured database to the latest version
+    Show available database migration history
     """
     check_call(["alembic", "history", "-i"])
 


### PR DESCRIPTION
**Description**
I replaced subprocess.call with check_call in the database cli, ensuring that operations stop immediately and report errors if something goes wrong.

This PR fixes #3579

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->