### PR TITLE
Add Job to Automatically Clear Unresolved Emails

### DIFF
--- a/augur/application/config.py
+++ b/augur/application/config.py
@@ -57,6 +57,7 @@ default_config = {
                 "run_facade_contributors": 1,
                 "facade_contributor_full_recollect": 0,
                 "commit_messages": 1,
+                "unresolved_commit_emails_refresh_interval_hours": 48,
             },
             "Server": {
                 "cache_expire": "3600",

--- a/augur/application/db/lib.py
+++ b/augur/application/db/lib.py
@@ -517,6 +517,10 @@ def get_contributor_aliases_by_email(email):
     with get_session() as session:
 
         return session.query(ContributorsAlias).filter_by(alias_email=email).all()
+
+def clear_unresolved_commit_emails_table():
+    remove_commit = s.sql.text("""DELETE FROM unresolved_commit_emails""")
+    execute_sql(remove_commit)
     
 def get_unresolved_commit_emails_by_name(name):
 

--- a/augur/tasks/git/util/facade_worker/facade_worker/config.py
+++ b/augur/tasks/git/util/facade_worker/facade_worker/config.py
@@ -133,6 +133,7 @@ class FacadeHelper():
         self.create_xlsx_summary_files = worker_options["create_xlsx_summary_files"]
         self.facade_contributor_full_recollect = worker_options["facade_contributor_full_recollect"]
         self.commit_messages = worker_options["commit_messages"]
+        self.unresolved_commit_emails_refresh_interval_hours = worker_options["unresolved_commit_emails_refresh_interval_hours"]
 
         self.tool_source = "Facade"
         self.data_source = "Git Log"

--- a/augur/tasks/start_tasks.py
+++ b/augur/tasks/start_tasks.py
@@ -29,7 +29,7 @@ from augur.application.db.models import CollectionStatus, Repo
 from augur.tasks.util.collection_state import CollectionState
 from augur.tasks.util.collection_util import *
 from augur.tasks.git.util.facade_worker.facade_worker.utilitymethods import get_facade_weight_time_factor
-from augur.application.db.lib import execute_sql, get_session
+from augur.application.db.lib import execute_sql, get_session, clear_unresolved_commit_emails_table
 from augur.application.config import AugurConfig
 
 RUNNING_DOCKER = os.environ.get('AUGUR_DOCKER_DEPLOY') == "1"
@@ -390,3 +390,9 @@ def create_collection_status_records(self):
 
     # no longer recursively run this task because collection status records are added when repos are inserted
     #create_collection_status_records.si().apply_async(countdown=60*7)
+
+
+#Automatically re-try to resolve unresolved emails after a set amount of time
+@celery.task(bind=True)
+def clear_all_unresolved_commit_emails(self):
+    clear_unresolved_commit_emails_table()


### PR DESCRIPTION
**Description**
- Add Method to automatically clear emails in the unresolved table
- Automatically run this method every 48 hours by default
- Add a config option to control interval

**Notes for Reviewers**
Currently being tested

**Signed commits**
- [x] Yes, I signed my commits.
