### PR TITLE
limit hourly contributor processing for large instances

### DIFF
--- a/augur/tasks/github/contributors.py
+++ b/augur/tasks/github/contributors.py
@@ -36,7 +36,7 @@ def process_contributors():
                 Contributor.cntrb_created_at.is_(None),
                 Contributor.cntrb_last_used.is_(None)
             )
-            .limit(100)
+            .limit(500)
         )
         contributors = execute_session_query(query, 'all')
 


### PR DESCRIPTION
**Description**
contributor processing stores at least two copies of the full list of contributors that havent yet had profile information fetched. On large instances (i.e. ours) this is over 50k records. This causes the process to take more than an hour, stacking them up until all the memory is gone.

This PR resolves this by applying a fix discussed in the last maintainers call: adding a limit to the query so it can only process up to some number of contributors an hour.

I chose 500 because its 1/10 of the available rate limit (5000 REST calls) for a single github key, a low enough number to process relatively quickly, yet also high enough to process 12,000 contrubutors over 24 hours, providing large instances with decent meaningful progress.

To be honest, this is probably a little low, and could probably be bumped to 1000. my brain is tired and i was assuming one github API key when thinking about the limit  

This PR fixes #3770

**Notes for Reviewers**
I will be testing this on our prod instance

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->