### PR TITLE
[docs] Update OpenAPI spec version to 0.92.0 and document update process

### DIFF
--- a/docs/source/development-guide/documentation.rst
+++ b/docs/source/development-guide/documentation.rst
@@ -45,6 +45,25 @@ After opening it once, Make your changes in the regular ``docs/source`` folder a
     # after opening the documentation
     $ make docs
 
+Updating the REST API Spec Version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The OpenAPI specification for the REST API lives in ``docs/source/rest-api/spec.yml``.
+The ``info.version`` field in that file must be kept in sync with the project version
+defined in ``metadata.py``.
+
+When a new release is cut, update the version field:
+
+.. code-block:: yaml
+
+    info:
+      title: Augur REST API
+      version: 0.92.0   # update to match metadata.__version__
+
+There is no automated sync between ``metadata.py`` and ``spec.yml`` yet; updating both
+manually is the current process. See `#3688 <https://github.com/chaoss/augur/issues/3688>`_
+for the longer-term goal of automating this.
+
 Hosting
 ~~~~~~~
 Our documentation is graciously hosted by `Read the Docs <https://readthedocs.org/>`_.

--- a/docs/source/rest-api/spec.yml
+++ b/docs/source/rest-api/spec.yml
@@ -6,7 +6,7 @@ externalDocs:
 host: ai.chaoss.io
 info:
   title: Augur REST API
-  version: 0.60.0
+  version: 0.92.0
 openapi: 3.1.0
 paths:
   #utility endpoints


### PR DESCRIPTION
## Changeset
- Updated `info.version` in `docs/source/rest-api/spec.yml` from `0.60.0` to `0.92.0` to match the current release
- Added a "Updating the REST API Spec Version" section in `documentation.rst` explaining how to keep `spec.yml` in sync with `metadata.py`

## Notes
The OpenAPI page on readthedocs still showed "Augur REST API (v0.60.0)" which made it look like the docs were years out of date. There's no automated sync between `metadata.__version__` and the spec file yet, so I also added a short doc section explaining the manual process until that's automated (see #3688 for the longer-term goal).

## Related issues/PRs
- Fixes #3688
- Related to #3665

**Description**
- Updated OpenAPI spec version and documented the manual update process

This PR fixes #3688

**Notes for Reviewers**
Two-file change: version bump in spec.yml and a new subsection in the dev guide explaining how to keep it up to date.

**Signed commits**
- [x] Yes, I signed my commits.