### PR TITLE
look up unresolved contributors by email, not name

### DIFF
--- a/augur/application/db/lib.py
+++ b/augur/application/db/lib.py
@@ -517,12 +517,6 @@ def get_contributor_aliases_by_email(email):
     with get_session() as session:
 
         return session.query(ContributorsAlias).filter_by(alias_email=email).all()
-    
-def get_unresolved_commit_emails_by_name(name):
-
-    with get_session() as session:
-
-        return session.query(UnresolvedCommitEmail).filter_by(name=name).all()
 
 def get_unresolved_commit_emails_by_email(email):
 

--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -6,7 +6,7 @@ from augur.tasks.init.celery_app import AugurFacadeRepoCollectionTask
 from augur.tasks.github.util.github_data_access import GithubDataAccess, UrlNotFoundException
 from augur.tasks.github.util.github_random_key_auth import GithubRandomKeyAuth
 from augur.tasks.github.facade_github.core import *
-from augur.application.db.lib import execute_sql, get_contributor_aliases_by_email, get_unresolved_commit_emails_by_name, get_unresolved_commit_emails_by_email, get_contributors_by_full_name, get_repo_by_repo_git, batch_insert_contributors, get_batch_size
+from augur.application.db.lib import execute_sql, get_contributor_aliases_by_email, get_unresolved_commit_emails_by_email, get_contributors_by_full_name, get_repo_by_repo_git, batch_insert_contributors, get_batch_size
 from augur.application.db.lib import get_session, execute_session_query
 from augur.tasks.git.util.facade_worker.facade_worker.facade00mainprogram import *
 


### PR DESCRIPTION
**Description**
This is a quick, but real fix to break the chain of bugs that has led to some contributor resolution issues.

Cant link a specific issue since im not aware of there being one for precisely what this fixes and im still waiting on testing to see how completely this resolves the main issue (#3693 )

I think this bug combined with https://github.com/chaoss/augur/issues/3740 to basically block a large fraction of contributors from ever even starting to get resolved

**Notes for Reviewers**
Am testing this alongside #3735 on my local instance. mostly bottlenecked on api key capacity (using one key)

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->