### PR TITLE
deduplicate contributor creation in facade contributor resolution

### DIFF
--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -111,7 +111,7 @@ def process_commit_metadata(logger, auth, contributorQueue, repo_id, platform_id
         if not cntrb.get('cntrb_canonical'):
             cntrb['cntrb_canonical'] = emailFromCommitData
         if not cntrb.get('cntrb_email'):
-            cntrb['cntrb_canonical'] = emailFromCommitData
+            cntrb['cntrb_email'] = emailFromCommitData
         
         if not cntrb.get('cntrb_full_name'):
             cntrb['cntrb_full_name'] = name_field


### PR DESCRIPTION
**Description**
The Augur repo suffers from massive code duplication. one place this happens is when creating dicts to populate the contributors table.

We already have a function for this that isnt being used.

This updates the facade task responsible for contributor resolution such that it doesn't reinvent the wheel and properly reuses the shared code (which means it will benefit from the improvements in #3754)

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->