### PR TITLE
[tasks/github] Catch ResourceGoneException in message collection

### DIFF
--- a/augur/tasks/github/messages.py
+++ b/augur/tasks/github/messages.py
@@ -4,7 +4,7 @@ from datetime import timedelta, timezone
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask
 from augur.application.db.data_parse import *
-from augur.tasks.github.util.github_data_access import GithubDataAccess, UrlNotFoundException
+from augur.tasks.github.util.github_data_access import GithubDataAccess, UrlNotFoundException, ResourceGoneException
 from augur.tasks.github.util.github_task_session import GithubTaskManifest
 from augur.tasks.util.worker_util import remove_duplicate_dicts
 from augur.tasks.github.util.util import get_owner_repo
@@ -124,8 +124,8 @@ def process_large_issue_and_pr_message_collection(repo_id, repo_git: str, logger
         try:
             messages = list(github_data_access.paginate_resource(comment_url))
             all_data += messages
-        except UrlNotFoundException:
-            logger.info(f"{task_name}: PR or issue comment url of {comment_url} returned 404. Skipping.")
+        except (UrlNotFoundException, ResourceGoneException) as e:
+            logger.info(f"{task_name}: Skipping {comment_url}: {e}")
             skipped_urls += 1
 
         if len(all_data) >= message_batch_size:


### PR DESCRIPTION
## Changeset
- Added `ResourceGoneException` to the import from `github_data_access` in `messages.py`
- Extended the existing `except UrlNotFoundException` clause to also catch `ResourceGoneException`

## Notes
Repos that have GitHub Issues disabled return HTTP 410 when you try to fetch comment URLs, which raises `ResourceGoneException` in `paginate_resource()`. Only `UrlNotFoundException` (404) was being caught, so message collection would crash on those repos and mark core collection as errored. The fix skips those URLs the same way 404s are already skipped, so collection continues normally for the rest of the repo.

The `ResourceGoneException` class is already defined in `github_data_access.py` and is already excluded from the tenacity retry logic there, so catching it here is the natural completion of that design.

## Related issues/PRs
- Fixes #3710

**Description**
- Catch ResourceGoneException (HTTP 410 / issues disabled) in message collection so the task doesn't crash

This PR fixes #3710

**Notes for Reviewers**
Two-line change: one import addition and one except clause extension. The log message now includes the exception string so it's clear whether it was a 404 or a 410.

**Signed commits**
- [x] Yes, I signed my commits.