### PR TITLE
Fix false PR event warnings for issue number collisionsFix false PR event warnings when issue numbers overlap with PR numbers (#3762)

### DIFF
--- a/augur/tasks/github/events.py
+++ b/augur/tasks/github/events.py
@@ -209,6 +209,7 @@ class BulkGithubEventCollection(GithubEventCollection):
         contributors = []
 
         pr_url_to_id_map = self._get_map_from_pr_url_to_id(repo_id)
+        issue_numbers = self._get_issue_numbers_by_repo_id(repo_id)
 
         for event in pr_events:
 
@@ -219,6 +220,10 @@ class BulkGithubEventCollection(GithubEventCollection):
             try:
                 pull_request_id = pr_url_to_id_map[pr_url]
             except KeyError:
+
+                pr_number = int(pr_url.rstrip("/").split("/")[-1])
+                if pr_number in issue_numbers:
+                    continue
 
                 self._logger.warning(f"{self.repo_identifier} - {self.task_name}: Could not find related pr. We were searching for: {pr_url}")
                 continue
@@ -254,6 +259,15 @@ class BulkGithubEventCollection(GithubEventCollection):
             issue_url_to_id_map[issue.issue_url] = issue.issue_id
 
         return issue_url_to_id_map
+
+    def _get_issue_numbers_by_repo_id(self, repo_id):
+
+        issue_numbers = set()
+        issues = get_issues_by_repo_id(repo_id)
+        for issue in issues:
+            issue_numbers.add(issue.gh_issue_number)
+
+        return issue_numbers
 
     def _is_pr_event(self, event):
 

--- a/tests/test_tasks/test_github_tasks/test_events.py
+++ b/tests/test_tasks/test_github_tasks/test_events.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock
+
+from augur.tasks.github.events import BulkGithubEventCollection
+
+
+def _make_pr_event(pr_number):
+    return {
+        "issue": {
+            "id": 1,
+            "pull_request": {
+                "url": f"https://api.github.com/repos/owner/repo/pulls/{pr_number}"
+            },
+        },
+        "actor": None,
+    }
+
+
+def test_process_pr_events_skips_warning_for_existing_issue_number():
+    logger = MagicMock()
+    collector = BulkGithubEventCollection(logger)
+    collector.repo_identifier = "owner/repo"
+    collector.task_name = "Bulk Github Event task"
+    collector._get_map_from_pr_url_to_id = MagicMock(return_value={})
+    collector._get_issue_numbers_by_repo_id = MagicMock(return_value={3383})
+    collector._insert_contributors = MagicMock()
+    collector._insert_pr_events = MagicMock()
+
+    collector._process_pr_events([_make_pr_event(3383)], repo_id=1)
+
+    logger.warning.assert_not_called()
+
+
+def test_process_pr_events_warns_for_missing_pr_number():
+    logger = MagicMock()
+    collector = BulkGithubEventCollection(logger)
+    collector.repo_identifier = "owner/repo"
+    collector.task_name = "Bulk Github Event task"
+    collector._get_map_from_pr_url_to_id = MagicMock(return_value={})
+    collector._get_issue_numbers_by_repo_id = MagicMock(return_value=set())
+    collector._insert_contributors = MagicMock()
+    collector._insert_pr_events = MagicMock()
+
+    collector._process_pr_events([_make_pr_event(9999)], repo_id=1)
+
+    logger.warning.assert_called_once()
+    assert "Could not find related pr" in logger.warning.call_args.args[0]


### PR DESCRIPTION
Fixes #3762.

## What changed
- Updated `BulkGithubEventCollection._process_pr_events` in `augur/tasks/github/events.py`.
- When related PR URL is missing from local PR map:
  - Parse PR number from URL
  - Check if that number exists in repo issues (`gh_issue_number`)
  - If yes, skip silently (expected due to shared GitHub issue/PR numbering)
  - If no, keep existing warning

## Why
GitHub uses a shared namespace for issue and PR numbers. The old logic emitted noisy warnings for valid issue numbers that are not PRs.

## Tests
Added `tests/test_tasks/test_github_tasks/test_events.py`:
- skips warning when missing PR number matches existing issue number
- still warns when PR number is missing from both PR and issue data