### PR TITLE
Fix automatic contributor refresh

### DIFF
--- a/augur/tasks/github/contributors.py
+++ b/augur/tasks/github/contributors.py
@@ -12,6 +12,7 @@ from augur.application.db.data_parse import extract_needed_contributor_data as e
 
 from augur.application.db.lib import bulk_insert_dicts, get_session, batch_insert_contributors
 from augur.tasks.github.util.github_random_key_auth import GithubRandomKeyAuth
+import json
 
 
 


### PR DESCRIPTION
**Description**
in https://github.com/chaoss/augur/issues/3748#issuecomment-3995432049 @shlokgilda pointed out that A) a bug was preventing the periodic hourly contributor profile refresh task from running, and b) this task was not pulling any useful updated info from the users profile

This PR fixes #3748

**Notes for Reviewers**
this PR by itself may be broken if #3754 is not also merged - they should be independent as far as merge order though

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->