### PR TITLE
[docs] Trim README "What is Augur?" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,7 @@ Augur is now releasing a dramatically improved new version. It is also available
 If the hosted instance already has a requested organization or repository it will be added to a user’s view. If its a new repository or organization, the user will be notified that collection will take (time required for the scale of repositories added). 
 
 ## What is Augur?
-Augur is a software suite for collecting and measuring structured data
-about [free](https://www.fsf.org/about/) and [open-source](https://opensource.org/docs/osd) software (FOSS) communities.
-
-We gather trace data for a group of repositories, normalize it into our data model, and provide a variety of metrics about said data. The structure of our data model enables us to synthesize data across various platforms to provide meaningful context for meaningful questions about the way these communities evolve.
-
-Augur’s main focus is to measure the overall health and sustainability of open source projects, as these types of projects are system critical for nearly every software organization or company. We do this by gathering data about project repositories and normalizing that into our data model to provide useful metrics about your project’s health.
-
-For example, one of our metrics is *burstiness*. Burstiness – how are short timeframes of intense activity, followed by a corresponding return to a typical pattern of activity, observed in a project? 
-This can paint a picture of a project’s focus and gain insight into the potential stability of a project and how its typical cycle of updates occurs. 
-
-We are a [CHAOSS](https://chaoss.community) project, and many of our
-metrics are implementations of the metrics defined by our awesome community. You can find a full list of them [here](https://chaoss.community/metrics/).
-
-For more information on [how to get involved on the CHAOSS website](https://chaoss.community/participate/).
+Augur is a software suite for collecting and measuring structured data about free and open-source software (FOSS) communities. It gathers data from Git logs, GitHub, and other sources, normalizes it into a shared data model, and exposes health and sustainability metrics via a REST API. For a full overview, see the [Augur documentation](https://oss-augur.readthedocs.io/en/main/).
 
 ## Collecting Data
 


### PR DESCRIPTION
## Changeset
- Replaced the multi-paragraph "What is Augur?" block in README.md with a 2-sentence summary and a link to the full readthedocs page

## Notes
The section was duplicating content that already lives in the readthedocs "what is augur" page which was recently updated. The README is already quite long, so trimming this down makes it easier to find the actually important quick-start info. The link keeps the detailed version accessible.

## Related issues/PRs
- Fixes #3703

**Description**
- Shortened the "What is Augur?" README section to 2 sentences + readthedocs link to avoid duplication

This PR fixes #3703

**Notes for Reviewers**
Simple content change — just removes duplicate prose and points to the canonical docs page.

**Signed commits**
- [x] Yes, I signed my commits.