### PR TITLE
[db/models] Remove duplicate unique-prx constraint on pull_requests

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -1712,7 +1712,6 @@ class PullRequest(Base):
     __tablename__ = "pull_requests"
     __table_args__ = (
         UniqueConstraint("repo_id", "pr_src_id", name="unique-pr"),
-        UniqueConstraint("repo_id", "pr_src_id", name="unique-prx"),
         UniqueConstraint("pr_url", name="pull-request-insert-unique"),
         Index("id_node", "pr_src_id", "pr_src_node_id"),
         Index(


### PR DESCRIPTION
## Changeset
- Remove the redundant UniqueConstraint("repo_id", "pr_src_id", name="unique-prx") from the PullRequest model

## Notes
The pull_requests table had two identical constraints: unique-pr and unique-prx, both on (repo_id, pr_src_id). The insert in bulk_insert_dicts uses ON CONFLICT (pr_url) which targets pull-request-insert-unique. When a PR conflicts on unique-prx instead, the ON CONFLICT clause does not catch it, resulting in an unhandled IntegrityError. Removing the duplicate declaration stops new installs from creating it. A companion migration to DROP CONSTRAINT "unique-prx" on existing databases should follow.

## Related issues/PRs
- Fixes #3712

**Description**
- Removed duplicate unique-prx constraint declaration from PullRequest model

This PR fixes #3712

**Notes for Reviewers**
The model change alone is not enough for existing deployments — a DROP CONSTRAINT migration will be needed. Noting this for the follow-up.

**Signed commits**
- [x] Yes, I signed my commits.