### PR TITLE
Add health checks to Rabbit and Postgres to prevent race conditions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,15 @@ services:
       - augurpostgres:/var/lib/postgresql/data
     networks:
       - augur
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${AUGUR_DB_USER:-augur} -d ${AUGUR_DB_NAME:-augur}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: "redis:alpine"
@@ -47,6 +56,12 @@ services:
       - RABBIT_MQ_DEFAULT_VHOST=${AUGUR_RABBITMQ_VHOST:-augur_vhost}
     networks:
       - augur
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   augur:
     image: augur-new:latest
@@ -80,10 +95,14 @@ services:
       - CACHE_LOCKDIR=/cache
       - CELERYBEAT_SCHEDULE_DB=/tmp/celerybeat-schedule.db
     depends_on:
-      - augur-db
-      - redis
-      - augur-keyman
-      - rabbitmq
+      augur-db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      augur-keyman:
+        condition: service_started
+      rabbitmq:
+        condition: service_healthy
     networks:
       - augur
     user: 2345:2345  # Run as an arbitrary non-root user


### PR DESCRIPTION
This avoids some race conditions with the startup process that could create issues, especially on first initialization as noted in https://github.com/chaoss/augur/issues/3548 but also observed by me (rabbit had some 

**Description**
- Please include a summary of the change.

This PR fixes #3548
This pr also fixes #3612 (i think)

Thanks to @Sukuna0007Abhi and @guptapratykshh for submitting PRs on this that each addressed different parts of the issue. This PR is the combination of both works and you have both been credited in the commit message


**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->