### PR TITLE
check for a lack of 200 status when looking up the moved repo name and log it

### DIFF
--- a/augur/tasks/github/detect_move/core.py
+++ b/augur/tasks/github/detect_move/core.py
@@ -59,10 +59,12 @@ def extract_owner_and_repo_from_endpoint(key_auth, url, logger):
     response_from_gh = hit_api(key_auth, url, logger)
 
     page_data = parse_json_response(logger, response_from_gh)
+    # Note: if parse_json_response fails, it will return a string, causing `in` to do a substring check.
+    # This may lead to a crash if the field is present but the parsing fails.
     if response_from_gh.status_code != 200 or 'full_name' not in page_data:
         logger.error(
             f"Unexpected response fetching redirect target: status={response_from_gh.status_code}, "
-            f"url={url}, body={page_data}"
+            f"url={url}, body={response_from_gh.text}"
         )
         raise Exception("Could not resolve owner/repo from redirect target due to missing data in the github response")
     full_repo_name = page_data['full_name']


### PR DESCRIPTION
**Description**
- This introduces a small defensive check for the HTTP status and presence of the value we need into the github move detection flow with some logging to help identify the root cause of the issue.

This PR will be helpful towards fixing #3621

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

AI provided the suggestion for this change and wrote the code, which was small enough for me to review manually and make some corrections to (such as printing the url from the variable we already have, removing some comments, etc.