### PR TITLE
enable the (new ish) CSV utils tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ constraint-dependencies = [
 addopts = "-ra -s"
 testpaths = [
     "tests/test_classes",
+    "tests/test_application/test_cli/test_csv_utils.py",
     # "tests/test_routes", # runs, but needs a fixture for connecting to the web interface of Augur
     # "tests/test_metrics",
     # "tests/test_tasks",


### PR DESCRIPTION
**Description**
in https://github.com/chaoss/augur/pull/3375, @shlokgilda improved the csv importer to be flexible with column order (since our CSVs are only 2 columns). This PR came with unit tests that were never enabled.

This PR fixes that by adding those tests to the list of tests that get run when `uv run pytest` is run (also in CI)
**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->