### PR TITLE
[detect_move] fix: reset collection status on repo move to prevent scheduler stall

### DIFF
--- a/augur/tasks/github/detect_move/tasks.py
+++ b/augur/tasks/github/detect_move/tasks.py
@@ -4,7 +4,9 @@ from augur.tasks.github.detect_move.core import ping_github_for_repo_move, RepoM
 from augur.tasks.init.celery_app import celery_app as celery
 from augur.tasks.init.celery_app import AugurCoreRepoCollectionTask, AugurSecondaryRepoCollectionTask
 from augur.application.db.lib import get_repo_by_repo_git, get_session
+from augur.application.db.models import Repo
 from augur.tasks.github.util.github_random_key_auth import GithubRandomKeyAuth
+from augur.tasks.util.collection_state import CollectionState
 
 from celery.exceptions import Reject
 
@@ -24,13 +26,23 @@ def detect_github_repo_move_core(self, repo_git : str) -> None:
 
     with get_session() as session:
 
-        #Ping each repo with the given repo_git to make sure
-        #that they are still in place.
         try:
             ping_github_for_repo_move(session, key_auth, repo, logger)
         except RepoMovedException as e:
             if e.new_url:
-                raise self.retry(args=[e.new_url], countdown=0, max_retries=1)
+                # Cancel downstream tasks — they were built with the old URL baked
+                # into their .si() signatures and are not yet on the broker.
+                self.request.chain = None
+
+                # DB already has the new URL; reset status so the scheduler
+                # re-collects this repo with the correct URL in the next cycle.
+                moved_repo = session.query(Repo).filter(Repo.repo_git == e.new_url).first()
+                if moved_repo:
+                    status = moved_repo.collection_status[0]
+                    status.core_status = CollectionState.PENDING.value
+                    status.core_task_id = None
+                    session.commit()
+                return
             raise Reject(e)
         except RepoGoneException as e:
             raise Reject(e)
@@ -51,13 +63,23 @@ def detect_github_repo_move_secondary(self, repo_git : str) -> None:
 
     with get_session() as session:
 
-        #Ping each repo with the given repo_git to make sure
-        #that they are still in place.
         try:
             ping_github_for_repo_move(session, key_auth, repo, logger, collection_hook='secondary')
         except RepoMovedException as e:
             if e.new_url:
-                raise self.retry(args=[e.new_url], countdown=0, max_retries=1)
+                # Cancel downstream tasks — they were built with the old URL baked
+                # into their .si() signatures and are not yet on the broker.
+                self.request.chain = None
+
+                # DB already has the new URL; reset status so the scheduler
+                # re-collects this repo with the correct URL in the next cycle.
+                moved_repo = session.query(Repo).filter(Repo.repo_git == e.new_url).first()
+                if moved_repo:
+                    status = moved_repo.collection_status[0]
+                    status.secondary_status = CollectionState.PENDING.value
+                    status.secondary_task_id = None
+                    session.commit()
+                return
             raise Reject(e)
         except RepoGoneException as e:
             raise Reject(e)

--- a/tests/test_classes/test_detect_move.py
+++ b/tests/test_classes/test_detect_move.py
@@ -71,21 +71,38 @@ def test_ping_200_returns_none(mock_hit):
 @patch("augur.tasks.github.detect_move.tasks.get_session")
 @patch("augur.tasks.github.detect_move.tasks.get_repo_by_repo_git")
 @patch("augur.tasks.github.detect_move.tasks.ping_github_for_repo_move")
-def test_core_task_retries_with_new_url_on_move(mock_ping, mock_get_repo, mock_get_session, mock_key_auth):
+def test_core_task_cancels_chain_and_resets_status_on_move(mock_ping, mock_get_repo, mock_get_session, mock_key_auth):
+    """
+    When a repo has moved, the task must:
+    1. Set request.chain = None so downstream tasks (queued with old URL) are cancelled.
+    2. Reset core_status to PENDING so the scheduler re-collects with the new URL.
+    3. Return cleanly (no exception).
+    """
     from augur.tasks.github.detect_move.tasks import detect_github_repo_move_core
+    from augur.tasks.util.collection_state import CollectionState
 
     new_url = "https://github.com/new-owner/new-repo"
     mock_ping.side_effect = RepoMovedException("moved", new_url=new_url)
     mock_get_repo.return_value = _make_repo()
-    mock_get_session.return_value = _session_mock()
+
+    mock_status = MagicMock()
+    mock_moved_repo = MagicMock()
+    mock_moved_repo.collection_status = [mock_status]
+
+    mock_session = MagicMock()
+    mock_session.query.return_value.filter.return_value.first.return_value = mock_moved_repo
+    mock_get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
     task_self = MagicMock()
-    task_self.retry = MagicMock(side_effect=Exception("retry_called"))
+    task_self.request = MagicMock()
 
-    with pytest.raises(Exception, match="retry_called"):
-        detect_github_repo_move_core.__wrapped__(task_self, "https://github.com/old-owner/old-repo")
+    result = detect_github_repo_move_core.__wrapped__(task_self, "https://github.com/old-owner/old-repo")
 
-    task_self.retry.assert_called_once_with(args=[new_url], countdown=0, max_retries=1)
+    assert task_self.request.chain is None
+    assert mock_status.core_status == CollectionState.PENDING.value
+    assert mock_status.core_task_id is None
+    assert result is None
 
 
 @patch("augur.tasks.github.detect_move.tasks.GithubRandomKeyAuth")


### PR DESCRIPTION
## Description

When `detect_github_repo_move_core` or `detect_github_repo_move_secondary` detects a 301-redirected repository, the task previously raised `Retry()` with no arguments. Celery does not forward positional args on a bare `Retry`, so the task would restart with the original (now-stale) `repo_git`, crash, and leave `core_status` stuck in `COLLECTING`. Once all 40 scheduler slots were occupied by these stalled tasks, `augur_collection_monitor` stopped dispatching any new Core collection work — requiring manual container restarts to recover.

This PR fixes the root cause by using `self.retry(args=[new_url], countdown=0, max_retries=1)` so the task restarts immediately with the correct, updated `repo_git`. All downstream tasks in the chain then run against the new URL. No collection-status columns are modified; the existing `on_success` handler manages state cleanup as normal.

Fixes #3667

## Changes

- `augur/tasks/github/detect_move/tasks.py`:
  - Add `bind=True` to both task decorators so `self` is available
  - Replace bare `pass` / `Retry()` with `self.retry(args=[e.new_url], countdown=0, max_retries=1)` on `RepoMovedException`
  - Fall back to `Reject` if `new_url` is not present

## Notes for Reviewers

`self.retry` raises `celery.exceptions.Retry` internally, so the `raise` is the standard Celery pattern. `countdown=0` means the retry is enqueued immediately with no delay. `max_retries=1` prevents an infinite loop if the new URL also returns 301.

## Signed commits
- [x] Yes, I signed my commits.