### PR TITLE
Port prior updates to central contributor extractor

### DIFF
--- a/augur/application/db/data_parse.py
+++ b/augur/application/db/data_parse.py
@@ -645,8 +645,6 @@ def extract_needed_message_data(comment: dict, platform_id: int, repo_id: int, t
     return dict_data
 
 def extract_needed_contributor_data(contributor, tool_source, tool_version, data_source):
-    # Set platform id to 1 since it is a github method
-    platform_id = 1
 
     if not contributor:
         return None


### PR DESCRIPTION
**Description**
in #3695 the contributor profile fields were updated for additional robustness

This only changed one of the many places we build this object due to our current tech debt

this PR updates the central function we built for this purpose to reflect these changes (and some small ones from what i saw in the contributor resolution process

**Notes for Reviewers**
This is part of a chain of PRs. while they should be largely independent,  id suggest merging this first

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->