### PR TITLE
Docs/python support and virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ For more information on [how to get involved on the CHAOSS website](https://chao
 
 ## Collecting Data
 
-Augur aims to support the current officially supported Python versions (currently centered around **Python 3.11**). On OSX, you can create a ```Python3.11``` environment, by running:
+Augur aims to support the current officially supported Python versions (currently centered around **Python 3.11**). We use [uv](https://github.com/astral-sh/uv) to manage the Python environment because it is fast and takes care of virtual environments for you. To run a command, such as `pytest` in the python environment, you would write:
 
 ```bash
-python3.11 -m venv path/to/venv
+uv run pytest
 ```
+
+The first time this is run, `uv` will automatically download and install the python dependencies for you.
 
 Augur's main focus is to measure the overall health and sustainability of open source projects.
 


### PR DESCRIPTION
**Description**
Updates the "collecting data" section of the README to have a current picture of python support and uv usage

This supersedes https://github.com/chaoss/augur/pull/3448 and https://github.com/chaoss/augur/pull/3443 because it contains changes/inspiration from both

This PR fixes #3441

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->