### PR TITLE
fix: prevent theoretical NameError from uninitialized keys variable in github_api_key_handler.py

### DIFF
--- a/augur/tasks/github/util/github_api_key_handler.py
+++ b/augur/tasks/github/util/github_api_key_handler.py
@@ -92,13 +92,15 @@ class GithubApiKeyHandler():
         if redis_keys:
             return redis_keys
 
+        # Initialize keys to empty list to prevent NameError if all retries fail
+        keys = []
         attempts = 0
         while attempts < 3:
-
             try:
                 keys = self.get_api_keys_from_database()
                 break
-            except:
+            except Exception as e:
+                self.logger.warning(f"Failed to get API keys from database (attempt {attempts + 1}/3): {e}")
                 time.sleep(5)
                 attempts += 1
 
@@ -132,16 +134,6 @@ class GithubApiKeyHandler():
             raise NoValidKeysError("No valid github api keys found in the config or worker oauth table")
 
 
-        # shuffling the keys so not all processes get the same keys in the same order
-        valid_now = valid_keys
-        #try: 
-            #self.logger.info(f'valid keys before shuffle: {valid_keys}')
-            #valid_keys = random.sample(valid_keys, len(valid_keys))
-            #self.logger.info(f'valid keys AFTER shuffle: {valid_keys}')
-        #except Exception as e: 
-         #   self.logger.debug(f'{e}')
-         #   valid_keys = valid_now
-         #   pass 
 
         return valid_keys
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the `keys` variable in `get_api_keys()` may be uninitialized, causing a `NameError`.

## The Problem

If `get_api_keys_from_database()` fails all 3 retry attempts, the `keys` variable was never assigned, causing a crash on line 106:

```
NameError: name 'keys' is not defined
```

## Changes Made

1. **Initialize `keys = []` before the retry loop** - Prevents NameError if all attempts fail
2. **Replace bare `except:` with `except Exception as e:`** - Avoids catching system exceptions like KeyboardInterrupt
3. **Add logging for failed attempts** - Helps with debugging
4. **Remove unused code** - Deleted unused `valid_now` variable and commented-out code

## Testing

- Code review confirms the fix addresses the initialization issue
- The change is backwards compatible and doesn't affect normal operation

## Related

Fixes #3602

## Signed commits

- [x] Yes, I signed my commits.