### PR TITLE
Replaced sys.exit() with ClickException in test_connection decorator.…

### DIFF
--- a/augur/application/cli/__init__.py
+++ b/augur/application/cli/__init__.py
@@ -33,14 +33,14 @@ def test_connection(function_internet_connection):
                 print(traceback.format_exc())
 
             if not success:
-                print(
+                raise click.ClickException(
                     f"""
-                    \n\n{usage} command setup failed.
+                    {usage} command setup failed.
                     There was an error while testing for network connectivity
                     Please check your connection to the internet to run Augur
                     Consider setting http_proxy variables for limited access installations."""
                 )
-                sys.exit(-1)
+                
         
         return ctx.invoke(function_internet_connection, *args, **kwargs)
         


### PR DESCRIPTION
### Summary
This PR replaces one occurrence of `sys.exit()` with `click.ClickException`
in the network connectivity check.

### Motivation
As discussed in #3676, `sys.exit()` bypasses Python's exception handling
and makes testing and error propagation harder. This change establishes a
pattern for handling CLI failures using Click's exception system.

### Changes
- Replaced `sys.exit()` with `click.ClickException`
- No behavioral change intended (CLI still exits with an error message)

### Testing
- Ran tests locally using `python -m pytest`
- All existing tests pass

Note: This is intended as the first incremental change before updating the
remaining occurrences.
