### PR TITLE
fix(docker): remove geckodriver and firefox-esr

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -41,33 +41,10 @@ RUN set -x \
         postgresql-client \
         libpq-dev \
         build-essential \
-        chromium \
         tar \
         jq \
-        chromium-driver \
-        firefox-esr \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install Geckodriver
-RUN GECKODRIVER_VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.tag_name' | sed 's/v//') \
-    && ARCH=$(uname -m) \
-    && if [ "$ARCH" = "aarch64" ]; then \
-         GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux-aarch64.tar.gz"; \
-         GECKODRIVER_FILE="geckodriver-v${GECKODRIVER_VERSION}-linux-aarch64.tar.gz"; \
-       else \
-         GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz"; \
-         GECKODRIVER_FILE="geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz"; \
-       fi \
-    && wget $GECKODRIVER_URL \
-    && tar -xzf $GECKODRIVER_FILE \
-    && mv geckodriver /usr/local/bin/ \
-    && rm $GECKODRIVER_FILE
-
-# Verify installations
-RUN firefox --version
-RUN geckodriver --version
-
 
 EXPOSE 5000
 

--- a/docker/backend/graphical
+++ b/docker/backend/graphical
@@ -26,37 +26,11 @@ RUN set -x \
         build-essential \
         rustc \
         cargo \
-        chromium \
         tar \
 	jq \
-        chromium-driver \
         && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-# Install Firefox from Debian repositories for ARM64 architecture
-RUN set -x \
-    && apt-get update \
-    && apt-get install -y firefox-esr
-
-# Install Geckodriver
-RUN GECKODRIVER_VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r '.tag_name' | sed 's/v//') \
-    && ARCH=$(uname -m) \
-    && if [ "$ARCH" = "aarch64" ]; then \
-         GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux-aarch64.tar.gz"; \
-         GECKODRIVER_FILE="geckodriver-v${GECKODRIVER_VERSION}-linux-aarch64.tar.gz"; \
-       else \
-         GECKODRIVER_URL="https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz"; \
-         GECKODRIVER_FILE="geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz"; \
-       fi \
-    && wget $GECKODRIVER_URL \
-    && tar -xzf $GECKODRIVER_FILE \
-    && mv geckodriver /usr/local/bin/ \
-    && rm $GECKODRIVER_FILE
-
-# Verify installations
-RUN firefox --version
-RUN geckodriver --version
 
 # Ensure Rust directories are writable
 RUN mkdir -p /root/.rustup/downloads /root/.cargo/registry && \


### PR DESCRIPTION
**Description**
- Removed geckodriver and firefox-esr from docker/backend/Dockerfile and docker/backend/graphical.
- These dependencies are no longer needed for the backend services, and removing them reduces the Docker image size and build complexity.

This PR fixes #3678

**Notes for Reviewers**
- Verified that all geckodriver installation steps (download, extract, move) were removed.
- Verified that firefox-esr apt package installation was removed.
- This addresses feedback suggesting the removal of the browser layer entirely since the driver is gone.

**Signed commits**
- [.] Yes, I signed my commits.
