### PR TITLE
[tasks] fix: undefined variable 's' in start_tasks.py

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -4,6 +4,7 @@ import os
 #from celery.result import AsyncResult
 from celery import group, chain
 from sqlalchemy import and_,update
+import sqlalchemy as s
 
 
 from augur.tasks.github import *


### PR DESCRIPTION
The variable 's' (sqlalchemy) was undefined in start_tasks.py, causing a NameError in cleanup tasks. Imported 'sqlalchemy as s' to fix.

Description

This PR fixes a NameError in augur/tasks/start_tasks.py
where the variable s (intended as an alias for sqlalchemy) was used but never imported. The functions 
retry_errored_repos() and create_collection_status_records() both call s.sql.text() to construct SQL queries, which would crash at runtime with NameError: name 's' is not defined.
Added import sqlalchemy as s to resolve the issue and allow these cleanup tasks to execute successfully.
This PR fixes #3606 

Notes for Reviewers

This is a minimal, single-line fix that only adds the missing import statement
The fix has been verified by creating a test environment with mocked dependencies and successfully executing both affected functions
No other changes were made to keep the PR focused and easy to review

Signed commits
atheendre130505-atheendreramesh@gmail.com
 Yes, I signed my commits.