### PR TITLE
Remove distributed dependency (Dask no longer used)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "celery~=5.5",
     "click~=8.1",
     "coloredlogs==15.0",
-    "distributed>=2021.03.0",
     "emoji==1.2.0",
     "flask==2.0.2",
     "flask-cors==4.0.1",


### PR DESCRIPTION
**Description**
Removes the unused distributed dependency from pyproject.toml since Dask support was removed earlier.

This PR fixes #3645 

**Signed commits**
- [x] Yes, I signed my commits.