### PR TITLE
fix: Use parameterized query to prevent SQL injection in email deletion

### DIFF
--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -140,17 +140,13 @@ def process_commit_metadata(logger, auth, contributorQueue, repo_id, platform_id
             return 
         
 
-        #Replace each instance of a single or double quote with escape characters 
-        #for postgres
-        escapedEmail = email.replace('"',r'\"')
-        escapedEmail = escapedEmail.replace("'",r'\'')
         # Resolve any unresolved emails if we get to this point.
         # They will get added to the alias table later
         # Do this last to absolutely make sure that the email was resolved before we remove it from the unresolved table.
         query = s.sql.text("""
             DELETE FROM unresolved_commit_emails
-            WHERE email='{}'
-        """.format(escapedEmail))
+            WHERE email = :email
+        """).bindparams(email=email)
 
         logger.debug(f"Updating now resolved email {email}")
 


### PR DESCRIPTION
**Description**
This PR replaces a string-formatted SQL `DELETE` query in `tasks.py` with a parameterized query.  
The previous implementation relied on manual escaping of user-provided input, which is error-prone and can lead to potential SQL injection risks. Using bound parameters aligns with SQLAlchemy best practices and improves overall query safety.

This PR fixes #<ISSUE_NUMBER>

**Notes for Reviewers**
- This is a small, targeted change limited to `tasks.py`
- No behavior changes are expected beyond safer query execution
- Manual string escaping has been removed in favor of parameter binding

**Signed commits**
- [x] Yes, I signed my commits.