### PR TITLE
access GraphQL urls from the designated graphql helper class

### DIFF
--- a/augur/tasks/github/releases/core.py
+++ b/augur/tasks/github/releases/core.py
@@ -1,5 +1,6 @@
 #SPDX-License-Identifier: MIT
 from augur.tasks.github.util.github_task_session import *
+from augur.tasks.github.util.github_graphql_data_access import GithubGraphQlDataAccess
 from augur.application.db.models import *
 from augur.tasks.github.util.util import get_owner_repo
 from augur.tasks.github.util.gh_graphql_entities import request_graphql_dict
@@ -159,7 +160,7 @@ def fetch_data(key_auth, logger, github_url, repo_id, tag_only = False):
 
     owner, repo = get_owner_repo(github_url)
 
-    url = 'https://api.github.com/graphql'
+    url = GithubGraphQlDataAccess.base_url()
 
     query = get_query(logger, owner, repo, tag_only)
 

--- a/augur/tasks/github/repo_info/core.py
+++ b/augur/tasks/github/repo_info/core.py
@@ -93,7 +93,7 @@ def is_archived(logger, repo_data):
     return False
 
 def grab_repo_info_from_graphql_endpoint(key_auth, logger, query):
-    url = 'https://api.github.com/graphql'
+    url = GithubGraphQlDataAccess.base_url()
     # Hit the graphql endpoint and retry 3 times in case of failure
     logger.info("Hitting endpoint: {} ...\n".format(url))
     data = request_graphql_dict(key_auth, logger, url, query)

--- a/augur/tasks/github/util/github_graphql_data_access.py
+++ b/augur/tasks/github/util/github_graphql_data_access.py
@@ -20,7 +20,12 @@ class InvalidDataException(Exception):
     pass
 
 class GithubGraphQlDataAccess:
+    """Utilities for accessing the GitHub GraphQL API
+    """
     
+    @staticmethod
+    def base_url():
+        return URL
 
     def __init__(self, key_manager, logger: logging.Logger, ingore_not_found_error=False):
     


### PR DESCRIPTION
**Description**
This is essentially the same as #3685, but for the github graphQL API (another small step towards resolving https://github.com/chaoss/augur/issues/3277)

**Notes for Reviewers**
No testing done yet, pretty trivial change to set the pattern for how i want things to work with building URLs in the future

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->