### PR TITLE
chown the definitions to the rabbit user after our script edits them

### DIFF
--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -12,7 +12,6 @@ ARG RABBIT_MQ_DEFAULT_VHOST=augur_vhost
 COPY --chown=rabbitmq:rabbitmq ./docker/rabbitmq/augur.conf /etc/rabbitmq/conf.d/
 
 ADD docker/rabbitmq/definitions.json /etc/rabbitmq/
-RUN chown rabbitmq:rabbitmq /etc/rabbitmq/definitions.json
 
 ADD docker/rabbitmq/advanced.config /etc/rabbitmq/
 RUN chown rabbitmq:rabbitmq /etc/rabbitmq/advanced.config
@@ -23,3 +22,5 @@ RUN apk add --no-cache python3
 COPY docker/rabbitmq/update_config.py /
 
 RUN exec python3 update_config.py
+
+RUN chown rabbitmq:rabbitmq /etc/rabbitmq/definitions.json


### PR DESCRIPTION
**Description**
- This makes a small adjustment to our container build order for rabbitmq such that the permissions are changed after our script that adjusts rabbit config is run

This PR fixes #3734

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->