### PR TITLE
mask keys being printed by GithubDataAccess

### DIFF
--- a/augur/tasks/github/util/github_data_access.py
+++ b/augur/tasks/github/util/github_data_access.py
@@ -123,8 +123,8 @@ class GithubDataAccess:
 
             if response.status_code in [403, 429]:
                 self.expired_keys_for_request.append(self.key)
-                self.logger.warning(f"Github rate limit exceeded. Key: {mask_key(self.key[-5:])}. Response: {response.text}")
-                raise RatelimitException(response, self.expired_keys_for_request[-5:])
+                self.logger.warning(f"Github rate limit exceeded. Key: {mask_key(self.key)}. Response: {response.text}")
+                raise RatelimitException(response, self.expired_keys_for_request)
 
             # There are cases with PR files, PR commits, and messages where the parent object is removed after 
             # It is collected, leading the the associated URL for those objects to return a 404. 
@@ -148,7 +148,7 @@ class GithubDataAccess:
             try:
                 if self.feature == "rest" and "X-RateLimit-Remaining" in response.headers and int(response.headers["X-RateLimit-Remaining"]) < GITHUB_RATELIMIT_REMAINING_CAP:
                     self.expired_keys_for_request.append(self.key)
-                    raise RatelimitException(response, self.expired_keys_for_request[-5:])
+                    raise RatelimitException(response, self.expired_keys_for_request)
             except ValueError:
                 self.logger.warning(f"X-RateLimit-Remaining was not an integer. Value: {response.headers['X-RateLimit-Remaining']}")
 
@@ -226,7 +226,7 @@ class GithubDataAccess:
             self.key = self.key_client.expire(self.key, time.time() + 60)
 
         if previous_key == self.key:
-            self.logger.error(f"The same key was returned after a request to expire it was sent (key: {mask_key(self.key[-5:])})")
+            self.logger.error(f"The same key was returned after a request to expire it was sent (key: {mask_key(self.key)})")
 
     def __add_query_params(self, url: str, additional_params: dict) -> str:
         """Add query params to a url.


### PR DESCRIPTION
**Description**
This makes use of our existing mask_key utility function to protect an additional place we are printing api keys unnecessarily 

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->