### PR TITLE
add about augur section with our scope statement (lightly edited)

### DIFF
--- a/docs/source/about-augur/scope.rst
+++ b/docs/source/about-augur/scope.rst
@@ -1,0 +1,10 @@
+Scope of the Augur project
+==========================
+
+Augur focuses on collecting data from public git-based code hosting platforms ("Forges") such as GitHub and GitLab. This helps us produce data about the health and sustainability of software projects based on the relevant CHAOSS metrics.
+The data Augur collects covers more than just code contributions and extends to anything that can be derived from forge data, including comments, change reviews, releases, and other project activity or interactions. 
+
+This scope is intentionally narrower than that of the CHAOSS project as a whole to help keep the Augur project sustainable with the resources available.
+Usecases and discussion of perspectives outside this defined scope are still welcome in the CHAOSS community, but may not be a good fit for direct contributions to Augur.
+These usecases may work best as a complementary add-on project, new working group, or third-party addon to augur that depends on or extends Augur functionality.
+Future expansions of Augur's scope may also bring in these community addons into the main codebase if new resources become available to sustain such expansion.

--- a/docs/source/about-augur/toc.rst
+++ b/docs/source/about-augur/toc.rst
@@ -1,0 +1,9 @@
+About Augur
+===========
+This section contains more details about what the Augur project is, including its mission/scope, and what we hope to accomplish.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   scope

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ Augur Documentation
 
    getting-started/Welcome
    quick-start
+   about-augur/toc
    deployment/toc
    getting-started/toc
    development-guide/toc


### PR DESCRIPTION
**Description**
This adds the scope statement I have been drafting and circulating for review to the ReadTheDocs, creating a new section where some existing content can live

**Notes for Reviewers**
Ran this build locally and it seems to work
**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->