### PR TITLE
[facade] fix contributor resolution permanently skipping commits with null cmt_ght_author_id

### DIFF
--- a/augur/tasks/github/facade_github/tasks.py
+++ b/augur/tasks/github/facade_github/tasks.py
@@ -212,7 +212,7 @@ def insert_facade_contributors(self, repo_git):
                 commits.repo_id = :repo_id
                 AND commits.cmt_ght_author_id IS NULL
                 AND commits.cmt_author_raw_email NOT IN (
-                    SELECT email FROM unresolved_commit_emails
+                    SELECT email FROM augur_data.unresolved_commit_emails
                 )
             ORDER BY hash
     """).bindparams(repo_id=repo_id)
@@ -276,11 +276,11 @@ def insert_facade_contributors(self, repo_git):
         )
         SELECT
             d.cntrb_id,
-            d.email
+            c.cmt_author_email AS email
         FROM
             commits c
         INNER JOIN
-            deduplicated d ON c.cmt_author_raw_email = d.email
+            deduplicated d ON c.cmt_author_email = d.email
         WHERE
             c.cmt_ght_author_id IS NULL
             AND c.repo_id = :repo_id


### PR DESCRIPTION
## Changeset
- Replace the `new_contrib_sql` query in `insert_facade_contributors` — the old query selected unresolved commits by checking whether the commit's email was **absent** from the `contributors`/`contributors_aliases` tables, gated behind a `last_collection_date` window. Now uses `cmt_ght_author_id IS NULL` as the sole eligibility signal, excluding known-dead emails via `unresolved_commit_emails`.
- Replace the `resolve_email_to_cntrb_id_sql` query — the old query had the same date window. New version uses a CTE that unions all three contributor email columns (`cntrb_email`, `cntrb_canonical`, `alias_email`), deduplicates with `DISTINCT ON`, then inner-joins against commits where `cmt_ght_author_id IS NULL AND repo_id = :repo_id`.
- Remove the `CollectionStatus` lookup block and `last_collected_date` variable — no longer needed after removing both `since_date` bind params.
- Remove the now-unused `get_session, execute_session_query` import.

## Notes
The old email-NOT-EXISTS logic had two compounding failure modes:

1. **Silent permanent skip** — if a commit email was *later* linked to a GitHub account (contributor or alias row inserted after the commit was collected), the email now EXISTS in the contributors table and the commit silently falls out of the selection set. `cmt_ght_author_id` stays `NULL` forever with no error raised.
2. **Date window makes it permanent** — the `last_collection_date` cutoff added in PR #3253 meant any commit that slipped through with an older `data_collection_date` was excluded on *every* subsequent run, making recovery impossible without a manual full-recollect flag.

`cmt_ght_author_id IS NULL` is the only semantically correct question: "has this commit been linked to a contributor yet?" It's also what enables the self-recovery path described in #3779 — setting `cmt_ght_author_id = NULL` on corrupted rows (from #3740) is now sufficient to re-queue them on the next collection cycle.

The `unresolved_commit_emails` exclusion in query 1 preserves the existing short-circuit: emails that have already been confirmed unresolvable via GitHub API aren't re-queried needlessly.

## Related issues/PRs
- Fixes #3779
- Enables self-recovery from secondary effects of #3740
- Supersedes the `since_date` change introduced in #3253 for this specific query