### PR TITLE
lint: remove invalid type annotation in repo_load_controller

### DIFF
--- a/augur/util/repo_load_controller.py
+++ b/augur/util/repo_load_controller.py
@@ -277,7 +277,7 @@ class RepoLoadController:
                 return None, {"status": "Invalid order by"}
             
             # Find the column named in the 'order_by', and get its asc() or desc() method 
-            directive: getattr(get_colum_by_label(order_by), direction.lower())
+            directive = getattr(get_colum_by_label(order_by), direction.lower())
             
             repos = repos.order_by(directive())
 


### PR DESCRIPTION
Removes invalid type annotation (function) that caused pylint E0602 (undefined-variable).

No functional behavior change.

Lint and tests pass locally.