### PR TITLE
Remove distributed from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "celery~=5.5",
     "click~=8.1",
     "coloredlogs==15.0",
-    "distributed>=2021.03.0",
     "emoji==1.2.0",
     "flask==2.0.2",
     "flask-cors==4.0.1",


### PR DESCRIPTION
fixes #3645

**Description**
- Removes the `distributed` package from `pyproject.toml`
- The `distributed` package is a scheduler for Dask, which was removed in #3336
- This dependency is no longer needed and can be safely removed

This PR fixes #3645

**Notes for Reviewers**
- Single line removal in `pyproject.toml`
- No code changes required as Dask/distributed was not being used anywhere in the codebase

**Signed commits**
- [x] Yes, I signed my commits.