### PR TITLE
fix: filter NULL comment URLs in github message task to prevent crash

### DIFF
--- a/augur/tasks/github/messages.py
+++ b/augur/tasks/github/messages.py
@@ -93,21 +93,21 @@ def process_large_issue_and_pr_message_collection(repo_id, repo_git: str, logger
 
         if since:
              query = text(f"""
-                (select pr_comments_url from pull_requests WHERE repo_id={repo_id} AND pr_updated_at > timestamptz(timestamp '{since}') order by pr_created_at desc)
+                (select pr_comments_url from pull_requests WHERE repo_id={repo_id} AND pr_comments_url IS NOT NULL AND pr_updated_at > timestamptz(timestamp '{since}') order by pr_created_at desc)
                 UNION
-                (select comments_url as comment_url from issues WHERE repo_id={repo_id} AND updated_at > timestamptz(timestamp '{since}') order by created_at desc);
+                (select comments_url as comment_url from issues WHERE repo_id={repo_id} AND comments_url IS NOT NULL AND updated_at > timestamptz(timestamp '{since}') order by created_at desc);
             """)
         else:
 
             query = text(f"""
-                (select pr_comments_url from pull_requests WHERE repo_id={repo_id} order by pr_created_at desc)
+                (select pr_comments_url from pull_requests WHERE repo_id={repo_id} AND pr_comments_url IS NOT NULL order by pr_created_at desc)
                 UNION
-                (select comments_url as comment_url from issues WHERE repo_id={repo_id} order by created_at desc);
+                (select comments_url as comment_url from issues WHERE repo_id={repo_id} AND comments_url IS NOT NULL order by created_at desc);
             """)
         
 
         result = connection.execute(query).fetchall()
-    comment_urls = [x[0] for x in result]
+    comment_urls = [x[0] for x in result if x[0] is not None]
 
     github_data_access = GithubDataAccess(key_auth, logger)
 


### PR DESCRIPTION
**Description**
filtering out NULL values for pull request and issue comment urls directly in the sql union query. this ensures that only valid endpoints are retrieved. it prevents potential worker crashes by adding secondary null check in list comprehension before passing urls to github paginator.

This PR fixes #3591


**Signed commits**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->