### PR TITLE
Update pylint filter mode to 'diff_context' 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
           reporter: github-pr-review
           level: warning
           glob_pattern: "**/*.py"
-          filter_mode: "file"
+          filter_mode: "diff_context"
 
   misspell:
     name: runner / misspell


### PR DESCRIPTION
**Description**                                                                                                                 
- Change pylint action `filter_mode` from `"file"` to `"diff_context"` so it only flags issues on changed lines instead of the entire file. This PR fixes #3657                                                                                                             

**Notes for Reviewers**
One-line change. Previously, touching any line in a file would surface every pre-existing pylint issue in that file, which made PRs fail for unrelated reasons. `diff_context` scopes it to just the diff.

**Signed commits**
- [x] Yes, I signed my commits.