### PR TITLE
rearrange task processing such that there isnt a chain within a group

### DIFF
--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -118,11 +118,14 @@ def primary_repo_collect_phase_gitlab(repo_git, full_collection):
 def secondary_repo_collect_phase(repo_git, full_collection):
     logger = logging.getLogger(secondary_repo_collect_phase.__name__)
 
-    repo_task_group = group(
-        process_pull_request_files.si(repo_git, full_collection),
-        process_pull_request_commits.si(repo_git, full_collection),
-        chain(collect_pull_request_reviews.si(repo_git, full_collection), collect_pull_request_review_comments.si(repo_git, full_collection)),
-        process_ossf_dependency_metrics.si(repo_git)
+    repo_task_group = chain(
+        group(
+            process_pull_request_files.si(repo_git, full_collection),
+            process_pull_request_commits.si(repo_git, full_collection),
+            collect_pull_request_reviews.si(repo_git, full_collection),
+            process_ossf_dependency_metrics.si(repo_git)
+        ),
+        collect_pull_request_review_comments.si(repo_git, full_collection)
     )
 
     return repo_task_group


### PR DESCRIPTION
**Description**
This change refactors the task processing to preserve the ordering (i.e. fetch reviews first, then their comments) but does so in a way that is less likely to trigger celery bugs.

This PR fixes #3610 

**Notes for Reviewers**
Planning to test in prod on our instance (possibly)
im giving this a quick build and run on my machine to sanity check too
and the CI should check it

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->