### PR TITLE
convert comments near contributor resolution functions into actual docstrings

### DIFF
--- a/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
+++ b/augur/tasks/github/facade_github/contributor_interfaceable/contributor_interface.py
@@ -289,7 +289,7 @@ def update_contributor(self, cntrb, max_attempts=3):
 
 
 
-def fetch_username_from_email(logger, auth, commit) -> dict:
+def fetch_username_from_email(logger, auth, commit) -> dict | None:
     """Try every distinct email found within a commit for possible username resolution.
     Add email to garbage table if can't be resolved.
     


### PR DESCRIPTION
**Description**
non-functional change to re-format our existing function docs in the contributor resolution file to be in proper python syntax so that they show up in peoples IDE's

**Notes for Reviewers**
no functional changes made. no testing done.
**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->