### PR TITLE
feat(schema): add platform columns to contributors and fix data contamination (#3469)

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -189,6 +189,12 @@ class Contributor(Base):
         String,
         comment="Will be a double population with the same value as gh_login for github, but the local value for other systems. ",
     )
+    platform = Column(
+        String,
+        server_default=text("'github'::character varying"),
+        nullable=False
+    )
+    platform_username = Column(String)
     cntrb_email = Column(
         String,
         comment="This needs to be here for matching contributor ids, which are augur, to the commit information. ",
@@ -280,6 +286,8 @@ class Contributor(Base):
 
         contributor_obj.cntrb_id = cntrb_id.to_UUID()
         contributor_obj.cntrb_login = contributor['login']
+        contributor_obj.platform = 'github'
+        contributor_obj.platform_username = contributor['login']
         contributor_obj.cntrb_created_at = contributor['created_at'] if 'created_at' in contributor else None
         contributor_obj.cntrb_email = contributor['email'] if 'email' in contributor else None
         contributor_obj.cntrb_company = contributor['company'] if 'company' in contributor else None

--- a/augur/application/schema/alembic/versions/39_add_platform_columns_to_contributors.py
+++ b/augur/application/schema/alembic/versions/39_add_platform_columns_to_contributors.py
@@ -1,0 +1,33 @@
+"""add platform data to contributors
+
+Revision ID: 39
+Revises: 38
+Create Date: 2026-01-16 14:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+
+# revision identifiers, used by Alembic.
+revision = '39'
+down_revision = '38'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add columns to augur_data.contributors
+    op.add_column('contributors', sa.Column('platform', sa.String(), nullable=False, server_default='github'), schema='augur_data')
+    op.add_column('contributors', sa.Column('platform_username', sa.String(), nullable=True), schema='augur_data')
+    
+    # Backfill platform_username from gh_login for the default 'github' platform entries
+    # We use execute with text() for safe SQL execution
+    connection = op.get_bind()
+    connection.execute(text("UPDATE augur_data.contributors SET platform_username = gh_login WHERE platform = 'github'"))
+
+
+def downgrade():
+    op.drop_column('contributors', 'platform_username', schema='augur_data')
+    op.drop_column('contributors', 'platform', schema='augur_data')

--- a/augur/tasks/github/facade_github/core.py
+++ b/augur/tasks/github/facade_github/core.py
@@ -85,6 +85,8 @@ def query_github_contributors(logger, key_auth, github_url):
             cntrb = {
                 "cntrb_id" : cntrb_id.to_UUID(),
                 "cntrb_login": contributor['login'],
+                "platform": "github",
+                "platform_username": contributor['login'],
                 "cntrb_created_at": contributor['created_at'],
                 "cntrb_email": email,
                 "cntrb_company": company,


### PR DESCRIPTION
**Description**
 i have introduced platform column to contributors table, creating source of truth for contributor data origin. this resolvesdata contamination where gitlab data was being stuffed into github specific columns (gh_login, gh_id, etc.) and gives way for flexible multi platform support(github, gitlab, forgejo etc)

i have added platform (default: 'github') and platform_username columns to contributors table via new Alembic migration and also updated extraction logic to populate these new fields. gitlab tasks now correctly tag data as platform='gitlab' and leave gh_ columns as NULL.  refactored data_parse.py to use helper function (_extract_base_contributor_data), reducing code duplication and making it easier to add new platforms in the future and also migration automatically populates platform='github' and platform_username for all existing records.

This PR fixes #3469

**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->