### PR TITLE
fix(db): use engine.begin() to commit cntrb_id updates in update_issue_closed_cntrbs_by_repo_id

### DIFF
--- a/augur/application/db/lib.py
+++ b/augur/application/db/lib.py
@@ -560,7 +560,7 @@ def update_issue_closed_cntrbs_by_repo_id(repo_id):
         )
 
     if update_data:
-        with engine.connect() as connection:
+        with engine.begin() as connection:
             update_stmt = s.text("""
                 UPDATE issues
                 SET cntrb_id = :cntrb_id


### PR DESCRIPTION
**Description**
- Replace `engine.connect()` with `engine.begin()` in `update_issue_closed_cntrbs_by_repo_id` so the `UPDATE` statement that sets `cntrb_id` on the `issues` table is actually committed.

In SQLAlchemy 2.0, `engine.connect()` uses `autobegin` but does not auto-commit on exit — the transaction is silently rolled back, so `cntrb_id` was never persisted. `engine.begin()` commits on a clean exit and rolls back on exception. Every other write in `lib.py` already uses `engine.begin()` (lines 78, 88, 384, 426) — this was the only outlier.

**Notes for Reviewers**

Standalone correctness fix — aligns this function with the existing `engine.begin()` pattern used throughout `lib.py`.

**Signed commits**
- [x] Yes, I signed my commits.