### PR TITLE
prevent bandit from security scanning unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,3 +166,6 @@ ignore_missing_imports = true
 follow_imports = "skip"
 disallow_untyped_defs = false
 exclude_gitignore = true
+
+[tool.bandit]
+exclude_dirs = ["tests"]


### PR DESCRIPTION
**Description**
Recent PRs and also maintainer observations have pointed out that the new `bandit` security tool added in #3732 is flagging a LOT of things, mostly in the unit tests.

This PR fixes #3750  and disabled bandit scanning for files in the `tests` folder.

**Notes for Reviewers**

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->