### PR TITLE
[tasks/init] Handle stale repo_git in augur_handle_task_failure

### DIFF
--- a/augur/tasks/init/celery_app.py
+++ b/augur/tasks/init/celery_app.py
@@ -87,7 +87,14 @@ class AugurCoreRepoCollectionTask(celery.Task):
 
         with get_session() as session:
             logger.info(f"Repo git: {repo_git}")
-            repo = session.query(Repo).filter(Repo.repo_git == repo_git).one()
+            repo = session.query(Repo).filter(Repo.repo_git == repo_git).one_or_none()
+
+            if repo is None:
+                logger.warning(
+                    f"Repo with git url {repo_git} not found during failure handling "
+                    f"(it may have been renamed); skipping status update."
+                )
+                return
 
             repoStatus = repo.collection_status[0]
 


### PR DESCRIPTION
## Changeset
- Changed `session.query(Repo).filter(...).one()` to `.one_or_none()` in `augur_handle_task_failure`
- Return early with a warning log when the repo is not found instead of raising NoResultFound

## Notes
When `detect_github_repo_move_core` detects that a repo has moved it updates the DB's `repo_git` to the new URL and then raises an exception. The `on_failure` Celery handler then tries to look up the repo by the old URL, which no longer matches anything in the DB, so `.one()` raises `NoResultFound`. This secondary exception masked the original one and showed up as a separate error in the worker logs.

Using `.one_or_none()` and returning early when the repo is not found avoids the crash. It's safe to skip the status update in this case because the repo-move handler already reset the collection state before raising.

## Related issues/PRs
- Fixes #3421

**Description**
- Switched repo lookup in failure handler to one_or_none() to avoid NoResultFound when a repo's URL has changed

This PR fixes #3421

**Notes for Reviewers**
The fix is in `augur_handle_task_failure` which is shared by both `AugurCoreRepoCollectionTask` and `AugurSecondaryRepoCollectionTask` (via inheritance), so both are covered.

**Signed commits**
- [x] Yes, I signed my commits.