### PR TITLE
[db/models] Widen releases.release_id column to Text

### DIFF
--- a/augur/application/db/models/augur_data.py
+++ b/augur/application/db/models/augur_data.py
@@ -1854,7 +1854,7 @@ class Release(Base):
     __table_args__ = {"schema": "augur_data"}
 
     release_id = Column(
-        CHAR(128),
+        Text,
         primary_key=True,
         server_default=text("nextval('augur_data.releases_release_id_seq'::regclass)"),
     )

--- a/augur/application/schema/alembic/versions/39_widen_release_id_to_text.py
+++ b/augur/application/schema/alembic/versions/39_widen_release_id_to_text.py
@@ -1,0 +1,39 @@
+"""widen release_id column to Text
+
+GitHub GraphQL node IDs for tags/releases are base64 strings that can
+exceed the original CHAR(128) / CHAR(64) limit seen in older installs.
+Change the column to Text so any length ID can be stored.
+
+Revision ID: 39
+Revises: 38
+Create Date: 2026-02-19
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '39'
+down_revision = '38'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        'releases',
+        'release_id',
+        existing_type=sa.CHAR(),
+        type_=sa.Text(),
+        schema='augur_data',
+    )
+
+
+def downgrade():
+    op.alter_column(
+        'releases',
+        'release_id',
+        existing_type=sa.Text(),
+        type_=sa.CHAR(length=128),
+        schema='augur_data',
+    )


### PR DESCRIPTION
## Changeset
- Changed `release_id` column type in the `Release` ORM model from `CHAR(128)` to `Text`
- Added Alembic migration `39_widen_release_id_to_text.py` to apply the change to existing databases

## Notes
GitHub GraphQL node IDs for tags are base64-encoded strings. Newer GitHub IDs (like those for tags in repos with very long ref names) can be well over 128 characters — the offending value in the issue decodes to 209 characters, and the base64-encoded form stored in the DB is 252 characters. Both `CHAR(64)` (legacy installs) and `CHAR(128)` (current ORM) are too narrow.

Changing to `Text` removes the artificial limit entirely. The `release_id` is used as a natural key so it needs to hold the full GitHub node ID regardless of length. `release_name` and `release_tag_name` are already `String` (unlimited varchar) in the ORM, this just brings `release_id` in line with them.

## Related issues/PRs
- Fixes #3454

**Description**
- Changed releases.release_id from CHAR to Text and added migration so long GitHub tag IDs no longer cause DataError

This PR fixes #3454

**Notes for Reviewers**
The migration uses `op.alter_column` which on PostgreSQL translates to `ALTER TABLE ... ALTER COLUMN ... TYPE TEXT`. The downgrade reverts to CHAR(128) — note that restoring CHAR from TEXT requires a CAST so data longer than 128 chars would be lost on downgrade (this is expected and acceptable).

**Signed commits**
- [x] Yes, I signed my commits.