### PR TITLE
reschedule clone_repos regardless of how many repos were found

### DIFF
--- a/augur/tasks/git/facade_tasks.py
+++ b/augur/tasks/git/facade_tasks.py
@@ -384,7 +384,7 @@ def clone_repos():
                 setattr(repoStatus,"facade_status", CollectionState.ERROR.value)
                 session.commit()
 
-            clone_repos.si().apply_async(countdown=60*5)
+    clone_repos.si().apply_async(countdown=60*5)
 
 
 #@celery.task(bind=True)


### PR DESCRIPTION
**Description**
This PR fixes #3321 - a bug where, especially on smaller instances, facade appears to not clone repos until the instance is restarted after core and facade are ready.

This was due to an indentation bug with the self-rescheduling behavior of this task where it only reschedules itself if it processed at least one repo.

given how this is implemented, we could maybe simplify it further by making this a properly scheduled task alongside the same lines as collection_monitor, rather than DIYing it

**Notes for Reviewers**
both the conversation in the issue and AI helped diagnose this issue but all code is human written

**Signed commits**
- [X] Yes, I signed my commits.

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/augur/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->