### PR TITLE
Apply engine.begin() to DELETE query

### DIFF
--- a/augur/api/routes/util.py
+++ b/augur/api/routes/util.py
@@ -27,7 +27,7 @@ def get_all_repo_groups(): #TODO: make this name automatic - wrapper?
         ORDER BY rg_name
     """)
 
-    with current_app.engine.begin() as conn:
+    with current_app.engine.connect() as conn:
         results = pd.read_sql(repoGroupsSQL,  conn)
     data = results.to_json(orient="records", date_format='iso', date_unit='ms')
     return Response(response=data,

--- a/augur/tasks/data_analysis/insight_worker/tasks.py
+++ b/augur/tasks/data_analysis/insight_worker/tasks.py
@@ -106,7 +106,7 @@ def insight_model(repo_git: str,logger,engine) -> None:
                 AND ri_date < :min_date
     """)
 
-    with engine.connect() as conn:
+    with engine.begin() as conn:
         result = conn.execute(delete_record_SQL, parameters=dict(repo_id=repo_id, min_date=min_date))
 
     logger.info("Deleting out of date data points ...\n")


### PR DESCRIPTION
This PR updates transaction handling by applying `engine.begin()` to a data-modifying DELETE query in `tasks.py`, ensuring proper commit/rollback behavior in line with SQLAlchemy 2.0 semantics.

The previous change applied to a read-only query in `util.py` has been reverted, as transaction handling is not required for SELECT operations.

The change is intentionally minimal and scoped to a single DELETE operation to ensure safety and ease of review.