### PR TITLE
Nest PR review comments collection inside pr review task

### DIFF
--- a/augur/tasks/github/pull_requests/tasks.py
+++ b/augur/tasks/github/pull_requests/tasks.py
@@ -535,3 +535,4 @@ def collect_pull_request_reviews(repo_git: str, full_collection: bool) -> None:
             logger.debug(f"{owner}/{repo} No pr reviews found for repo")
         else:
             logger.info(f"{owner}/{repo}: Completed - collected {total_reviews_collected} reviews total")
+    collect_pull_request_review_comments(repo_git, full_collection)

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -121,7 +121,7 @@ def secondary_repo_collect_phase(repo_git, full_collection):
     repo_task_group = group(
         process_pull_request_files.si(repo_git, full_collection),
         process_pull_request_commits.si(repo_git, full_collection),
-        chain(collect_pull_request_reviews.si(repo_git, full_collection), collect_pull_request_review_comments.si(repo_git, full_collection)),
+        collect_pull_request_reviews.si(repo_git, full_collection),
         process_ossf_dependency_metrics.si(repo_git)
     )
 


### PR DESCRIPTION
**Description**
An attempted fix suggested by Andrew

This change refactors the task processing to preserve the ordering (i.e. fetch reviews first, then their comments) by nesting it inside the task we know is running (pr reviews). This will make it take longer but may help things start actually succeeding

This PR fixes #3610 

**Notes for Reviewers**
Planning to test in prod on our instance (possibly)
i may give this a quick build and run on my machine to sanity check too
and the CI should check it

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->